### PR TITLE
Fix donation history routing and restore createDonationPayment service

### DIFF
--- a/routes/store.js
+++ b/routes/store.js
@@ -142,6 +142,20 @@ router.get('/upgrades/:wallet', readLimiter, async (req, res) => {
 });
 
 /**
+ * GET /api/store/donations/history/:wallet
+ * Get donation payment history for a wallet
+ */
+router.get('/donations/history/:wallet', readLimiter, async (req, res) => {
+  try {
+    const payload = await listDonationPayments(req.params.wallet, { limit: req.query.limit });
+    res.json(payload);
+  } catch (error) {
+    logger.error({ err: error }, 'GET /donations/history error');
+    res.status(error.statusCode || 500).json({ error: error.message || 'Server error' });
+  }
+});
+
+/**
  * GET /api/store/donations/:wallet
  * Get all USDT donation products for a wallet
  */
@@ -158,20 +172,6 @@ router.get('/donations/:wallet', readLimiter, async (req, res) => {
   } catch (error) {
     logger.error({ err: error }, 'GET /donations error');
     res.status(500).json({ error: 'Server error' });
-  }
-});
-
-/**
- * GET /api/store/donations/history/:wallet
- * Get donation payment history for a wallet
- */
-router.get('/donations/history/:wallet', readLimiter, async (req, res) => {
-  try {
-    const payload = await listDonationPayments(req.params.wallet, { limit: req.query.limit });
-    res.json(payload);
-  } catch (error) {
-    logger.error({ err: error }, 'GET /donations/history error');
-    res.status(error.statusCode || 500).json({ error: error.message || 'Server error' });
   }
 });
 

--- a/utils/donationService.js
+++ b/utils/donationService.js
@@ -130,6 +130,51 @@ async function listDonationPayments(wallet, options = {}) {
   };
 }
 
+async function createDonationPayment(wallet, productKey) {
+  const normalizedWallet = normalizeWallet(wallet);
+  const config = getDonationConfig(productKey);
+
+  if (!normalizedWallet || !config) {
+    const err = new Error(!normalizedWallet ? 'Invalid wallet address' : 'Unknown donation product');
+    err.statusCode = 400;
+    throw err;
+  }
+
+  if (config.purchaseLimit === 'once' && await hasSuccessfulDonation(normalizedWallet, config.key)) {
+    const err = new Error(`${config.title} already purchased`);
+    err.statusCode = 409;
+    throw err;
+  }
+
+  const now = new Date();
+  const payment = new DonationPayment({
+    paymentId: crypto.randomUUID(),
+    wallet: normalizedWallet,
+    productKey: config.key,
+    productSnapshot: {
+      key: config.key,
+      title: config.title,
+      grant: config.grant,
+      price: config.price,
+      currency: config.currency,
+      network: config.network,
+      requiredConfirmations: config.requiredConfirmations,
+      purchaseLimit: config.purchaseLimit
+    },
+    status: 'created',
+    network: config.network,
+    tokenSymbol: config.currency,
+    tokenContract: config.tokenContract,
+    merchantWallet: config.merchantWallet,
+    expectedAmount: config.price,
+    expectedDecimals: config.tokenDecimals,
+    expiresAt: new Date(now.getTime() + (config.ttlMinutes * 60 * 1000))
+  });
+
+  await payment.save();
+  return payment;
+}
+
 
 async function creditDonationPayment(payment) {
   if (payment.status === 'credited') {


### PR DESCRIPTION
### Motivation
- The donations history endpoint was being shadowed by a more generic wallet-products route and the service function to create donation payments was missing, causing donation-related flows and tests to fail.

### Description
- Moved the `GET /api/store/donations/history/:wallet` route ahead of the generic `GET /api/store/donations/:wallet` route in `routes/store.js` so history requests are handled by the specific endpoint.
- Restored `createDonationPayment` in `utils/donationService.js`, adding wallet/product validation, once-only purchase blocking for limited products, payment record creation with `paymentId` and `expiresAt`, and saving to `DonationPayment`.
- Preserved existing behaviors including validation error status codes, purchase-limit enforcement, newest-first sorting for history, and omitting `txRequest` from history items.
- No changes to external APIs; route order and service signatures remain compatible with existing callers.

### Testing
- Reproduced the original failing scenario with a focused test run: `npm test -- --test-name-pattern="GET /api/store/donations/history/:wallet returns payments sorted by newest first"` to validate the issue prior to the fix.
- Ran the full test suite with `npm test` after the changes and all tests passed (20/20 subtests succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bd35b2923883328b6aaa765f16ecee)