### PR TITLE
Adjust donation USDT payment status flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ The store now contains **two parallel product systems**:
 - `UPGRADES_CONFIG` for gameplay upgrades and rides purchased with in-game `gold` / `silver`
 - `DONATIONS_CONFIG` for real-money style USDT donation packs that credit in-game currencies after on-chain verification
 
-`create-payment` / `payment status` responses also include a prebuilt `txRequest` payload for an ERC-20 `transfer(...)` call, so the frontend can immediately open the connected wallet confirmation instead of manually assembling transaction data.
+`create-payment` / `payment status` responses also include a prebuilt `txRequest` payload for an ERC-20 `transfer(...)` call, so the frontend can immediately open the connected wallet confirmation instead of manually assembling transaction data. The backend no longer exposes a `created` donation status; before a tx hash is submitted the payment record is non-final and `status` is `null`, while post-submit verification stays `submitted` until it resolves to `credited` or `failed`.
 
 - `shield` is now a **1-level permanent progression**:
   - level 1 enables `activeEffects.start_with_shield = true`.

--- a/models/DonationPayment.js
+++ b/models/DonationPayment.js
@@ -24,8 +24,8 @@ const donationPaymentSchema = new mongoose.Schema({
   },
   status: {
     type: String,
-    enum: ['created', 'submitted', 'pending', 'confirmed', 'credited', 'failed', 'expired'],
-    default: 'created',
+    enum: ['awaiting_tx', 'submitted', 'confirmed', 'credited', 'failed', 'expired'],
+    default: 'awaiting_tx',
     index: true
   },
   network: {
@@ -83,7 +83,7 @@ const donationPaymentSchema = new mongoose.Schema({
   },
   expiresAt: {
     type: Date,
-    required: true,
+    default: null,
     index: true
   },
   submittedAt: {
@@ -95,6 +95,10 @@ const donationPaymentSchema = new mongoose.Schema({
     default: null
   },
   creditedAt: {
+    type: Date,
+    default: null
+  },
+  rewardGrantedAt: {
     type: Date,
     default: null
   }

--- a/tests/api.integration.test.js
+++ b/tests/api.integration.test.js
@@ -101,6 +101,23 @@ test.beforeEach(() => {
     } } : null;
   };
   
+
+  DonationPayment.findOneAndUpdate = async (query = {}, update = {}, options = {}) => {
+    const index = donationPayments.findIndex((item) => matchesDonationQuery(item, query));
+    if (index < 0) {
+      return null;
+    }
+
+    const current = donationPayments[index];
+    const next = {
+      ...current,
+      ...(update.$set || {}),
+      updatedAt: new Date()
+    };
+    donationPayments[index] = next;
+    return options.new ? { ...next, save: async function saveSelf() { return this; } } : { ...current, save: async function saveSelf() { return this; } };
+  };
+
   DonationPayment.find = (query = {}) => {
     let results = donationPayments.filter((item) => matchesDonationQuery(item, query)).map((item) => ({ ...item }));
 
@@ -335,7 +352,7 @@ test('POST /api/store/donations/create-payment creates payment intent', async ()
 
   assert.equal(res.status, 201);
   const body = await res.json();
-  assert.equal(body.status, 'created');
+  assert.equal(body.status, null);
   assert.equal(body.productKey, 'starter_pack');
   assert.equal(body.amount, '0.02');
   assert.equal(body.currency, 'USDT');
@@ -476,17 +493,117 @@ test('GET /api/store/donations/history/:wallet returns payments sorted by newest
   assert.equal(history.wallet, wallet);
   assert.equal(history.payments.length, 2);
   assert.equal(history.payments[0].paymentId, secondPayment.paymentId);
-  assert.equal(history.payments[0].status, 'pending');
+  assert.equal(history.payments[0].status, 'submitted');
   assert.equal(history.payments[0].title, 'Basic Pack');
   assert.equal(history.payments[0].amount, '0.09');
   assert.equal(history.payments[0].txRequest, null);
   assert.ok(history.payments[0].createdAt);
   assert.equal(history.payments[1].paymentId, firstPayment.paymentId);
-  assert.equal(history.payments[1].status, 'created');
+  assert.equal(history.payments[1].status, null);
 
   await server.close();
 });
 ;
+
+
+test('GET /api/store/donations/payment/:paymentId returns failed after 30 minute verification timeout', async () => {
+  const wallet = Wallet.createRandom().address.toLowerCase();
+  const player = {
+    wallet,
+    totalGoldCoins: 0,
+    totalSilverCoins: 0,
+    save: async function save() { return this; }
+  };
+
+  Player.findOne = () => queryResult(player);
+
+  setDonationVerifierForTests(async () => ({
+    status: 'pending',
+    reason: 'receipt_not_found',
+    confirmations: 0
+  }));
+
+  const { server, baseUrl } = await startServer();
+
+  const createRes = await fetch(`${baseUrl}/api/store/donations/create-payment`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ wallet, productKey: 'basic_pack' })
+  });
+  const created = await createRes.json();
+
+  await fetch(`${baseUrl}/api/store/donations/submit-transaction`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ wallet, paymentId: created.paymentId, txHash: '0xtimeouthash' })
+  });
+
+  const paymentIndex = donationPayments.findIndex((item) => item.paymentId === created.paymentId);
+  donationPayments[paymentIndex] = {
+    ...donationPayments[paymentIndex],
+    submittedAt: new Date(Date.now() - (30 * 60 * 1000) - 1000),
+    expiresAt: new Date(Date.now() - 1000)
+  };
+
+  const paymentRes = await fetch(`${baseUrl}/api/store/donations/payment/${created.paymentId}?wallet=${wallet}`);
+  assert.equal(paymentRes.status, 200);
+  const payment = await paymentRes.json();
+  assert.equal(payment.status, 'failed');
+  assert.equal(payment.failureReason, 'merchant_confirmation_timeout');
+
+  await server.close();
+});
+
+test('GET /api/store/donations/payment/:paymentId does not double-credit on refresh', async () => {
+  const wallet = Wallet.createRandom().address.toLowerCase();
+  let saveCalls = 0;
+  const player = {
+    wallet,
+    totalGoldCoins: 10,
+    totalSilverCoins: 20,
+    save: async function save() {
+      saveCalls += 1;
+      return this;
+    }
+  };
+
+  Player.findOne = ({ wallet: requestedWallet }) => queryResult(requestedWallet === wallet ? player : null);
+
+  setDonationVerifierForTests(async () => ({
+    status: 'confirmed',
+    reason: 'confirmed',
+    confirmations: 2,
+    actualFrom: '0xsender',
+    actualTo: '0x244bcc2721f1037958862825c3feb6a7be6204a7',
+    actualAmount: '20000000000000000'
+  }));
+
+  const { server, baseUrl } = await startServer();
+
+  const createRes = await fetch(`${baseUrl}/api/store/donations/create-payment`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ wallet, productKey: 'starter_pack' })
+  });
+  const created = await createRes.json();
+
+  const submitRes = await fetch(`${baseUrl}/api/store/donations/submit-transaction`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ wallet, paymentId: created.paymentId, txHash: '0xrefreshhash' })
+  });
+  assert.equal(submitRes.status, 200);
+
+  const refreshRes = await fetch(`${baseUrl}/api/store/donations/payment/${created.paymentId}?wallet=${wallet}`);
+  assert.equal(refreshRes.status, 200);
+  const refreshed = await refreshRes.json();
+  assert.equal(refreshed.status, 'credited');
+  assert.equal(player.totalGoldCoins, 410);
+  assert.equal(player.totalSilverCoins, 420);
+  assert.equal(saveCalls, 1);
+
+  await server.close();
+});
 
 test('POST /api/store/donations/create-payment blocks second Starter Pack after successful credit', async () => {
   const wallet = Wallet.createRandom().address.toLowerCase();

--- a/utils/donationService.js
+++ b/utils/donationService.js
@@ -11,6 +11,10 @@ let verifierImpl = verifyDonationTransaction;
 const erc20TransferInterface = new ethers.utils.Interface([
   'function transfer(address to, uint256 value)'
 ]);
+const SUBMIT_TIMEOUT_MS = 30 * 60 * 1000;
+const INTERNAL_STATUS_AWAITING_TX = 'awaiting_tx';
+const RESPONSELESS_STATUSES = new Set([INTERNAL_STATUS_AWAITING_TX]);
+const FINAL_STATUSES = new Set(['credited', 'failed', 'expired']);
 
 function setDonationVerifierForTests(verifier) {
   verifierImpl = verifier || verifyDonationTransaction;
@@ -73,6 +77,23 @@ function buildDonationTxRequest(payment) {
   };
 }
 
+function getVerificationDeadline(payment) {
+  if (!payment?.submittedAt) {
+    return null;
+  }
+
+  return new Date(new Date(payment.submittedAt).getTime() + SUBMIT_TIMEOUT_MS);
+}
+
+function hasVerificationTimedOut(payment, now = new Date()) {
+  const deadline = getVerificationDeadline(payment);
+  return !!deadline && deadline <= now;
+}
+
+function getPublicStatus(status) {
+  return RESPONSELESS_STATUSES.has(status) ? null : status;
+}
+
 async function hasSuccessfulDonation(wallet, productKey) {
   const existing = await DonationPayment.findOne({
     wallet,
@@ -124,9 +145,14 @@ async function listDonationPayments(wallet, options = {}) {
     .sort({ createdAt: -1 })
     .limit(limit);
 
+  const refreshedPayments = [];
+  for (const payment of payments) {
+    refreshedPayments.push(await getDonationPayment(payment.paymentId, { wallet: normalizedWallet }));
+  }
+
   return {
     wallet: normalizedWallet,
-    payments: payments.map((payment) => serializeDonationPayment(payment, { includeTxRequest: false }))
+    payments: refreshedPayments.map((payment) => serializeDonationPayment(payment, { includeTxRequest: false }))
   };
 }
 
@@ -146,7 +172,6 @@ async function createDonationPayment(wallet, productKey) {
     throw err;
   }
 
-  const now = new Date();
   const payment = new DonationPayment({
     paymentId: crypto.randomUUID(),
     wallet: normalizedWallet,
@@ -161,23 +186,26 @@ async function createDonationPayment(wallet, productKey) {
       requiredConfirmations: config.requiredConfirmations,
       purchaseLimit: config.purchaseLimit
     },
-    status: 'created',
+    status: INTERNAL_STATUS_AWAITING_TX,
     network: config.network,
     tokenSymbol: config.currency,
     tokenContract: config.tokenContract,
     merchantWallet: config.merchantWallet,
     expectedAmount: config.price,
     expectedDecimals: config.tokenDecimals,
-    expiresAt: new Date(now.getTime() + (config.ttlMinutes * 60 * 1000))
+    expiresAt: null
   });
 
   await payment.save();
   return payment;
 }
 
-
 async function creditDonationPayment(payment) {
-  if (payment.status === 'credited') {
+  if (!payment) {
+    return null;
+  }
+
+  if (payment.status === 'credited' || payment.rewardGrantedAt) {
     return payment;
   }
 
@@ -189,20 +217,53 @@ async function creditDonationPayment(payment) {
     return payment;
   }
 
+  const rewardGrantedAt = new Date();
+  const rewardUpdate = await DonationPayment.findOneAndUpdate(
+    {
+      paymentId: payment.paymentId,
+      rewardGrantedAt: null,
+      status: { $in: ['confirmed', 'credited'] }
+    },
+    {
+      $set: {
+        status: 'credited',
+        rewardGrantedAt,
+        creditedAt: rewardGrantedAt,
+        confirmedAt: payment.confirmedAt || rewardGrantedAt,
+        failureReason: null
+      }
+    },
+    { new: true }
+  );
+
+  if (!rewardUpdate) {
+    return DonationPayment.findOne({ paymentId: payment.paymentId });
+  }
+
   const { gold = 0, silver = 0 } = payment.productSnapshot?.grant || {};
   player.totalGoldCoins += gold;
   player.totalSilverCoins += silver;
-  player.updatedAt = new Date();
-
+  player.updatedAt = rewardGrantedAt;
   await player.save();
 
-  payment.status = 'credited';
-  payment.creditedAt = new Date();
-  if (!payment.confirmedAt) {
-    payment.confirmedAt = new Date();
-  }
-  await payment.save();
+  payment.status = rewardUpdate.status;
+  payment.rewardGrantedAt = rewardUpdate.rewardGrantedAt;
+  payment.creditedAt = rewardUpdate.creditedAt;
+  payment.confirmedAt = rewardUpdate.confirmedAt;
+  payment.failureReason = rewardUpdate.failureReason;
 
+  return rewardUpdate;
+}
+
+async function finalizeExpiredPayment(payment) {
+  if (!payment || FINAL_STATUSES.has(payment.status) || !hasVerificationTimedOut(payment)) {
+    return payment;
+  }
+
+  payment.status = 'failed';
+  payment.failureReason = payment.failureReason || 'merchant_confirmation_timeout';
+  payment.expiresAt = getVerificationDeadline(payment);
+  await payment.save();
   return payment;
 }
 
@@ -211,7 +272,7 @@ async function recheckDonationPayment(payment) {
     return null;
   }
 
-  if (payment.status === 'credited' || payment.status === 'failed' || payment.status === 'expired') {
+  if (FINAL_STATUSES.has(payment.status)) {
     return payment;
   }
 
@@ -219,11 +280,8 @@ async function recheckDonationPayment(payment) {
     return payment;
   }
 
-  if (payment.expiresAt <= new Date()) {
-    payment.status = 'expired';
-    payment.failureReason = 'payment_expired';
-    await payment.save();
-    return payment;
+  if (hasVerificationTimedOut(payment)) {
+    return finalizeExpiredPayment(payment);
   }
 
   const verification = await verifierImpl({
@@ -240,16 +298,18 @@ async function recheckDonationPayment(payment) {
   payment.txTo = verification.actualTo || payment.txTo;
   payment.txAmount = verification.actualAmount || payment.txAmount;
 
-  if (verification.status === 'pending') {
-    payment.status = 'pending';
-    payment.failureReason = verification.reason || null;
+  if (verification.status === 'failed') {
+    payment.status = 'failed';
+    payment.failureReason = verification.reason || 'verification_failed';
+    payment.expiresAt = getVerificationDeadline(payment);
     await payment.save();
     return payment;
   }
 
-  if (verification.status === 'failed') {
-    payment.status = 'failed';
-    payment.failureReason = verification.reason || 'verification_failed';
+  if (verification.status === 'pending') {
+    payment.status = 'submitted';
+    payment.failureReason = null;
+    payment.expiresAt = getVerificationDeadline(payment);
     await payment.save();
     return payment;
   }
@@ -257,6 +317,7 @@ async function recheckDonationPayment(payment) {
   payment.status = 'confirmed';
   payment.failureReason = null;
   payment.confirmedAt = payment.confirmedAt || new Date();
+  payment.expiresAt = getVerificationDeadline(payment);
   await payment.save();
 
   return creditDonationPayment(payment);
@@ -285,10 +346,12 @@ async function submitDonationTransaction({ wallet, paymentId, txHash }) {
     throw err;
   }
 
-  if (payment.expiresAt <= new Date()) {
-    payment.status = 'expired';
-    payment.failureReason = 'payment_expired';
-    await payment.save();
+  if (FINAL_STATUSES.has(payment.status)) {
+    if (payment.txHash && payment.txHash !== normalizedHash) {
+      const err = new Error('Payment already finalized with another transaction hash');
+      err.statusCode = 409;
+      throw err;
+    }
     return payment;
   }
 
@@ -299,10 +362,19 @@ async function submitDonationTransaction({ wallet, paymentId, txHash }) {
     throw err;
   }
 
-  payment.txHash = normalizedHash;
-  payment.submittedAt = new Date();
+  if (payment.txHash && payment.txHash !== normalizedHash) {
+    const err = new Error('Payment already linked to a different transaction hash');
+    err.statusCode = 409;
+    throw err;
+  }
+
+  if (!payment.txHash) {
+    payment.txHash = normalizedHash;
+  }
+  payment.submittedAt = payment.submittedAt || new Date();
   payment.status = 'submitted';
   payment.failureReason = null;
+  payment.expiresAt = getVerificationDeadline(payment);
   await payment.save();
 
   return recheckDonationPayment(payment);
@@ -314,7 +386,7 @@ async function getDonationPayment(paymentId, options = {}) {
     return null;
   }
 
-    const normalizedWallet = options.wallet ? normalizeWallet(options.wallet) : null;
+  const normalizedWallet = options.wallet ? normalizeWallet(options.wallet) : null;
   const normalizedHash = typeof options.txHash === 'string' ? options.txHash.trim() : '';
 
   if (normalizedWallet && payment.wallet !== normalizedWallet) {
@@ -323,7 +395,7 @@ async function getDonationPayment(paymentId, options = {}) {
     throw err;
   }
 
-  if (normalizedHash && !payment.txHash && payment.status === 'created') {
+  if (normalizedHash && !payment.txHash) {
     const existingHash = await DonationPayment.findOne({ txHash: normalizedHash, paymentId: { $ne: paymentId } });
     if (existingHash) {
       const err = new Error('Transaction hash already used');
@@ -335,20 +407,15 @@ async function getDonationPayment(paymentId, options = {}) {
     payment.submittedAt = payment.submittedAt || new Date();
     payment.status = 'submitted';
     payment.failureReason = null;
+    payment.expiresAt = getVerificationDeadline(payment);
     await payment.save();
   }
 
-  if (payment.status === 'submitted' || payment.status === 'pending') {
+  if (payment.txHash && !FINAL_STATUSES.has(payment.status)) {
     return recheckDonationPayment(payment);
   }
 
-  if (payment.status === 'created' && payment.expiresAt <= new Date()) {
-    payment.status = 'expired';
-    payment.failureReason = 'payment_expired';
-    await payment.save();
-  }
-
-  return payment;
+  return finalizeExpiredPayment(payment);
 }
 
 function serializeDonationPayment(payment, options = {}) {
@@ -360,15 +427,16 @@ function serializeDonationPayment(payment, options = {}) {
   return {
     paymentId: payment.paymentId,
     wallet: payment.wallet,
-    status: payment.status,
+    status: getPublicStatus(payment.status),
     productKey: payment.productKey,
+    productTitle: payment.productSnapshot?.title || null,
     title: payment.productSnapshot?.title || null,
     amount: payment.expectedAmount,
     currency: payment.tokenSymbol,
     network: payment.network,
     tokenContract: payment.tokenContract,
     merchantWallet: payment.merchantWallet,
-    expiresAt: payment.expiresAt,
+    expiresAt: payment.expiresAt || getVerificationDeadline(payment),
     txHash: payment.txHash,
     confirmations: payment.confirmations,
     reward: payment.productSnapshot?.grant || { gold: 0, silver: 0 },


### PR DESCRIPTION
### Motivation
- Align backend donation/payment lifecycle with frontend expectations by removing the exposed `created` UI status and avoiding backend-driven `pending` UI states.
- Ensure idempotent reward crediting and enforce a 30-minute verification timeout so unconfirmed submissions resolve to a final negative status instead of lingering indefinitely.

### Description
- Updated the donation model to remove `created`, add an internal non-UI status `awaiting_tx` (used as the default) and a `rewardGrantedAt` timestamp to guard reward delivery (`models/DonationPayment.js`).
- Reworked `utils/donationService.js` to introduce internal constants (`SUBMIT_TIMEOUT_MS`, `INTERNAL_STATUS_AWAITING_TX`, `FINAL_STATUSES`), treat pre-submit records as responseless (`status` exposed as `null`), set `submitted` after tx submit, perform time-based finalization to `failed` after 30 minutes, and centralize recheck logic via `recheckDonationPayment`/`finalizeExpiredPayment`.
- Made crediting idempotent by using a guarded `findOneAndUpdate` that sets `rewardGrantedAt` when moving a `confirmed` record to `credited`, so repeated submit/refresh calls do not double-credit the player.
- Updated serialization and listing to refresh server-side status on history requests, expose `productTitle`, return only real server-side statuses (pre-submit shows `null`), and updated README to document the new behavior.

### Testing
- Ran the integration tests with `npm test` (donation-related integration coverage added/updated) and all tests passed.
- Ran syntax checks with `npm run check:syntax` and the check completed successfully.
- Added/updated unit/integration assertions around pre-submit `null` status, `submitted` in history, 30-minute timeout finalization, and refresh idempotency to validate the new flow.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bdc73d9e5c832ea0a6054c2ea43df2)