### PR TITLE
Expose unauthenticated game mode config endpoint and presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ URSASS_Backend/
 ├── routes/
 │   ├── leaderboard.js   # Leaderboard & game result routes
 │   ├── store.js         # Upgrades & rides store routes
-│   └── account.js       # Auth & account linking routes
+│   ├── account.js       # Auth & account linking routes
+│   └── game.js          # Runtime game mode configuration routes
 ├── models/
 │   ├── Player.js
 │   ├── PlayerUpgrades.js
@@ -98,7 +99,16 @@ Versioned aliases are also available under `/api/v1/*` (backward-compatible with
 | `POST` | `/api/account/auth/wallet` | Authenticate via wallet (requires EIP-191 signature) |
 | `POST` | `/api/account/link/request-code` | Generate a 6-character code to link Telegram to a wallet |
 | `GET` | `/api/account/info` | Get account info |
+| `GET` | `/api/game/config?mode=unauth` | Get runtime config for non-persistent game modes |
 
+
+
+## Unauthenticated Browser Mode
+
+- Use `GET /api/game/config?mode=unauth` to fetch the runtime preset for browser users who choose not to authenticate.
+- This mode is **non-persistent**: no leaderboard entry, no progress save, no store purchases, and no ride limits are enforced by the config response.
+- The backend returns a ready-to-apply `activeEffects` object built with the same `calculateEffects` logic used for real player upgrades, so the frontend does not need to hardcode a separate improvement set.
+- Current preset: `all_improvements_enabled` (max gameplay improvements enabled for preview/demo sessions).
 
 ## Store Upgrade Semantics
 

--- a/app.js
+++ b/app.js
@@ -3,6 +3,7 @@ const cors = require('cors');
 const leaderboardRoutes = require('./routes/leaderboard');
 const storeRoutes = require('./routes/store');
 const accountRoutes = require('./routes/account');
+const gameRoutes = require('./routes/game');
 const logger = require('./utils/logger');
 const { metricsMiddleware, renderMetricsText } = require('./middleware/requestMetrics');
 
@@ -56,10 +57,12 @@ function createApp() {
   app.use('/api/leaderboard', leaderboardRoutes);
   app.use('/api/store', storeRoutes);
   app.use('/api/account', accountRoutes);
+  app.use('/api/game', gameRoutes);
 
   app.use('/api/v1/leaderboard', leaderboardRoutes);
   app.use('/api/v1/store', storeRoutes);
   app.use('/api/v1/account', accountRoutes);
+  app.use('/api/v1/game', gameRoutes);
 
   app.get('/health', (req, res) => {
     res.json({ status: 'OK', timestamp: new Date(), mongodb: 'connected' });

--- a/routes/game.js
+++ b/routes/game.js
@@ -1,0 +1,25 @@
+const express = require('express');
+const router = express.Router();
+const { readLimiter } = require('../middleware/rateLimiter');
+const logger = require('../utils/logger');
+const { getGameModeConfig } = require('../utils/gameModeConfig');
+
+router.get('/config', readLimiter, async (req, res) => {
+  try {
+    const requestedMode = req.query.mode || 'unauth';
+    const config = getGameModeConfig(requestedMode);
+
+    if (!config) {
+      return res.status(404).json({
+        error: `Unknown game mode config: ${requestedMode}`
+      });
+    }
+
+    res.json(config);
+  } catch (error) {
+    logger.error({ err: error }, 'GET /config error');
+    res.status(500).json({ error: 'Server error' });
+  }
+});
+
+module.exports = router;

--- a/tests/api.integration.test.js
+++ b/tests/api.integration.test.js
@@ -404,3 +404,38 @@ test('POST /api/store/donations/create-payment blocks second Starter Pack after 
 
   await server.close();
 });
+
+
+test('GET /api/game/config returns unauth preset built from backend config', async () => {
+  const { server, baseUrl } = await startServer();
+
+  const res = await fetch(`${baseUrl}/api/game/config?mode=unauth`);
+
+  assert.equal(res.status, 200);
+  const body = await res.json();
+  assert.equal(body.mode, 'unauth');
+  assert.equal(body.saveProgress, false);
+  assert.equal(body.eligibleForLeaderboard, false);
+  assert.equal(body.storeEnabled, false);
+  assert.equal(body.rides.limited, false);
+  assert.equal(body.preset, 'all_improvements_enabled');
+  assert.equal(body.activeEffects.start_with_shield, true);
+  assert.equal(body.activeEffects.start_with_radar, true);
+  assert.equal(body.activeEffects.perfect_spin_enabled, true);
+  assert.equal(body.activeEffects.shield_capacity, 3);
+  assert.equal(body.activeEffects.x2_duration_bonus, 15);
+
+  await server.close();
+});
+
+test('GET /api/game/config rejects unknown mode', async () => {
+  const { server, baseUrl } = await startServer();
+
+  const res = await fetch(`${baseUrl}/api/game/config?mode=unknown`);
+
+  assert.equal(res.status, 404);
+  const body = await res.json();
+  assert.match(body.error, /Unknown game mode config/i);
+
+  await server.close();
+});

--- a/utils/gameModeConfig.js
+++ b/utils/gameModeConfig.js
@@ -1,0 +1,68 @@
+const { calculateEffects } = require('./upgradesConfig');
+
+const UNAUTH_MAX_UPGRADES = Object.freeze({
+  x2_duration: 3,
+  score_plus_300_mult: 3,
+  score_plus_500_mult: 3,
+  score_minus_300_mult: 3,
+  score_minus_500_mult: 3,
+  invert_score: 3,
+  speed_up_mult: 3,
+  speed_down_mult: 3,
+  magnet_duration: 3,
+  spin_cooldown: 3,
+  shield: 1,
+  shield_capacity: 2,
+  radar: 1,
+  alert: 2
+});
+
+function createUnauthUpgradesPreset(overrides = {}) {
+  return {
+    ...UNAUTH_MAX_UPGRADES,
+    freeRidesRemaining: 3,
+    paidRidesRemaining: 0,
+    getTotalRides() {
+      return this.freeRidesRemaining + this.paidRidesRemaining;
+    },
+    ...overrides
+  };
+}
+
+function getGameModeConfig(mode = 'unauth') {
+  const normalizedMode = String(mode || 'unauth').trim().toLowerCase();
+
+  if (normalizedMode !== 'unauth') {
+    return null;
+  }
+
+  const upgrades = createUnauthUpgradesPreset();
+
+  return {
+    mode: 'unauth',
+    preset: 'all_improvements_enabled',
+    authRequired: false,
+    saveProgress: false,
+    eligibleForLeaderboard: false,
+    storeEnabled: false,
+    rides: {
+      limited: false,
+      freeRides: null,
+      paidRides: null,
+      totalRides: null,
+      resetInMs: null,
+      resetInFormatted: null
+    },
+    balance: {
+      gold: 0,
+      silver: 0
+    },
+    activeEffects: calculateEffects(upgrades)
+  };
+}
+
+module.exports = {
+  UNAUTH_MAX_UPGRADES,
+  createUnauthUpgradesPreset,
+  getGameModeConfig
+};


### PR DESCRIPTION
### Motivation

- Provide a runtime preset for browser users who opt out of authentication so frontend can fetch a ready-to-apply configuration without hardcoding improvements.
- Enable a non-persistent demo/preview mode that mirrors real upgrade effects while preventing leaderboard/save/store interactions.

### Description

- Added a new route `GET /api/game/config` implemented in `routes/game.js` and mounted in `app.js` (also available under `/api/v1/game`).
- Implemented `utils/gameModeConfig.js` with `UNAUTH_MAX_UPGRADES`, `createUnauthUpgradesPreset`, and `getGameModeConfig` that builds the unauth preset and reuses `calculateEffects` from `upgradesConfig`.
- Updated `README.md` to document the new `GET /api/game/config?mode=unauth` endpoint and the unauthenticated browser mode semantics.
- Added integration tests in `tests/api.integration.test.js` to verify the unauth config response and handling of unknown modes, and used existing `readLimiter`/logging in the route implementation.

### Testing

- Ran the integration test suite (`tests/api.integration.test.js`) which includes the new tests `GET /api/game/config returns unauth preset built from backend config` and `GET /api/game/config rejects unknown mode`.
- All new and existing automated integration tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc5a381338833288ec8b449cd9ecc5)