### PR TITLE
Add wallet-ready donation payment payload

### DIFF
--- a/routes/store.js
+++ b/routes/store.js
@@ -166,8 +166,9 @@ router.get('/donations/:wallet', readLimiter, async (req, res) => {
  */
 router.post('/donations/create-payment', writeLimiter, async (req, res) => {
   try {
-    const { wallet, productKey } = req.body;
-    const payment = await createDonationPayment(wallet, productKey);
+    const { wallet, productKey, donationKey, key, productId } = req.body;
+    const resolvedProductKey = productKey || donationKey || key || productId;
+    const payment = await createDonationPayment(wallet, resolvedProductKey);
 
     await logSecurityEvent({
       wallet: payment.wallet,

--- a/tests/api.integration.test.js
+++ b/tests/api.integration.test.js
@@ -312,6 +312,37 @@ test('POST /api/store/donations/create-payment creates payment intent', async ()
   assert.equal(body.txRequest.transferTo, '0x244bcc2721f1037958862825c3feb6a7be6204a7');
   assert.equal(body.txRequest.transferAmount, '0.02');
   assert.match(body.txRequest.data, /^0xa9059cbb/i);
+  assert.equal(body.txRequest.walletPayload.method, 'eth_sendTransaction');
+  assert.deepEqual(body.txRequest.walletPayload.params[0], {
+    to: body.txRequest.to,
+    value: '0x0',
+    data: body.txRequest.data
+  });
+
+  await server.close();
+});
+
+
+
+test('POST /api/store/donations/create-payment accepts legacy productId alias', async () => {
+  const wallet = Wallet.createRandom().address.toLowerCase();
+
+  Player.findOne = () => queryResult({
+    wallet,
+    totalGoldCoins: 0,
+    totalSilverCoins: 0
+  });
+
+  const { server, baseUrl } = await startServer();
+  const res = await fetch(`${baseUrl}/api/store/donations/create-payment`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ wallet, productId: 'starter_pack' })
+  });
+
+  assert.equal(res.status, 201);
+  const body = await res.json();
+  assert.equal(body.productKey, 'starter_pack');
 
   await server.close();
 });

--- a/utils/donationService.js
+++ b/utils/donationService.js
@@ -49,19 +49,27 @@ function buildDonationTxRequest(payment) {
     payment.expectedDecimals
   ).toHexString();
 
-  return {
+  const transaction = {
     to: payment.tokenContract,
     value: '0x0',
     data: erc20TransferInterface.encodeFunctionData('transfer', [
       payment.merchantWallet,
       ethers.BigNumber.from(amountRaw)
-    ]),
+    ])
+  };
+
+  return {
+    ...transaction,
     chainLabel: payment.network,
     tokenSymbol: payment.tokenSymbol,
     tokenDecimals: payment.expectedDecimals,
     transferTo: payment.merchantWallet,
     transferAmount: payment.expectedAmount,
-    transferAmountRaw: amountRaw
+    transferAmountRaw: amountRaw,
+    walletPayload: {
+      method: 'eth_sendTransaction',
+      params: [transaction]
+    }
   };
 }
 


### PR DESCRIPTION
### Motivation
- Enable the frontend to immediately open a connected wallet confirmation for donation payments without asking the user to manually enter amount/address by returning a wallet-ready transaction payload from the `create-payment` endpoint.
- Make donation creation more robust by accepting legacy/alternate product key fields so frontend variations do not cause a `400` error.

### Description
- Add a `walletPayload` object to the donation `txRequest` returned by `serializeDonationPayment` with a ready-to-send `eth_sendTransaction` request (method and `params` containing `{ to, value, data }`) so the frontend can pass it directly to a connected wallet (`utils/donationService.js`).
- Accept fallback product key fields `donationKey`, `key`, and `productId` in `POST /api/store/donations/create-payment` and resolve them to `productKey` before creating a payment (`routes/store.js`).
- Extend integration tests to assert the presence and shape of `txRequest.walletPayload` and to cover the legacy `productId` alias (`tests/api.integration.test.js`).

### Testing
- Ran `npm test` and all integration tests passed (19 tests, 0 failures). 
- Ran the repository syntax check with `npm run check:syntax` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bc830831d48332be5b589c7d77039b)