### PR TITLE
Add donations history endpoint and extend donation payment service

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,7 @@ Versioned aliases are also available under `/api/v1/*` (backward-compatible with
 | `GET` | `/api/store/upgrades/:wallet` | Get player upgrades, rides, and balance |
 | `GET` | `/api/store/donations/:wallet` | Get donation products available for a wallet |
 | `POST` | `/api/store/buy` | Buy an upgrade or ride pack (requires EIP-191 signature) |
+| `GET` | `/api/store/donations/history/:wallet` | Get donation payment history for a wallet (for purchases history UI) |
 | `POST` | `/api/store/donations/create-payment` | Create a USDT donation payment intent |
 | `POST` | `/api/store/donations/submit-transaction` | Submit tx hash for donation payment verification |
 | `GET` | `/api/store/donations/payment/:paymentId` | Get donation payment status |

--- a/routes/store.js
+++ b/routes/store.js
@@ -4,7 +4,7 @@ const Player = require('../models/Player');
 const PlayerUpgrades = require('../models/PlayerUpgrades');
 const AccountLink = require('../models/AccountLink');
 const { UPGRADES_CONFIG, calculateEffects } = require('../utils/upgradesConfig');
-const { listDonationProducts, createDonationPayment, submitDonationTransaction, getDonationPayment, serializeDonationPayment } = require('../utils/donationService');
+const { listDonationProducts, listDonationPayments, createDonationPayment, submitDonationTransaction, getDonationPayment, serializeDonationPayment } = require('../utils/donationService');
 const { verifySignature } = require('../utils/verifySignature');
 const { writeLimiter, readLimiter } = require('../middleware/rateLimiter');
 const SecurityEvent = require('../models/SecurityEvent');
@@ -162,6 +162,20 @@ router.get('/donations/:wallet', readLimiter, async (req, res) => {
 });
 
 /**
+ * GET /api/store/donations/history/:wallet
+ * Get donation payment history for a wallet
+ */
+router.get('/donations/history/:wallet', readLimiter, async (req, res) => {
+  try {
+    const payload = await listDonationPayments(req.params.wallet, { limit: req.query.limit });
+    res.json(payload);
+  } catch (error) {
+    logger.error({ err: error }, 'GET /donations/history error');
+    res.status(error.statusCode || 500).json({ error: error.message || 'Server error' });
+  }
+});
+
+/**
  * POST /api/store/donations/create-payment
  */
 router.post('/donations/create-payment', writeLimiter, async (req, res) => {
@@ -222,7 +236,8 @@ router.post('/donations/submit-transaction', writeLimiter, async (req, res) => {
  */
 router.get('/donations/payment/:paymentId', readLimiter, async (req, res) => {
   try {
-    const payment = await getDonationPayment(req.params.paymentId);
+    const { wallet, txHash } = req.query;
+    const payment = await getDonationPayment(req.params.paymentId, { wallet, txHash });
     if (!payment) {
       return res.status(404).json({ error: 'Payment not found' });
     }
@@ -230,7 +245,7 @@ router.get('/donations/payment/:paymentId', readLimiter, async (req, res) => {
     res.json(serializeDonationPayment(payment));
   } catch (error) {
     logger.error({ err: error }, 'GET /donations/payment error');
-    res.status(500).json({ error: 'Server error' });
+    res.status(error.statusCode || 500).json({ error: error.message || 'Server error' });
   }
 });
 

--- a/tests/api.integration.test.js
+++ b/tests/api.integration.test.js
@@ -58,6 +58,12 @@ test.beforeEach(() => {
   LinkCode.deleteOne = async () => ({ deletedCount: 1 });
   donationPayments = [];
   DonationPayment.prototype.save = async function save() {
+    const now = new Date();
+    if (!this.createdAt) {
+      this.createdAt = now;
+    }
+    this.updatedAt = now;
+
     const plain = this.toObject ? this.toObject() : { ...this };
     const index = donationPayments.findIndex((item) => item.paymentId === plain.paymentId);
     const stored = {
@@ -72,27 +78,52 @@ test.beforeEach(() => {
     Object.assign(this, stored);
     return this;
   };
+  const matchesDonationQuery = (item, query = {}) => Object.entries(query).every(([key, value]) => {
+    if (value && typeof value === 'object' && !Array.isArray(value)) {
+      if ('$in' in value) {
+        return value.$in.includes(item[key]);
+      }
+      if ('$ne' in value) {
+        return item[key] !== value.$ne;
+      }
+    }
+    return item[key] === value;
+  });
+
   DonationPayment.findOne = async (query = {}) => {
-    const match = donationPayments.find((item) => {
-      return Object.entries(query).every(([key, value]) => {
-        if (value && typeof value === 'object' && !Array.isArray(value)) {
-          if ('$in' in value) {
-            return value.$in.includes(item[key]);
-          }
-          if ('$ne' in value) {
-            return item[key] !== value.$ne;
-          }
-        }
-        return item[key] === value;
-      });
-    });
+    const match = donationPayments.find((item) => matchesDonationQuery(item, query));
 
     return match ? { ...match, save: async function saveSelf() {
       const index = donationPayments.findIndex((item) => item.paymentId === this.paymentId);
-      const updated = { ...this, save: this.save };
+      const updated = { ...this, updatedAt: new Date(), save: this.save };
       donationPayments[index] = updated;
       return this;
     } } : null;
+  };
+
+  DonationPayment.find = (query = {}) => {
+    let results = donationPayments.filter((item) => matchesDonationQuery(item, query)).map((item) => ({ ...item }));
+
+    const chain = {
+      sort(sortSpec = {}) {
+        const [[field, direction]] = Object.entries(sortSpec);
+        results = results.sort((a, b) => {
+          const av = new Date(a[field] || 0).getTime();
+          const bv = new Date(b[field] || 0).getTime();
+          return direction < 0 ? bv - av : av - bv;
+        });
+        return chain;
+      },
+      limit(limitValue) {
+        results = results.slice(0, limitValue);
+        return Promise.resolve(results.map((item) => ({ ...item })));
+      },
+      then(resolve, reject) {
+        return Promise.resolve(results.map((item) => ({ ...item }))).then(resolve, reject);
+      }
+    };
+
+    return chain;
   };
   resetDonationVerifier();
 });
@@ -389,6 +420,70 @@ test('POST /api/store/donations/submit-transaction credits player after successf
   assert.equal(submitted.txRequest.transferAmount, '0.02');
   assert.equal(player.totalGoldCoins, 410);
   assert.equal(player.totalSilverCoins, 420);
+
+  await server.close();
+});
+
+
+
+test('GET /api/store/donations/history/:wallet returns payments sorted by newest first', async () => {
+  const wallet = Wallet.createRandom().address.toLowerCase();
+  const player = {
+    wallet,
+    totalGoldCoins: 0,
+    totalSilverCoins: 0,
+    save: async function save() { return this; }
+  };
+
+  Player.findOne = () => queryResult(player);
+
+  setDonationVerifierForTests(async () => ({
+    status: 'pending',
+    reason: 'awaiting_confirmations',
+    confirmations: 0,
+    actualFrom: '0xsender',
+    actualTo: '0x244bcc2721f1037958862825c3feb6a7be6204a7',
+    actualAmount: '30000000000000000'
+  }));
+
+  const { server, baseUrl } = await startServer();
+
+  const firstCreate = await fetch(`${baseUrl}/api/store/donations/create-payment`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ wallet, productKey: 'starter_pack' })
+  });
+  const firstPayment = await firstCreate.json();
+
+  await new Promise((resolve) => setTimeout(resolve, 5));
+
+  const secondCreate = await fetch(`${baseUrl}/api/store/donations/create-payment`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ wallet, productKey: 'basic_pack' })
+  });
+  const secondPayment = await secondCreate.json();
+
+  await fetch(`${baseUrl}/api/store/donations/submit-transaction`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ wallet, paymentId: secondPayment.paymentId, txHash: '0xpendinghash' })
+  });
+
+  const historyRes = await fetch(`${baseUrl}/api/store/donations/history/${wallet}`);
+
+  assert.equal(historyRes.status, 200);
+  const history = await historyRes.json();
+  assert.equal(history.wallet, wallet);
+  assert.equal(history.payments.length, 2);
+  assert.equal(history.payments[0].paymentId, secondPayment.paymentId);
+  assert.equal(history.payments[0].status, 'pending');
+  assert.equal(history.payments[0].title, 'Basic Pack');
+  assert.equal(history.payments[0].amount, '0.09');
+  assert.equal(history.payments[0].txRequest, null);
+  assert.ok(history.payments[0].createdAt);
+  assert.equal(history.payments[1].paymentId, firstPayment.paymentId);
+  assert.equal(history.payments[1].status, 'created');
 
   await server.close();
 });

--- a/utils/donationService.js
+++ b/utils/donationService.js
@@ -110,6 +110,26 @@ async function listDonationProducts(wallet) {
   };
 }
 
+async function listDonationPayments(wallet, options = {}) {
+  const normalizedWallet = normalizeWallet(wallet);
+
+  if (!normalizedWallet) {
+    const err = new Error('Invalid wallet address');
+    err.statusCode = 400;
+    throw err;
+  }
+
+  const limit = Math.max(1, Math.min(100, Number(options.limit) || 20));
+  const payments = await DonationPayment.find({ wallet: normalizedWallet })
+    .sort({ createdAt: -1 })
+    .limit(limit);
+
+  return {
+    wallet: normalizedWallet,
+    payments: payments.map((payment) => serializeDonationPayment(payment, { includeTxRequest: false }))
+  };
+}
+
 async function createDonationPayment(wallet, productKey) {
   const normalizedWallet = normalizeWallet(wallet);
   const config = getDonationConfig(productKey);
@@ -304,10 +324,34 @@ async function submitDonationTransaction({ wallet, paymentId, txHash }) {
   return recheckDonationPayment(payment);
 }
 
-async function getDonationPayment(paymentId) {
+async function getDonationPayment(paymentId, options = {}) {
   const payment = await DonationPayment.findOne({ paymentId });
   if (!payment) {
     return null;
+  }
+
+  const normalizedWallet = options.wallet ? normalizeWallet(options.wallet) : null;
+  const normalizedHash = typeof options.txHash === 'string' ? options.txHash.trim() : '';
+
+  if (normalizedWallet && payment.wallet !== normalizedWallet) {
+    const err = new Error('Payment does not belong to this wallet');
+    err.statusCode = 403;
+    throw err;
+  }
+
+  if (normalizedHash && !payment.txHash && payment.status === 'created') {
+    const existingHash = await DonationPayment.findOne({ txHash: normalizedHash, paymentId: { $ne: paymentId } });
+    if (existingHash) {
+      const err = new Error('Transaction hash already used');
+      err.statusCode = 409;
+      throw err;
+    }
+
+    payment.txHash = normalizedHash;
+    payment.submittedAt = payment.submittedAt || new Date();
+    payment.status = 'submitted';
+    payment.failureReason = null;
+    await payment.save();
   }
 
   if (payment.status === 'submitted' || payment.status === 'pending') {
@@ -323,10 +367,12 @@ async function getDonationPayment(paymentId) {
   return payment;
 }
 
-function serializeDonationPayment(payment) {
+function serializeDonationPayment(payment, options = {}) {
   if (!payment) {
     return null;
   }
+
+  const includeTxRequest = options.includeTxRequest !== false;
 
   return {
     paymentId: payment.paymentId,
@@ -344,12 +390,18 @@ function serializeDonationPayment(payment) {
     confirmations: payment.confirmations,
     reward: payment.productSnapshot?.grant || { gold: 0, silver: 0 },
     failureReason: payment.failureReason,
-    txRequest: buildDonationTxRequest(payment)
+    createdAt: payment.createdAt || null,
+    updatedAt: payment.updatedAt || null,
+    submittedAt: payment.submittedAt || null,
+    confirmedAt: payment.confirmedAt || null,
+    creditedAt: payment.creditedAt || null,
+    txRequest: includeTxRequest ? buildDonationTxRequest(payment) : null
   };
 }
 
 module.exports = {
   listDonationProducts,
+  listDonationPayments,
   createDonationPayment,
   submitDonationTransaction,
   getDonationPayment,


### PR DESCRIPTION
### Motivation
- Provide a way for the frontend to fetch a player's donation/payment history for the purchases history UI.
- Improve donation payment handling by allowing retrieval/update via query params and exposing timestamps for better client-side display and sorting.
- Harden API error propagation so callers can receive appropriate HTTP status codes and messages.

### Description
- Add `GET /api/store/donations/history/:wallet` route in `routes/store.js` that calls `listDonationPayments` and returns a per-wallet payments list with a `limit` query option.
- Implement `listDonationPayments` in `utils/donationService.js` to validate wallet, paginate (limit clamp), sort by `createdAt` desc, and return serialized payments.
- Extend `getDonationPayment` to accept `options` (`wallet` and `txHash`), validate ownership, and allow auto-submitting a `txHash` for a `created` payment while checking for duplicate tx hashes.
- Extend `serializeDonationPayment` to include `createdAt`, `updatedAt`, `submittedAt`, `confirmedAt`, `creditedAt`, and make `txRequest` optional via `includeTxRequest` flag.
- Update route imports and error responses to propagate `error.statusCode` and `error.message` when available, and update README to document the new endpoint.
- Update tests in `tests/api.integration.test.js` to mock `DonationPayment` storage more fully (timestamps, `find`, `findOne`, sorting/limit) and add an integration test `GET /api/store/donations/history/:wallet returns payments sorted by newest first`.

### Testing
- Updated integration tests in `tests/api.integration.test.js` were run, including the new `GET /api/store/donations/history/:wallet` test, and all tests succeeded.
- Existing donation flow tests (`create-payment`, `submit-transaction`, crediting behavior) were executed and remained passing after the changes.
- Mocked `DonationPayment.find`/`findOne` behavior was validated to ensure sorting, limiting and timestamp fields are handled correctly in tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd2b2be7108332b60d14f3a2347657)