### PR TITLE
Fix donation verification, add diagnostics and background recheck

### DIFF
--- a/models/DonationPayment.js
+++ b/models/DonationPayment.js
@@ -81,6 +81,18 @@ const donationPaymentSchema = new mongoose.Schema({
     type: String,
     default: null
   },
+  verificationReason: {
+    type: String,
+    default: null
+  },
+  providerStatus: {
+    type: String,
+    default: null
+  },
+  lastVerificationAt: {
+    type: Date,
+    default: null
+  },
   expiresAt: {
     type: Date,
     default: null,

--- a/server.js
+++ b/server.js
@@ -3,6 +3,7 @@ const connectDB = require('./database');
 const { initBot } = require('./bot');
 const logger = require('./utils/logger');
 const { createApp } = require('./app');
+const { startDonationPaymentRecheckLoop } = require('./utils/donationService');
 
 const app = createApp();
 
@@ -11,6 +12,8 @@ const runBotInProcess = process.env.BOT_MODE !== 'worker' && process.env.START_B
 // Connect DB then optionally start bot in the same process
 connectDB()
   .then(() => {
+    startDonationPaymentRecheckLoop();
+
     if (!runBotInProcess) {
       logger.info('BOT_MODE=worker (or START_BOT_IN_PROCESS=false): skipping bot in API process');
       return;

--- a/tests/donation.verifier.test.js
+++ b/tests/donation.verifier.test.js
@@ -1,0 +1,243 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { ethers } = require('ethers');
+
+const { verifyDonationTransaction } = require('../utils/donationVerifier');
+const DonationPayment = require('../models/DonationPayment');
+const Player = require('../models/Player');
+const {
+  processPendingDonationPayments,
+  setDonationVerifierForTests,
+  resetDonationVerifier,
+  stopDonationPaymentRecheckLoop
+} = require('../utils/donationService');
+
+const transferInterface = new ethers.utils.Interface([
+  'event Transfer(address indexed from, address indexed to, uint256 value)'
+]);
+
+function buildTransferLog({ tokenContract, from, to, value }) {
+  const event = transferInterface.encodeEventLog(
+    transferInterface.getEvent('Transfer'),
+    [from, to, value]
+  );
+
+  return {
+    address: tokenContract,
+    topics: event.topics,
+    data: event.data
+  };
+}
+
+test.afterEach(() => {
+  resetDonationVerifier();
+  stopDonationPaymentRecheckLoop();
+});
+
+test('verifyDonationTransaction confirms exact recipient/amount match even if earlier log mismatches', async () => {
+  const tokenContract = '0x55d398326f99059ff775485246999027b3197955';
+  const merchantWallet = '0x244bcc2721f1037958862825c3feb6a7be6204a7';
+  const sender = '0x1111111111111111111111111111111111111111';
+  const otherRecipient = '0x2222222222222222222222222222222222222222';
+
+  const provider = {
+    async getTransactionReceipt() {
+      return {
+        status: 1,
+        blockNumber: 100,
+        logs: [
+          buildTransferLog({
+            tokenContract,
+            from: sender,
+            to: otherRecipient,
+            value: ethers.utils.parseUnits('0.02', 18)
+          }),
+          buildTransferLog({
+            tokenContract,
+            from: sender,
+            to: merchantWallet,
+            value: ethers.utils.parseUnits('0.02', 18)
+          })
+        ]
+      };
+    },
+    async getBlockNumber() {
+      return 101;
+    }
+  };
+
+  const result = await verifyDonationTransaction({
+    txHash: '0xabc',
+    expectedAmount: '0.02',
+    expectedDecimals: 18,
+    tokenContract,
+    merchantWallet,
+    requiredConfirmations: 1
+  }, provider);
+
+  assert.equal(result.status, 'confirmed');
+  assert.equal(result.reason, 'confirmed');
+  assert.equal(result.actualTo, merchantWallet);
+  assert.equal(result.actualAmount, ethers.utils.parseUnits('0.02', 18).toString());
+});
+
+test('verifyDonationTransaction returns detailed mismatch reason when no exact transfer match exists', async () => {
+  const tokenContract = '0x55d398326f99059ff775485246999027b3197955';
+  const merchantWallet = '0x244bcc2721f1037958862825c3feb6a7be6204a7';
+  const sender = '0x1111111111111111111111111111111111111111';
+
+  const provider = {
+    async getTransactionReceipt() {
+      return {
+        status: 1,
+        blockNumber: 100,
+        logs: [
+          buildTransferLog({
+            tokenContract,
+            from: sender,
+            to: merchantWallet,
+            value: ethers.utils.parseUnits('0.03', 18)
+          })
+        ]
+      };
+    },
+    async getBlockNumber() {
+      return 101;
+    }
+  };
+
+  const result = await verifyDonationTransaction({
+    txHash: '0xdef',
+    expectedAmount: '0.02',
+    expectedDecimals: 18,
+    tokenContract,
+    merchantWallet,
+    requiredConfirmations: 1
+  }, provider);
+
+  assert.equal(result.status, 'failed');
+  assert.equal(result.reason, 'amount_mismatch');
+  assert.equal(result.actualTo, merchantWallet);
+  assert.equal(result.actualAmount, ethers.utils.parseUnits('0.03', 18).toString());
+  assert.equal(result.candidateCount, 1);
+});
+
+test('processPendingDonationPayments credits submitted donation in background recheck without double credit', async () => {
+  const wallet = '0x3333333333333333333333333333333333333333';
+  const paymentId = 'payment-bg-1';
+  const now = new Date();
+  let playerSaveCalls = 0;
+
+  const player = {
+    wallet,
+    totalGoldCoins: 10,
+    totalSilverCoins: 20,
+    async save() {
+      playerSaveCalls += 1;
+      return this;
+    }
+  };
+
+  const paymentStore = [{
+    paymentId,
+    wallet,
+    productKey: 'starter_pack',
+    productSnapshot: {
+      title: 'Starter Pack',
+      grant: { gold: 400, silver: 400 },
+      requiredConfirmations: 1
+    },
+    status: 'submitted',
+    network: 'BSC',
+    tokenSymbol: 'USDT',
+    tokenContract: '0x55d398326f99059ff775485246999027b3197955',
+    merchantWallet: '0x244bcc2721f1037958862825c3feb6a7be6204a7',
+    expectedAmount: '0.02',
+    expectedDecimals: 18,
+    txHash: '0xbackgroundhash',
+    confirmations: 0,
+    createdAt: now,
+    updatedAt: now,
+    submittedAt: now,
+    rewardGrantedAt: null,
+    confirmedAt: null,
+    creditedAt: null,
+    failureReason: null,
+    verificationReason: null,
+    providerStatus: null,
+    async save() {
+      const index = paymentStore.findIndex((item) => item.paymentId === this.paymentId);
+      paymentStore[index] = { ...paymentStore[index], ...this, updatedAt: new Date(), save: this.save };
+      return this;
+    }
+  }];
+
+  const matchesQuery = (item, query = {}) => Object.entries(query).every(([key, value]) => {
+    if (value && typeof value === 'object' && !Array.isArray(value)) {
+      if ('$in' in value) {
+        return value.$in.includes(item[key]);
+      }
+      if ('$ne' in value) {
+        return item[key] !== value.$ne;
+      }
+    }
+    return item[key] === value;
+  });
+
+  DonationPayment.find = (query = {}) => {
+    let results = paymentStore.filter((item) => matchesQuery(item, query)).map((item) => ({ ...item }));
+    const chain = {
+      sort() {
+        return chain;
+      },
+      limit(limitValue) {
+        return Promise.resolve(results.slice(0, limitValue).map((item) => ({ ...item, save: paymentStore[0].save })));
+      }
+    };
+    return chain;
+  };
+
+  DonationPayment.findOneAndUpdate = async (query = {}, update = {}, options = {}) => {
+    const index = paymentStore.findIndex((item) => matchesQuery(item, query));
+    if (index < 0) {
+      return null;
+    }
+    paymentStore[index] = {
+      ...paymentStore[index],
+      ...(update.$set || {}),
+      updatedAt: new Date()
+    };
+    return options.new ? { ...paymentStore[index], save: paymentStore[0].save } : null;
+  };
+
+  DonationPayment.findOne = async (query = {}) => {
+    const match = paymentStore.find((item) => matchesQuery(item, query));
+    return match ? { ...match, save: paymentStore[0].save } : null;
+  };
+
+  Player.findOne = ({ wallet: requestedWallet }) => ({
+    then(resolve, reject) {
+      return Promise.resolve(requestedWallet === wallet ? player : null).then(resolve, reject);
+    }
+  });
+
+  setDonationVerifierForTests(async () => ({
+    status: 'confirmed',
+    reason: 'confirmed',
+    confirmations: 2,
+    actualFrom: '0xsender',
+    actualTo: paymentStore[0].merchantWallet,
+    actualAmount: ethers.utils.parseUnits('0.02', 18).toString(),
+    providerStatus: 'ok'
+  }));
+
+  const firstRun = await processPendingDonationPayments({ limit: 10 });
+  const secondRun = await processPendingDonationPayments({ limit: 10 });
+
+  assert.equal(firstRun.processed, 1);
+  assert.equal(secondRun.processed, 0);
+  assert.equal(paymentStore[0].status, 'credited');
+  assert.equal(player.totalGoldCoins, 410);
+  assert.equal(player.totalSilverCoins, 420);
+  assert.equal(playerSaveCalls, 1);
+});

--- a/utils/donationService.js
+++ b/utils/donationService.js
@@ -6,6 +6,7 @@ const DonationPayment = require('../models/DonationPayment');
 const { DONATIONS_CONFIG, DONATIONS_PRICE_MODE, getDonationConfig } = require('./donationsConfig');
 const { normalizeWallet } = require('./security');
 const { verifyDonationTransaction } = require('./donationVerifier');
+const logger = require('./logger');
 
 let verifierImpl = verifyDonationTransaction;
 const erc20TransferInterface = new ethers.utils.Interface([
@@ -15,6 +16,10 @@ const SUBMIT_TIMEOUT_MS = 30 * 60 * 1000;
 const INTERNAL_STATUS_AWAITING_TX = 'awaiting_tx';
 const RESPONSELESS_STATUSES = new Set([INTERNAL_STATUS_AWAITING_TX]);
 const FINAL_STATUSES = new Set(['credited', 'failed', 'expired']);
+const DEFAULT_BSC_PUBLIC_RPC_URL = 'https://bsc-dataseed.binance.org/';
+const DONATION_RECHECK_INTERVAL_MS = Math.max(15 * 1000, Number(process.env.DONATIONS_RECHECK_INTERVAL_MS || 60 * 1000));
+const DONATION_RECHECK_BATCH_SIZE = Math.max(1, Number(process.env.DONATIONS_RECHECK_BATCH_SIZE || 25));
+let donationRecheckTimer = null;
 
 function setDonationVerifierForTests(verifier) {
   verifierImpl = verifier || verifyDonationTransaction;
@@ -25,12 +30,27 @@ function resetDonationVerifier() {
 }
 
 function getProvider() {
-  const rpcUrl = process.env.BSC_RPC_URL || process.env.DONATIONS_RPC_URL;
-  if (!rpcUrl) {
-    return null;
-  }
+  const configuredRpcUrl = process.env.BSC_RPC_URL || process.env.DONATIONS_RPC_URL;
+  const rpcUrl = configuredRpcUrl || DEFAULT_BSC_PUBLIC_RPC_URL;
 
-  return new ethers.providers.JsonRpcProvider(rpcUrl);
+  try {
+    const provider = new ethers.providers.JsonRpcProvider(rpcUrl);
+    return {
+      provider,
+      status: configuredRpcUrl ? 'configured' : 'fallback_public_rpc',
+      rpcUrl,
+      configuredRpcUrl: configuredRpcUrl || null
+    };
+  } catch (error) {
+    logger.error({ err: error, rpcUrl }, 'Failed to initialize donation RPC provider');
+    return {
+      provider: null,
+      status: configuredRpcUrl ? 'configured_error' : 'fallback_public_rpc_error',
+      rpcUrl,
+      configuredRpcUrl: configuredRpcUrl || null,
+      errorMessage: error.message
+    };
+  }
 }
 
 function buildProductView(config, alreadyPurchased) {
@@ -284,6 +304,8 @@ async function recheckDonationPayment(payment) {
     return finalizeExpiredPayment(payment);
   }
 
+  const providerState = getProvider();
+  const verificationStartedAt = new Date();
   const verification = await verifierImpl({
     txHash: payment.txHash,
     expectedAmount: payment.expectedAmount,
@@ -291,12 +313,36 @@ async function recheckDonationPayment(payment) {
     tokenContract: payment.tokenContract,
     merchantWallet: payment.merchantWallet,
     requiredConfirmations: payment.productSnapshot?.requiredConfirmations || 1
-  }, getProvider());
+  }, providerState?.provider || null);
 
   payment.confirmations = verification.confirmations || 0;
   payment.txFrom = verification.actualFrom || payment.txFrom;
   payment.txTo = verification.actualTo || payment.txTo;
   payment.txAmount = verification.actualAmount || payment.txAmount;
+  payment.providerStatus = verification.providerStatus || providerState?.status || 'unknown';
+  payment.verificationReason = verification.reason || null;
+  payment.lastVerificationAt = verificationStartedAt;
+
+  logger.info({
+    paymentId: payment.paymentId,
+    wallet: payment.wallet,
+    txHash: payment.txHash,
+    tokenContract: payment.tokenContract,
+    merchantWallet: payment.merchantWallet,
+    expectedAmount: payment.expectedAmount,
+    expectedDecimals: payment.expectedDecimals,
+    verificationStatus: verification.status,
+    verificationReason: verification.reason,
+    actualFrom: verification.actualFrom || null,
+    actualTo: verification.actualTo || null,
+    actualAmount: verification.actualAmount || null,
+    confirmations: verification.confirmations || 0,
+    providerAvailability: Boolean(providerState?.provider),
+    providerStatus: verification.providerStatus || providerState?.status || 'unknown',
+    providerRpcUrl: providerState?.rpcUrl || null,
+    providerConfiguredRpcUrl: providerState?.configuredRpcUrl || null,
+    providerErrorMessage: verification.errorMessage || providerState?.errorMessage || null
+  }, 'Donation payment verification result');
 
   if (verification.status === 'failed') {
     payment.status = 'failed';
@@ -441,6 +487,12 @@ function serializeDonationPayment(payment, options = {}) {
     confirmations: payment.confirmations,
     reward: payment.productSnapshot?.grant || { gold: 0, silver: 0 },
     failureReason: payment.failureReason,
+    verificationReason: payment.verificationReason || payment.failureReason || null,
+    lastVerificationAt: payment.lastVerificationAt || null,
+    providerStatus: payment.providerStatus || null,
+    txFrom: payment.txFrom || null,
+    txTo: payment.txTo || null,
+    txAmount: payment.txAmount || null,
     createdAt: payment.createdAt || null,
     updatedAt: payment.updatedAt || null,
     submittedAt: payment.submittedAt || null,
@@ -450,6 +502,63 @@ function serializeDonationPayment(payment, options = {}) {
   };
 }
 
+async function processPendingDonationPayments(options = {}) {
+  const limit = Math.max(1, Number(options.limit) || DONATION_RECHECK_BATCH_SIZE);
+  const candidates = await DonationPayment.find({
+    status: { $in: ['submitted', 'confirmed'] },
+    txHash: { $ne: null }
+  })
+    .sort({ updatedAt: 1 })
+    .limit(limit);
+
+  let processed = 0;
+  for (const payment of candidates) {
+    if (!payment?.txHash || FINAL_STATUSES.has(payment.status)) {
+      continue;
+    }
+    await recheckDonationPayment(payment);
+    processed += 1;
+  }
+
+  if (processed > 0) {
+    logger.info({ processed }, 'Processed pending donation payment recheck batch');
+  }
+
+  return { processed };
+}
+
+function startDonationPaymentRecheckLoop() {
+  if (donationRecheckTimer) {
+    return donationRecheckTimer;
+  }
+
+  donationRecheckTimer = setInterval(() => {
+    processPendingDonationPayments().catch((error) => {
+      logger.error({ err: error }, 'Donation payment background recheck failed');
+    });
+  }, DONATION_RECHECK_INTERVAL_MS);
+
+  if (typeof donationRecheckTimer.unref === 'function') {
+    donationRecheckTimer.unref();
+  }
+
+  logger.info({
+    intervalMs: DONATION_RECHECK_INTERVAL_MS,
+    batchSize: DONATION_RECHECK_BATCH_SIZE
+  }, 'Donation payment background recheck loop started');
+
+  return donationRecheckTimer;
+}
+
+function stopDonationPaymentRecheckLoop() {
+  if (!donationRecheckTimer) {
+    return;
+  }
+
+  clearInterval(donationRecheckTimer);
+  donationRecheckTimer = null;
+}
+
 module.exports = {
   listDonationProducts,
   listDonationPayments,
@@ -457,6 +566,9 @@ module.exports = {
   submitDonationTransaction,
   getDonationPayment,
   serializeDonationPayment,
+  processPendingDonationPayments,
+  startDonationPaymentRecheckLoop,
+  stopDonationPaymentRecheckLoop,
   setDonationVerifierForTests,
   resetDonationVerifier
 };

--- a/utils/donationVerifier.js
+++ b/utils/donationVerifier.js
@@ -9,6 +9,14 @@ function normalizeAddress(value) {
   return typeof value === 'string' ? value.toLowerCase() : null;
 }
 
+function buildCandidate(decoded) {
+  return {
+    actualTo: normalizeAddress(decoded.args.to),
+    actualFrom: normalizeAddress(decoded.args.from),
+    actualAmount: decoded.args.value.toString()
+  };
+}
+
 async function verifyDonationTransaction({
   txHash,
   expectedAmount,
@@ -18,61 +26,92 @@ async function verifyDonationTransaction({
   requiredConfirmations = 1
 }, provider) {
   if (!provider) {
-    return { status: 'failed', reason: 'provider_unavailable' };
+    return {
+      status: 'pending',
+      reason: 'provider_unavailable',
+      providerStatus: 'unavailable'
+    };
   }
 
-  const receipt = await provider.getTransactionReceipt(txHash);
+  let receipt;
+  try {
+    receipt = await provider.getTransactionReceipt(txHash);
+  } catch (error) {
+    return {
+      status: 'pending',
+      reason: 'provider_error',
+      providerStatus: 'error',
+      errorMessage: error.message
+    };
+  }
+
   if (!receipt) {
-    return { status: 'pending', reason: 'receipt_not_found' };
+    return { status: 'pending', reason: 'receipt_not_found', providerStatus: 'ok' };
   }
 
   if (receipt.status !== 1) {
-    return { status: 'failed', reason: 'transaction_failed' };
+    return { status: 'failed', reason: 'transaction_failed', providerStatus: 'ok' };
   }
 
-  const currentBlock = await provider.getBlockNumber();
+  let currentBlock;
+  try {
+    currentBlock = await provider.getBlockNumber();
+  } catch (error) {
+    return {
+      status: 'pending',
+      reason: 'provider_error',
+      providerStatus: 'error',
+      errorMessage: error.message
+    };
+  }
+
   const confirmations = typeof receipt.confirmations === 'number'
     ? receipt.confirmations
     : Math.max(0, currentBlock - receipt.blockNumber + 1);
 
   const targetContract = normalizeAddress(tokenContract);
   const targetWallet = normalizeAddress(merchantWallet);
+  const expectedAmountRaw = ethers.utils.parseUnits(String(expectedAmount), expectedDecimals).toString();
 
-  const transferLog = receipt.logs.find((log) =>
+  const transferLogs = receipt.logs.filter((log) =>
     normalizeAddress(log.address) === targetContract &&
     Array.isArray(log.topics) &&
     log.topics[0] === ERC20_TRANSFER_TOPIC
   );
 
-  if (!transferLog) {
-    return { status: 'failed', reason: 'transfer_log_not_found', confirmations };
-  }
-
-  const decoded = ERC20_TRANSFER_IFACE.parseLog(transferLog);
-  const actualTo = normalizeAddress(decoded.args.to);
-  const actualFrom = normalizeAddress(decoded.args.from);
-  const actualAmountRaw = decoded.args.value.toString();
-  const expectedAmountRaw = ethers.utils.parseUnits(String(expectedAmount), expectedDecimals).toString();
-
-  if (actualTo !== targetWallet) {
+  if (!transferLogs.length) {
     return {
       status: 'failed',
-      reason: 'recipient_mismatch',
+      reason: 'transfer_log_not_found',
       confirmations,
-      actualTo,
-      actualFrom,
-      actualAmount: actualAmountRaw
+      providerStatus: 'ok'
     };
   }
 
-  if (actualAmountRaw !== expectedAmountRaw) {
+  const decodedCandidates = transferLogs.map((log) => {
+    const decoded = ERC20_TRANSFER_IFACE.parseLog(log);
+    return buildCandidate(decoded);
+  });
+  const exactMatch = decodedCandidates.find((candidate) =>
+    candidate.actualTo === targetWallet &&
+    candidate.actualAmount === expectedAmountRaw
+  );
+
+  if (!exactMatch) {
+    const recipientMatch = decodedCandidates.find((candidate) => candidate.actualTo === targetWallet);
+    const amountMatch = decodedCandidates.find((candidate) => candidate.actualAmount === expectedAmountRaw);
+    const mismatchCandidate = recipientMatch || amountMatch || decodedCandidates[0];
+
     return {
       status: 'failed',
-      reason: 'amount_mismatch',
+      reason: recipientMatch ? 'amount_mismatch' : amountMatch ? 'recipient_mismatch' : 'transfer_match_not_found',
       confirmations,
-      actualTo,
-      actualFrom,
-      actualAmount: actualAmountRaw
+      providerStatus: 'ok',
+      actualTo: mismatchCandidate?.actualTo || null,
+      actualFrom: mismatchCandidate?.actualFrom || null,
+      actualAmount: mismatchCandidate?.actualAmount || null,
+      expectedAmount: expectedAmountRaw,
+      candidateCount: decodedCandidates.length
     };
   }
 
@@ -81,9 +120,10 @@ async function verifyDonationTransaction({
       status: 'pending',
       reason: 'awaiting_confirmations',
       confirmations,
-      actualTo,
-      actualFrom,
-      actualAmount: actualAmountRaw
+      providerStatus: 'ok',
+      actualTo: exactMatch.actualTo,
+      actualFrom: exactMatch.actualFrom,
+      actualAmount: exactMatch.actualAmount
     };
   }
 
@@ -91,9 +131,10 @@ async function verifyDonationTransaction({
     status: 'confirmed',
     reason: 'confirmed',
     confirmations,
-    actualTo,
-    actualFrom,
-    actualAmount: actualAmountRaw
+    providerStatus: 'ok',
+    actualTo: exactMatch.actualTo,
+    actualFrom: exactMatch.actualFrom,
+    actualAmount: exactMatch.actualAmount
   };
 }
 


### PR DESCRIPTION
### Motivation
- The verifier could pick the wrong `Transfer` log (it used the first matching log), causing real USDT/BSC transfers to not be confirmed and payments to remain uncredited. 
- Provider/RPC failures and lack of a background recheck made diagnosis and recovery difficult and left payments stuck until manual refresh.

### Description
- Update `utils/donationVerifier.js` to scan all ERC20 `Transfer` logs for the token contract, decode candidates, and require an exact match of `recipient == merchantWallet` and `amount == expectedAmount`; return detailed mismatch diagnostics when no exact match is found. 
- Add provider diagnostics and resilient RPC fallback in `utils/donationService.js` (uses `BSC_RPC_URL`/`DONATIONS_RPC_URL` if set, otherwise falls back to the public `https://bsc-dataseed.binance.org/`) and propagate `providerStatus`/`errorMessage`. 
- Add detailed logging in `recheckDonationPayment()` (includes `paymentId`, `wallet`, `txHash`, `tokenContract`, `merchantWallet`, expected amounts/decimals, `verification.status`/`reason`, actual tx fields, confirmations, and provider info). 
- Add safe background recheck loop (`processPendingDonationPayments()`, `startDonationPaymentRecheckLoop()`, `stopDonationPaymentRecheckLoop()`), start loop after DB connect in `server.js`, and keep `creditDonationPayment()` idempotent via existing `findOneAndUpdate` guard. 
- Extend persistence and API: add `verificationReason`, `providerStatus`, and `lastVerificationAt` to `models/DonationPayment.js` and expose `verificationReason`, `lastVerificationAt`, `providerStatus`, `txFrom`, `txTo`, `txAmount` in `serializeDonationPayment()` while remaining backwards-compatible. 
- Add tests in `tests/donation.verifier.test.js` covering: correct candidate selection when earlier logs mismatch, detailed mismatch reporting, and idempotent background crediting.

### Testing
- Ran `npm test` (node --test on `tests/*.test.js`) and all tests passed (`25` tests, `0` failures). 
- Ran `npm run check:syntax` and syntax check passed for project files.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bdd7856340832e806ad57dc4b8fd83)