### PR TITLE
Add USDT donation products and on-chain payment flow (model, services, routes, verifier, tests)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ URSASS_Backend/
 ├── models/
 │   ├── Player.js
 │   ├── PlayerUpgrades.js
+│   ├── DonationPayment.js
 │   ├── GameResult.js
 │   ├── AccountLink.js
 │   └── LinkCode.js
@@ -31,7 +32,10 @@ URSASS_Backend/
 ├── utils/
 │   ├── verifySignature.js
 │   ├── accountManager.js
-│   └── upgradesConfig.js
+│   ├── upgradesConfig.js
+│   ├── donationsConfig.js
+│   ├── donationService.js
+│   └── donationVerifier.js
 ├── .env.example
 └── package.json
 ```
@@ -58,6 +62,16 @@ npm start
 | `CORS_ALLOWED_ORIGINS` | Optional comma-separated list of extra allowed origins |
 | `MAX_RESULT_TIMESTAMP_AGE_MS` | Max allowed age for game result timestamp in the past (default: `7200000`, i.e. 2h) |
 | `MAX_RESULT_FUTURE_SKEW_MS` | Max allowed future clock skew for game result timestamp (default: `180000`, i.e. 3m) |
+| `DONATIONS_PRICE_MODE` | Donation prices mode: `test` or `prod` (default: `test`) |
+| `DONATIONS_NETWORK` | Donation network label (default: `BSC`) |
+| `DONATIONS_TOKEN_SYMBOL` | Donation token symbol (default: `USDT`) |
+| `DONATIONS_TOKEN_DECIMALS` | Donation token decimals (default: `18`) |
+| `DONATIONS_TOKEN_CONTRACT` | USDT contract address used for donation validation |
+| `DONATIONS_MERCHANT_WALLET` | Merchant wallet that receives player transfers |
+| `DONATIONS_TTL_MINUTES` | Payment intent lifetime in minutes (default: `30`) |
+| `DONATIONS_REQUIRED_CONFIRMATIONS` | Required confirmations before crediting (default: `1`) |
+| `DONATIONS_RPC_URL` | JSON-RPC endpoint used to verify donation transactions |
+| `BSC_RPC_URL` | Alias for donation RPC URL |
 
 See `.env.example` for a template.
 
@@ -74,7 +88,11 @@ Versioned aliases are also available under `/api/v1/*` (backward-compatible with
 | `GET` | `/api/leaderboard/player/:wallet` | Get player info and history |
 | `GET` | `/api/leaderboard/verified-results/:wallet` | Get verified game results for a wallet |
 | `GET` | `/api/store/upgrades/:wallet` | Get player upgrades, rides, and balance |
+| `GET` | `/api/store/donations/:wallet` | Get donation products available for a wallet |
 | `POST` | `/api/store/buy` | Buy an upgrade or ride pack (requires EIP-191 signature) |
+| `POST` | `/api/store/donations/create-payment` | Create a USDT donation payment intent |
+| `POST` | `/api/store/donations/submit-transaction` | Submit tx hash for donation payment verification |
+| `GET` | `/api/store/donations/payment/:paymentId` | Get donation payment status |
 | `POST` | `/api/store/consume-ride` | Consume a ride when starting a game (requires unique `rideSessionId`) |
 | `POST` | `/api/account/auth/telegram` | Authenticate via Telegram |
 | `POST` | `/api/account/auth/wallet` | Authenticate via wallet (requires EIP-191 signature) |
@@ -83,6 +101,11 @@ Versioned aliases are also available under `/api/v1/*` (backward-compatible with
 
 
 ## Store Upgrade Semantics
+
+The store now contains **two parallel product systems**:
+
+- `UPGRADES_CONFIG` for gameplay upgrades and rides purchased with in-game `gold` / `silver`
+- `DONATIONS_CONFIG` for real-money style USDT donation packs that credit in-game currencies after on-chain verification
 
 - `shield` is now a **1-level permanent progression**:
   - level 1 enables `activeEffects.start_with_shield = true`.

--- a/models/DonationPayment.js
+++ b/models/DonationPayment.js
@@ -1,0 +1,108 @@
+const mongoose = require('mongoose');
+
+const donationPaymentSchema = new mongoose.Schema({
+  paymentId: {
+    type: String,
+    required: true,
+    unique: true,
+    index: true
+  },
+  wallet: {
+    type: String,
+    required: true,
+    lowercase: true,
+    index: true
+  },
+  productKey: {
+    type: String,
+    required: true,
+    index: true
+  },
+  productSnapshot: {
+    type: Object,
+    required: true
+  },
+  status: {
+    type: String,
+    enum: ['created', 'submitted', 'pending', 'confirmed', 'credited', 'failed', 'expired'],
+    default: 'created',
+    index: true
+  },
+  network: {
+    type: String,
+    required: true
+  },
+  tokenSymbol: {
+    type: String,
+    required: true
+  },
+  tokenContract: {
+    type: String,
+    required: true,
+    lowercase: true
+  },
+  merchantWallet: {
+    type: String,
+    required: true,
+    lowercase: true
+  },
+  expectedAmount: {
+    type: String,
+    required: true
+  },
+  expectedDecimals: {
+    type: Number,
+    required: true
+  },
+  txHash: {
+    type: String,
+    default: null,
+    sparse: true,
+    unique: true,
+    index: true
+  },
+  txFrom: {
+    type: String,
+    default: null
+  },
+  txTo: {
+    type: String,
+    default: null
+  },
+  txAmount: {
+    type: String,
+    default: null
+  },
+  confirmations: {
+    type: Number,
+    default: 0
+  },
+  failureReason: {
+    type: String,
+    default: null
+  },
+  expiresAt: {
+    type: Date,
+    required: true,
+    index: true
+  },
+  submittedAt: {
+    type: Date,
+    default: null
+  },
+  confirmedAt: {
+    type: Date,
+    default: null
+  },
+  creditedAt: {
+    type: Date,
+    default: null
+  }
+}, {
+  timestamps: true
+});
+
+donationPaymentSchema.index({ wallet: 1, createdAt: -1 });
+donationPaymentSchema.index({ status: 1, expiresAt: 1 });
+
+module.exports = mongoose.model('DonationPayment', donationPaymentSchema);

--- a/routes/store.js
+++ b/routes/store.js
@@ -4,6 +4,7 @@ const Player = require('../models/Player');
 const PlayerUpgrades = require('../models/PlayerUpgrades');
 const AccountLink = require('../models/AccountLink');
 const { UPGRADES_CONFIG, calculateEffects } = require('../utils/upgradesConfig');
+const { listDonationProducts, createDonationPayment, submitDonationTransaction, getDonationPayment, serializeDonationPayment } = require('../utils/donationService');
 const { verifySignature } = require('../utils/verifySignature');
 const { writeLimiter, readLimiter } = require('../middleware/rateLimiter');
 const SecurityEvent = require('../models/SecurityEvent');
@@ -136,6 +137,98 @@ router.get('/upgrades/:wallet', readLimiter, async (req, res) => {
 
   } catch (error) {
     logger.error({ err: error }, 'GET /upgrades error');
+    res.status(500).json({ error: 'Server error' });
+  }
+});
+
+/**
+ * GET /api/store/donations/:wallet
+ * Get all USDT donation products for a wallet
+ */
+router.get('/donations/:wallet', readLimiter, async (req, res) => {
+  try {
+    const wallet = normalizeWallet(req.params.wallet);
+
+    if (!wallet || wallet.length < 3) {
+      return res.status(400).json({ error: 'Invalid wallet address' });
+    }
+
+    const payload = await listDonationProducts(wallet);
+    res.json(payload);
+  } catch (error) {
+    logger.error({ err: error }, 'GET /donations error');
+    res.status(500).json({ error: 'Server error' });
+  }
+});
+
+/**
+ * POST /api/store/donations/create-payment
+ */
+router.post('/donations/create-payment', writeLimiter, async (req, res) => {
+  try {
+    const { wallet, productKey } = req.body;
+    const payment = await createDonationPayment(wallet, productKey);
+
+    await logSecurityEvent({
+      wallet: payment.wallet,
+      eventType: 'donation_payment_created',
+      route: req.path,
+      ipAddress: req.ip,
+      details: {
+        paymentId: payment.paymentId,
+        productKey: payment.productKey,
+        amount: payment.expectedAmount
+      }
+    });
+
+    res.status(201).json(serializeDonationPayment(payment));
+  } catch (error) {
+    logger.error({ err: error }, 'POST /donations/create-payment error');
+    res.status(error.statusCode || 500).json({ error: error.message || 'Server error' });
+  }
+});
+
+/**
+ * POST /api/store/donations/submit-transaction
+ */
+router.post('/donations/submit-transaction', writeLimiter, async (req, res) => {
+  try {
+    const { wallet, paymentId, txHash } = req.body;
+    const payment = await submitDonationTransaction({ wallet, paymentId, txHash });
+
+    await logSecurityEvent({
+      wallet: payment.wallet,
+      eventType: 'donation_tx_submitted',
+      route: req.path,
+      ipAddress: req.ip,
+      details: {
+        paymentId: payment.paymentId,
+        productKey: payment.productKey,
+        txHash: payment.txHash,
+        status: payment.status
+      }
+    });
+
+    res.json(serializeDonationPayment(payment));
+  } catch (error) {
+    logger.error({ err: error }, 'POST /donations/submit-transaction error');
+    res.status(error.statusCode || 500).json({ error: error.message || 'Server error' });
+  }
+});
+
+/**
+ * GET /api/store/donations/payment/:paymentId
+ */
+router.get('/donations/payment/:paymentId', readLimiter, async (req, res) => {
+  try {
+    const payment = await getDonationPayment(req.params.paymentId);
+    if (!payment) {
+      return res.status(404).json({ error: 'Payment not found' });
+    }
+
+    res.json(serializeDonationPayment(payment));
+  } catch (error) {
+    logger.error({ err: error }, 'GET /donations/payment error');
     res.status(500).json({ error: 'Server error' });
   }
 });

--- a/tests/api.integration.test.js
+++ b/tests/api.integration.test.js
@@ -8,6 +8,8 @@ const GameResult = require('../models/GameResult');
 const PlayerUpgrades = require('../models/PlayerUpgrades');
 const SecurityEvent = require('../models/SecurityEvent');
 const LinkCode = require('../models/LinkCode');
+const DonationPayment = require('../models/DonationPayment');
+const { setDonationVerifierForTests, resetDonationVerifier } = require('../utils/donationService');
 
 const { createApp } = require('../app');
 
@@ -31,6 +33,7 @@ async function startServer() {
 }
 
 let originalStartSession;
+let donationPayments;
 
 test.before(() => {
   process.env.TELEGRAM_BOT_SECRET = 'test-secret';
@@ -53,6 +56,45 @@ test.beforeEach(() => {
   Player.prototype.save = async function save() { return this; };
   PlayerUpgrades.prototype.save = async function save() { return this; };
   LinkCode.deleteOne = async () => ({ deletedCount: 1 });
+  donationPayments = [];
+  DonationPayment.prototype.save = async function save() {
+    const plain = this.toObject ? this.toObject() : { ...this };
+    const index = donationPayments.findIndex((item) => item.paymentId === plain.paymentId);
+    const stored = {
+      ...plain,
+      save: async function saveSelf() { return this; }
+    };
+    if (index >= 0) {
+      donationPayments[index] = stored;
+    } else {
+      donationPayments.push(stored);
+    }
+    Object.assign(this, stored);
+    return this;
+  };
+  DonationPayment.findOne = async (query = {}) => {
+    const match = donationPayments.find((item) => {
+      return Object.entries(query).every(([key, value]) => {
+        if (value && typeof value === 'object' && !Array.isArray(value)) {
+          if ('$in' in value) {
+            return value.$in.includes(item[key]);
+          }
+          if ('$ne' in value) {
+            return item[key] !== value.$ne;
+          }
+        }
+        return item[key] === value;
+      });
+    });
+
+    return match ? { ...match, save: async function saveSelf() {
+      const index = donationPayments.findIndex((item) => item.paymentId === this.paymentId);
+      const updated = { ...this, save: this.save };
+      donationPayments[index] = updated;
+      return this;
+    } } : null;
+  };
+  resetDonationVerifier();
 });
 
 test('POST /api/leaderboard/save rejects invalid signature', async () => {
@@ -218,5 +260,147 @@ test('POST /api/account/link/verify-telegram rejects expired code', async () => 
   assert.equal(res.status, 400);
   const body = await res.json();
   assert.match(body.error, /Code expired/i);
+  await server.close();
+});
+
+test('GET /api/store/donations/:wallet returns donation products with Starter Pack available', async () => {
+  const wallet = Wallet.createRandom().address.toLowerCase();
+
+  Player.findOne = () => queryResult({
+    wallet,
+    totalGoldCoins: 0,
+    totalSilverCoins: 0
+  });
+
+  const { server, baseUrl } = await startServer();
+  const res = await fetch(`${baseUrl}/api/store/donations/${wallet}`);
+
+  assert.equal(res.status, 200);
+  const body = await res.json();
+  assert.equal(body.network, 'BSC');
+  assert.equal(body.priceMode, 'test');
+  assert.equal(body.products.length, 6);
+  assert.equal(body.products[0].key, 'starter_pack');
+  assert.equal(body.products[0].canPurchase, true);
+
+  await server.close();
+});
+
+test('POST /api/store/donations/create-payment creates payment intent', async () => {
+  const wallet = Wallet.createRandom().address.toLowerCase();
+
+  Player.findOne = () => queryResult({
+    wallet,
+    totalGoldCoins: 0,
+    totalSilverCoins: 0
+  });
+
+  const { server, baseUrl } = await startServer();
+  const res = await fetch(`${baseUrl}/api/store/donations/create-payment`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ wallet, productKey: 'starter_pack' })
+  });
+
+  assert.equal(res.status, 201);
+  const body = await res.json();
+  assert.equal(body.status, 'created');
+  assert.equal(body.productKey, 'starter_pack');
+  assert.equal(body.amount, '0.02');
+  assert.equal(body.currency, 'USDT');
+
+  await server.close();
+});
+
+test('POST /api/store/donations/submit-transaction credits player after successful verification', async () => {
+  const wallet = Wallet.createRandom().address.toLowerCase();
+  const player = {
+    wallet,
+    totalGoldCoins: 10,
+    totalSilverCoins: 20,
+    save: async function save() { return this; }
+  };
+
+  Player.findOne = ({ wallet: requestedWallet }) => queryResult(requestedWallet === wallet ? player : null);
+
+  setDonationVerifierForTests(async () => ({
+    status: 'confirmed',
+    reason: 'confirmed',
+    confirmations: 2,
+    actualFrom: '0xsender',
+    actualTo: '0x244bcc2721f1037958862825c3feb6a7be6204a7',
+    actualAmount: '20000000000000000'
+  }));
+
+  const { server, baseUrl } = await startServer();
+
+  const createRes = await fetch(`${baseUrl}/api/store/donations/create-payment`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ wallet, productKey: 'starter_pack' })
+  });
+  const created = await createRes.json();
+
+  const submitRes = await fetch(`${baseUrl}/api/store/donations/submit-transaction`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ wallet, paymentId: created.paymentId, txHash: '0xtesthash' })
+  });
+
+  assert.equal(submitRes.status, 200);
+  const submitted = await submitRes.json();
+  assert.equal(submitted.status, 'credited');
+  assert.deepEqual(submitted.reward, { gold: 400, silver: 400 });
+  assert.equal(player.totalGoldCoins, 410);
+  assert.equal(player.totalSilverCoins, 420);
+
+  await server.close();
+});
+
+test('POST /api/store/donations/create-payment blocks second Starter Pack after successful credit', async () => {
+  const wallet = Wallet.createRandom().address.toLowerCase();
+  const player = {
+    wallet,
+    totalGoldCoins: 0,
+    totalSilverCoins: 0,
+    save: async function save() { return this; }
+  };
+
+  Player.findOne = () => queryResult(player);
+
+  setDonationVerifierForTests(async () => ({
+    status: 'confirmed',
+    reason: 'confirmed',
+    confirmations: 2,
+    actualFrom: '0xsender',
+    actualTo: '0x244bcc2721f1037958862825c3feb6a7be6204a7',
+    actualAmount: '20000000000000000'
+  }));
+
+  const { server, baseUrl } = await startServer();
+
+  const firstCreate = await fetch(`${baseUrl}/api/store/donations/create-payment`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ wallet, productKey: 'starter_pack' })
+  });
+  const created = await firstCreate.json();
+
+  await fetch(`${baseUrl}/api/store/donations/submit-transaction`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ wallet, paymentId: created.paymentId, txHash: '0xstarterhash' })
+  });
+
+  const secondCreate = await fetch(`${baseUrl}/api/store/donations/create-payment`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ wallet, productKey: 'starter_pack' })
+  });
+
+  assert.equal(secondCreate.status, 409);
+  const body = await secondCreate.json();
+  assert.match(body.error, /already purchased/i);
+
   await server.close();
 });

--- a/utils/donationService.js
+++ b/utils/donationService.js
@@ -1,0 +1,325 @@
+const crypto = require('crypto');
+const { ethers } = require('ethers');
+
+const Player = require('../models/Player');
+const DonationPayment = require('../models/DonationPayment');
+const { DONATIONS_CONFIG, DONATIONS_PRICE_MODE, getDonationConfig } = require('./donationsConfig');
+const { normalizeWallet } = require('./security');
+const { verifyDonationTransaction } = require('./donationVerifier');
+
+let verifierImpl = verifyDonationTransaction;
+
+function setDonationVerifierForTests(verifier) {
+  verifierImpl = verifier || verifyDonationTransaction;
+}
+
+function resetDonationVerifier() {
+  verifierImpl = verifyDonationTransaction;
+}
+
+function getProvider() {
+  const rpcUrl = process.env.BSC_RPC_URL || process.env.DONATIONS_RPC_URL;
+  if (!rpcUrl) {
+    return null;
+  }
+
+  return new ethers.providers.JsonRpcProvider(rpcUrl);
+}
+
+function buildProductView(config, alreadyPurchased) {
+  return {
+    key: config.key,
+    title: config.title,
+    price: config.price,
+    currency: config.currency,
+    network: config.network,
+    grant: config.grant,
+    purchaseLimit: config.purchaseLimit,
+    alreadyPurchased,
+    canPurchase: config.purchaseLimit === 'once' ? !alreadyPurchased : true
+  };
+}
+
+async function hasSuccessfulDonation(wallet, productKey) {
+  const existing = await DonationPayment.findOne({
+    wallet,
+    productKey,
+    status: { $in: ['confirmed', 'credited'] }
+  });
+
+  return !!existing;
+}
+
+async function listDonationProducts(wallet) {
+  const normalizedWallet = normalizeWallet(wallet);
+  const products = [];
+
+  for (const config of Object.values(DONATIONS_CONFIG)) {
+    const alreadyPurchased = normalizedWallet && config.purchaseLimit === 'once'
+      ? await hasSuccessfulDonation(normalizedWallet, config.key)
+      : false;
+
+    products.push(buildProductView(config, alreadyPurchased));
+  }
+
+  const sampleConfig = Object.values(DONATIONS_CONFIG)[0];
+
+  return {
+    wallet: normalizedWallet,
+    network: sampleConfig?.network || 'BSC',
+    token: sampleConfig ? {
+      symbol: sampleConfig.currency,
+      contract: sampleConfig.tokenContract,
+      merchantWallet: sampleConfig.merchantWallet
+    } : null,
+    priceMode: DONATIONS_PRICE_MODE,
+    products
+  };
+}
+
+async function createDonationPayment(wallet, productKey) {
+  const normalizedWallet = normalizeWallet(wallet);
+  const config = getDonationConfig(productKey);
+
+  if (!normalizedWallet) {
+    const err = new Error('Invalid wallet address');
+    err.statusCode = 400;
+    throw err;
+  }
+
+  if (!config) {
+    const err = new Error(`Unknown donation product: ${productKey}`);
+    err.statusCode = 400;
+    throw err;
+  }
+
+  const player = await Player.findOne({ wallet: normalizedWallet });
+  if (!player) {
+    const err = new Error('Player not found. Play at least one game first.');
+    err.statusCode = 404;
+    throw err;
+  }
+
+  if (config.purchaseLimit === 'once') {
+    const alreadyPurchased = await hasSuccessfulDonation(normalizedWallet, config.key);
+    if (alreadyPurchased) {
+      const err = new Error('This donation product is already purchased');
+      err.statusCode = 409;
+      throw err;
+    }
+  }
+
+  const now = new Date();
+  const expiresAt = new Date(now.getTime() + (config.ttlMinutes * 60 * 1000));
+  const payment = new DonationPayment({
+    paymentId: `pay_${crypto.randomBytes(12).toString('hex')}`,
+    wallet: normalizedWallet,
+    productKey: config.key,
+    productSnapshot: {
+      key: config.key,
+      title: config.title,
+      price: config.price,
+      currency: config.currency,
+      grant: config.grant,
+      purchaseLimit: config.purchaseLimit,
+      requiredConfirmations: config.requiredConfirmations
+    },
+    status: 'created',
+    network: config.network,
+    tokenSymbol: config.currency,
+    tokenContract: config.tokenContract,
+    merchantWallet: config.merchantWallet,
+    expectedAmount: config.price,
+    expectedDecimals: config.tokenDecimals,
+    expiresAt
+  });
+
+  await payment.save();
+
+  return payment;
+}
+
+async function creditDonationPayment(payment) {
+  if (payment.status === 'credited') {
+    return payment;
+  }
+
+  const player = await Player.findOne({ wallet: payment.wallet });
+  if (!player) {
+    payment.status = 'failed';
+    payment.failureReason = 'player_not_found';
+    await payment.save();
+    return payment;
+  }
+
+  const { gold = 0, silver = 0 } = payment.productSnapshot?.grant || {};
+  player.totalGoldCoins += gold;
+  player.totalSilverCoins += silver;
+  player.updatedAt = new Date();
+
+  await player.save();
+
+  payment.status = 'credited';
+  payment.creditedAt = new Date();
+  if (!payment.confirmedAt) {
+    payment.confirmedAt = new Date();
+  }
+  await payment.save();
+
+  return payment;
+}
+
+async function recheckDonationPayment(payment) {
+  if (!payment) {
+    return null;
+  }
+
+  if (payment.status === 'credited' || payment.status === 'failed' || payment.status === 'expired') {
+    return payment;
+  }
+
+  if (!payment.txHash) {
+    return payment;
+  }
+
+  if (payment.expiresAt <= new Date()) {
+    payment.status = 'expired';
+    payment.failureReason = 'payment_expired';
+    await payment.save();
+    return payment;
+  }
+
+  const verification = await verifierImpl({
+    txHash: payment.txHash,
+    expectedAmount: payment.expectedAmount,
+    expectedDecimals: payment.expectedDecimals,
+    tokenContract: payment.tokenContract,
+    merchantWallet: payment.merchantWallet,
+    requiredConfirmations: payment.productSnapshot?.requiredConfirmations || 1
+  }, getProvider());
+
+  payment.confirmations = verification.confirmations || 0;
+  payment.txFrom = verification.actualFrom || payment.txFrom;
+  payment.txTo = verification.actualTo || payment.txTo;
+  payment.txAmount = verification.actualAmount || payment.txAmount;
+
+  if (verification.status === 'pending') {
+    payment.status = 'pending';
+    payment.failureReason = verification.reason || null;
+    await payment.save();
+    return payment;
+  }
+
+  if (verification.status === 'failed') {
+    payment.status = 'failed';
+    payment.failureReason = verification.reason || 'verification_failed';
+    await payment.save();
+    return payment;
+  }
+
+  payment.status = 'confirmed';
+  payment.failureReason = null;
+  payment.confirmedAt = payment.confirmedAt || new Date();
+  await payment.save();
+
+  return creditDonationPayment(payment);
+}
+
+async function submitDonationTransaction({ wallet, paymentId, txHash }) {
+  const normalizedWallet = normalizeWallet(wallet);
+  const normalizedHash = typeof txHash === 'string' ? txHash.trim() : '';
+
+  if (!normalizedWallet || !paymentId || !normalizedHash) {
+    const err = new Error('Missing wallet, paymentId or txHash');
+    err.statusCode = 400;
+    throw err;
+  }
+
+  const payment = await DonationPayment.findOne({ paymentId });
+  if (!payment) {
+    const err = new Error('Payment not found');
+    err.statusCode = 404;
+    throw err;
+  }
+
+  if (payment.wallet !== normalizedWallet) {
+    const err = new Error('Payment does not belong to this wallet');
+    err.statusCode = 403;
+    throw err;
+  }
+
+  if (payment.expiresAt <= new Date()) {
+    payment.status = 'expired';
+    payment.failureReason = 'payment_expired';
+    await payment.save();
+    return payment;
+  }
+
+  const existingHash = await DonationPayment.findOne({ txHash: normalizedHash, paymentId: { $ne: paymentId } });
+  if (existingHash) {
+    const err = new Error('Transaction hash already used');
+    err.statusCode = 409;
+    throw err;
+  }
+
+  payment.txHash = normalizedHash;
+  payment.submittedAt = new Date();
+  payment.status = 'submitted';
+  payment.failureReason = null;
+  await payment.save();
+
+  return recheckDonationPayment(payment);
+}
+
+async function getDonationPayment(paymentId) {
+  const payment = await DonationPayment.findOne({ paymentId });
+  if (!payment) {
+    return null;
+  }
+
+  if (payment.status === 'submitted' || payment.status === 'pending') {
+    return recheckDonationPayment(payment);
+  }
+
+  if (payment.status === 'created' && payment.expiresAt <= new Date()) {
+    payment.status = 'expired';
+    payment.failureReason = 'payment_expired';
+    await payment.save();
+  }
+
+  return payment;
+}
+
+function serializeDonationPayment(payment) {
+  if (!payment) {
+    return null;
+  }
+
+  return {
+    paymentId: payment.paymentId,
+    wallet: payment.wallet,
+    status: payment.status,
+    productKey: payment.productKey,
+    title: payment.productSnapshot?.title || null,
+    amount: payment.expectedAmount,
+    currency: payment.tokenSymbol,
+    network: payment.network,
+    tokenContract: payment.tokenContract,
+    merchantWallet: payment.merchantWallet,
+    expiresAt: payment.expiresAt,
+    txHash: payment.txHash,
+    confirmations: payment.confirmations,
+    reward: payment.productSnapshot?.grant || { gold: 0, silver: 0 },
+    failureReason: payment.failureReason
+  };
+}
+
+module.exports = {
+  listDonationProducts,
+  createDonationPayment,
+  submitDonationTransaction,
+  getDonationPayment,
+  serializeDonationPayment,
+  setDonationVerifierForTests,
+  resetDonationVerifier
+};

--- a/utils/donationVerifier.js
+++ b/utils/donationVerifier.js
@@ -1,0 +1,102 @@
+const { ethers } = require('ethers');
+
+const ERC20_TRANSFER_TOPIC = ethers.utils.id('Transfer(address,address,uint256)');
+const ERC20_TRANSFER_IFACE = new ethers.utils.Interface([
+  'event Transfer(address indexed from, address indexed to, uint256 value)'
+]);
+
+function normalizeAddress(value) {
+  return typeof value === 'string' ? value.toLowerCase() : null;
+}
+
+async function verifyDonationTransaction({
+  txHash,
+  expectedAmount,
+  expectedDecimals,
+  tokenContract,
+  merchantWallet,
+  requiredConfirmations = 1
+}, provider) {
+  if (!provider) {
+    return { status: 'failed', reason: 'provider_unavailable' };
+  }
+
+  const receipt = await provider.getTransactionReceipt(txHash);
+  if (!receipt) {
+    return { status: 'pending', reason: 'receipt_not_found' };
+  }
+
+  if (receipt.status !== 1) {
+    return { status: 'failed', reason: 'transaction_failed' };
+  }
+
+  const currentBlock = await provider.getBlockNumber();
+  const confirmations = typeof receipt.confirmations === 'number'
+    ? receipt.confirmations
+    : Math.max(0, currentBlock - receipt.blockNumber + 1);
+
+  const targetContract = normalizeAddress(tokenContract);
+  const targetWallet = normalizeAddress(merchantWallet);
+
+  const transferLog = receipt.logs.find((log) =>
+    normalizeAddress(log.address) === targetContract &&
+    Array.isArray(log.topics) &&
+    log.topics[0] === ERC20_TRANSFER_TOPIC
+  );
+
+  if (!transferLog) {
+    return { status: 'failed', reason: 'transfer_log_not_found', confirmations };
+  }
+
+  const decoded = ERC20_TRANSFER_IFACE.parseLog(transferLog);
+  const actualTo = normalizeAddress(decoded.args.to);
+  const actualFrom = normalizeAddress(decoded.args.from);
+  const actualAmountRaw = decoded.args.value.toString();
+  const expectedAmountRaw = ethers.utils.parseUnits(String(expectedAmount), expectedDecimals).toString();
+
+  if (actualTo !== targetWallet) {
+    return {
+      status: 'failed',
+      reason: 'recipient_mismatch',
+      confirmations,
+      actualTo,
+      actualFrom,
+      actualAmount: actualAmountRaw
+    };
+  }
+
+  if (actualAmountRaw !== expectedAmountRaw) {
+    return {
+      status: 'failed',
+      reason: 'amount_mismatch',
+      confirmations,
+      actualTo,
+      actualFrom,
+      actualAmount: actualAmountRaw
+    };
+  }
+
+  if (confirmations < requiredConfirmations) {
+    return {
+      status: 'pending',
+      reason: 'awaiting_confirmations',
+      confirmations,
+      actualTo,
+      actualFrom,
+      actualAmount: actualAmountRaw
+    };
+  }
+
+  return {
+    status: 'confirmed',
+    reason: 'confirmed',
+    confirmations,
+    actualTo,
+    actualFrom,
+    actualAmount: actualAmountRaw
+  };
+}
+
+module.exports = {
+  verifyDonationTransaction
+};

--- a/utils/donationsConfig.js
+++ b/utils/donationsConfig.js
@@ -1,0 +1,110 @@
+const DEFAULT_NETWORK = process.env.DONATIONS_NETWORK || 'BSC';
+const DEFAULT_TOKEN_SYMBOL = process.env.DONATIONS_TOKEN_SYMBOL || 'USDT';
+const DEFAULT_TOKEN_DECIMALS = Number(process.env.DONATIONS_TOKEN_DECIMALS || 18);
+const DEFAULT_TOKEN_CONTRACT = (process.env.DONATIONS_TOKEN_CONTRACT || '0x55d398326f99059ff775485246999027b3197955').toLowerCase();
+const DEFAULT_MERCHANT_WALLET = (process.env.DONATIONS_MERCHANT_WALLET || '0x244bcc2721f1037958862825c3feb6a7be6204a7').toLowerCase();
+const PRICE_MODE = String(process.env.DONATIONS_PRICE_MODE || 'test').toLowerCase() === 'prod' ? 'prod' : 'test';
+const TTL_MINUTES = Number(process.env.DONATIONS_TTL_MINUTES || 30);
+const REQUIRED_CONFIRMATIONS = Number(process.env.DONATIONS_REQUIRED_CONFIRMATIONS || 1);
+
+function price(testPrice, prodPrice) {
+  return PRICE_MODE === 'prod' ? prodPrice : testPrice;
+}
+
+const DONATIONS_CONFIG = {
+  starter_pack: {
+    key: 'starter_pack',
+    title: 'Starter Pack',
+    currency: DEFAULT_TOKEN_SYMBOL,
+    network: DEFAULT_NETWORK,
+    tokenContract: DEFAULT_TOKEN_CONTRACT,
+    tokenDecimals: DEFAULT_TOKEN_DECIMALS,
+    merchantWallet: DEFAULT_MERCHANT_WALLET,
+    price: price('0.02', '2'),
+    purchaseLimit: 'once',
+    ttlMinutes: TTL_MINUTES,
+    requiredConfirmations: REQUIRED_CONFIRMATIONS,
+    grant: { gold: 400, silver: 400 }
+  },
+  basic_pack: {
+    key: 'basic_pack',
+    title: 'Basic Pack',
+    currency: DEFAULT_TOKEN_SYMBOL,
+    network: DEFAULT_NETWORK,
+    tokenContract: DEFAULT_TOKEN_CONTRACT,
+    tokenDecimals: DEFAULT_TOKEN_DECIMALS,
+    merchantWallet: DEFAULT_MERCHANT_WALLET,
+    price: price('0.09', '9'),
+    purchaseLimit: 'unlimited',
+    ttlMinutes: TTL_MINUTES,
+    requiredConfirmations: REQUIRED_CONFIRMATIONS,
+    grant: { gold: 200, silver: 200 }
+  },
+  advanced_pack: {
+    key: 'advanced_pack',
+    title: 'Advanced Pack',
+    currency: DEFAULT_TOKEN_SYMBOL,
+    network: DEFAULT_NETWORK,
+    tokenContract: DEFAULT_TOKEN_CONTRACT,
+    tokenDecimals: DEFAULT_TOKEN_DECIMALS,
+    merchantWallet: DEFAULT_MERCHANT_WALLET,
+    price: price('0.17', '17'),
+    purchaseLimit: 'unlimited',
+    ttlMinutes: TTL_MINUTES,
+    requiredConfirmations: REQUIRED_CONFIRMATIONS,
+    grant: { gold: 400, silver: 400 }
+  },
+  super_pack: {
+    key: 'super_pack',
+    title: 'Super Pack',
+    currency: DEFAULT_TOKEN_SYMBOL,
+    network: DEFAULT_NETWORK,
+    tokenContract: DEFAULT_TOKEN_CONTRACT,
+    tokenDecimals: DEFAULT_TOKEN_DECIMALS,
+    merchantWallet: DEFAULT_MERCHANT_WALLET,
+    price: price('0.40', '40'),
+    purchaseLimit: 'unlimited',
+    ttlMinutes: TTL_MINUTES,
+    requiredConfirmations: REQUIRED_CONFIRMATIONS,
+    grant: { gold: 1000, silver: 1000 }
+  },
+  gold_pack: {
+    key: 'gold_pack',
+    title: 'Gold',
+    currency: DEFAULT_TOKEN_SYMBOL,
+    network: DEFAULT_NETWORK,
+    tokenContract: DEFAULT_TOKEN_CONTRACT,
+    tokenDecimals: DEFAULT_TOKEN_DECIMALS,
+    merchantWallet: DEFAULT_MERCHANT_WALLET,
+    price: price('0.05', '5'),
+    purchaseLimit: 'unlimited',
+    ttlMinutes: TTL_MINUTES,
+    requiredConfirmations: REQUIRED_CONFIRMATIONS,
+    grant: { gold: 100, silver: 0 }
+  },
+  silver_pack: {
+    key: 'silver_pack',
+    title: 'Silver',
+    currency: DEFAULT_TOKEN_SYMBOL,
+    network: DEFAULT_NETWORK,
+    tokenContract: DEFAULT_TOKEN_CONTRACT,
+    tokenDecimals: DEFAULT_TOKEN_DECIMALS,
+    merchantWallet: DEFAULT_MERCHANT_WALLET,
+    price: price('0.03', '3'),
+    purchaseLimit: 'unlimited',
+    ttlMinutes: TTL_MINUTES,
+    requiredConfirmations: REQUIRED_CONFIRMATIONS,
+    grant: { gold: 0, silver: 100 }
+  }
+};
+
+function getDonationConfig(productKey) {
+  return DONATIONS_CONFIG[String(productKey || '').trim()];
+}
+
+module.exports = {
+  DONATIONS_CONFIG,
+  DONATIONS_PRICE_MODE: PRICE_MODE,
+  DONATIONS_REQUIRED_CONFIRMATIONS: REQUIRED_CONFIRMATIONS,
+  getDonationConfig
+};


### PR DESCRIPTION
### Motivation
- Add real-money donation products (USDT on BSC) so players can purchase in-game currency via on-chain transfers with server-side verification.
- Provide a secure payment intent lifecycle with TTL, duplicate-tx protection, confirmation checks and one-time purchase limits for specific products.

### Description
- Introduces a new Mongoose model `DonationPayment` to track payment intents, tx metadata, status transitions and timestamps. 
- Adds donation configuration and pricing via `utils/donationsConfig.js` and new environment variables documented in `README.md`. 
- Implements payment lifecycle and public helpers in `utils/donationService.js` including `listDonationProducts`, `createDonationPayment`, `submitDonationTransaction`, `getDonationPayment`, serialization, and test hooks (`setDonationVerifierForTests`/`resetDonationVerifier`).
- Adds on-chain verification logic in `utils/donationVerifier.js` that inspects ERC-20 transfer logs, compares recipient and amount, and checks confirmations using an RPC provider. 
- Exposes donation endpoints in `routes/store.js`: `GET /api/store/donations/:wallet`, `POST /api/store/donations/create-payment`, `POST /api/store/donations/submit-transaction`, and `GET /api/store/donations/payment/:paymentId`, and wires logging/security events. 
- Adds integration tests and test stubs in `tests/api.integration.test.js` covering product listing, payment intent creation, transaction submission leading to crediting, and prevention of duplicate one-time purchases. 

### Testing
- Ran the integration tests in `tests/api.integration.test.js` which include new donation flow tests for listing products, creating a payment intent, submitting a tx that results in credit, and blocking a second one-time purchase; these tests passed. 
- Existing leaderboard, account linking and store tests were exercised as part of the same suite and continued to pass. 
- Donation verification is testable via `setDonationVerifierForTests` to simulate RPC/receipt responses in CI/local runs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc52f3fc7483329e388429431f61d0)