### PR TITLE
Add donation status recovery via txHash

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Versioned aliases are also available under `/api/v1/*` (backward-compatible with
 | `POST` | `/api/store/buy` | Buy an upgrade or ride pack (requires EIP-191 signature) |
 | `POST` | `/api/store/donations/create-payment` | Create a USDT donation payment intent |
 | `POST` | `/api/store/donations/submit-transaction` | Submit tx hash for donation payment verification |
-| `GET` | `/api/store/donations/payment/:paymentId` | Get donation payment status |
+| `GET` | `/api/store/donations/payment/:paymentId` | Get donation payment status; optional `wallet` + `txHash` query can recover verification if wallet send succeeded but submit call was lost |
 | `POST` | `/api/store/consume-ride` | Consume a ride when starting a game (requires unique `rideSessionId`) |
 | `POST` | `/api/account/auth/telegram` | Authenticate via Telegram |
 | `POST` | `/api/account/auth/wallet` | Authenticate via wallet (requires EIP-191 signature) |

--- a/routes/store.js
+++ b/routes/store.js
@@ -222,7 +222,8 @@ router.post('/donations/submit-transaction', writeLimiter, async (req, res) => {
  */
 router.get('/donations/payment/:paymentId', readLimiter, async (req, res) => {
   try {
-    const payment = await getDonationPayment(req.params.paymentId);
+    const { wallet, txHash } = req.query;
+    const payment = await getDonationPayment(req.params.paymentId, { wallet, txHash });
     if (!payment) {
       return res.status(404).json({ error: 'Payment not found' });
     }
@@ -230,7 +231,7 @@ router.get('/donations/payment/:paymentId', readLimiter, async (req, res) => {
     res.json(serializeDonationPayment(payment));
   } catch (error) {
     logger.error({ err: error }, 'GET /donations/payment error');
-    res.status(500).json({ error: 'Server error' });
+    res.status(error.statusCode || 500).json({ error: error.message || 'Server error' });
   }
 });
 

--- a/tests/api.integration.test.js
+++ b/tests/api.integration.test.js
@@ -393,6 +393,50 @@ test('POST /api/store/donations/submit-transaction credits player after successf
   await server.close();
 });
 
+
+test('GET /api/store/donations/payment/:paymentId accepts txHash recovery query and credits player', async () => {
+  const wallet = Wallet.createRandom().address.toLowerCase();
+  const player = {
+    wallet,
+    totalGoldCoins: 5,
+    totalSilverCoins: 7,
+    save: async function save() { return this; }
+  };
+
+  Player.findOne = ({ wallet: requestedWallet }) => queryResult(requestedWallet === wallet ? player : null);
+
+  setDonationVerifierForTests(async () => ({
+    status: 'confirmed',
+    reason: 'confirmed',
+    confirmations: 2,
+    actualFrom: '0xsender',
+    actualTo: '0x244bcc2721f1037958862825c3feb6a7be6204a7',
+    actualAmount: '20000000000000000'
+  }));
+
+  const { server, baseUrl } = await startServer();
+
+  const createRes = await fetch(`${baseUrl}/api/store/donations/create-payment`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ wallet, productKey: 'starter_pack' })
+  });
+  const created = await createRes.json();
+
+  const statusRes = await fetch(
+    `${baseUrl}/api/store/donations/payment/${created.paymentId}?wallet=${encodeURIComponent(wallet)}&txHash=0xrecoverhash`
+  );
+
+  assert.equal(statusRes.status, 200);
+  const recovered = await statusRes.json();
+  assert.equal(recovered.status, 'credited');
+  assert.equal(recovered.txHash, '0xrecoverhash');
+  assert.equal(player.totalGoldCoins, 405);
+  assert.equal(player.totalSilverCoins, 407);
+
+  await server.close();
+});
+
 test('POST /api/store/donations/create-payment blocks second Starter Pack after successful credit', async () => {
   const wallet = Wallet.createRandom().address.toLowerCase();
   const player = {

--- a/utils/donationService.js
+++ b/utils/donationService.js
@@ -304,10 +304,34 @@ async function submitDonationTransaction({ wallet, paymentId, txHash }) {
   return recheckDonationPayment(payment);
 }
 
-async function getDonationPayment(paymentId) {
+async function getDonationPayment(paymentId, options = {}) {
   const payment = await DonationPayment.findOne({ paymentId });
   if (!payment) {
     return null;
+  }
+
+  const normalizedWallet = options.wallet ? normalizeWallet(options.wallet) : null;
+  const normalizedHash = typeof options.txHash === 'string' ? options.txHash.trim() : '';
+
+  if (normalizedWallet && payment.wallet !== normalizedWallet) {
+    const err = new Error('Payment does not belong to this wallet');
+    err.statusCode = 403;
+    throw err;
+  }
+
+  if (normalizedHash && !payment.txHash && payment.status === 'created') {
+    const existingHash = await DonationPayment.findOne({ txHash: normalizedHash, paymentId: { $ne: paymentId } });
+    if (existingHash) {
+      const err = new Error('Transaction hash already used');
+      err.statusCode = 409;
+      throw err;
+    }
+
+    payment.txHash = normalizedHash;
+    payment.submittedAt = payment.submittedAt || new Date();
+    payment.status = 'submitted';
+    payment.failureReason = null;
+    await payment.save();
   }
 
   if (payment.status === 'submitted' || payment.status === 'pending') {


### PR DESCRIPTION
### Motivation
- Payment flow could lose the `txHash` if the frontend's `submit-transaction` request failed, leaving a created payment that never gets credited despite on-chain transfer having happened. 
- A simple `GET /api/store/donations/payment/:paymentId` read-only call without the `txHash` cannot recover such cases. 
- Provide a resilient recovery path so a lost `submit-transaction` can be recovered from the client without requiring manual backend intervention.

### Description
- Extended `getDonationPayment` to accept an `options` argument (`{ wallet, txHash }`) and, when a `txHash` is provided for a `created` payment, attach the hash, mark the payment as `submitted`, ensure `txHash` uniqueness, persist the change and trigger verification via the existing `recheckDonationPayment` flow. 
- Updated `GET /api/store/donations/payment/:paymentId` to accept optional `wallet` and `txHash` query parameters and pass them to `getDonationPayment`. 
- Improved error propagation in the status route to return `error.statusCode`/`error.message` when appropriate. 
- Added an integration test that simulates creating a payment and then calling the status endpoint with `wallet`+`txHash` to verify the recovery path credits the player, and documented the recovery behavior in `README.md`.

### Testing
- Ran the test suite with `npm test -- --runInBand` and all tests passed (`20` tests, `0` failures). 
- The new integration test that exercises the `txHash` recovery path passed as part of the suite. 
- Existing donation flows (`create-payment`, `submit-transaction`, purchase blocking for single-purchase items) were covered by the test run and remained green.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd2b2be7108332b60d14f3a2347657)