### PR TITLE
Fix Telegram Stars donation error handling and normalize donation history serialization

### DIFF
--- a/routes/donations.js
+++ b/routes/donations.js
@@ -57,8 +57,12 @@ router.post('/donations/stars/create', writeLimiter, async (req, res) => {
       invoiceUrl
     });
   } catch (error) {
-    logger.error({ err: error }, 'POST /donations/stars/create error');
-    res.status(error.statusCode || 500).json({ error: error.message || 'Server error' });
+    logger.error({ err: error, code: error.code, details: error.details || null }, 'POST /donations/stars/create error');
+    res.status(error.statusCode || 500).json({
+      error: error.message || 'Server error',
+      code: error.code || 'server_error',
+      ...(error.details ? { details: error.details } : {})
+    });
   }
 });
 

--- a/tests/api.integration.test.js
+++ b/tests/api.integration.test.js
@@ -513,8 +513,21 @@ test('GET /api/store/donations/history/:wallet returns payments sorted by newest
   assert.equal(history.payments.length, 2);
   assert.equal(history.payments[0].paymentId, secondPayment.paymentId);
   assert.equal(history.payments[0].status, 'submitted');
+  assert.equal(history.payments[0].paymentMethod, 'crypto');
+  assert.equal(history.payments[0].paymentProvider, 'wallet');
+  assert.equal(history.payments[0].paymentCategory, 'crypto');
   assert.equal(history.payments[0].title, 'Basic Pack');
   assert.equal(history.payments[0].amount, '0.09');
+  assert.equal(history.payments[0].amountValue, '0.09');
+  assert.equal(history.payments[0].currency, 'USDT');
+  assert.deepEqual(history.payments[0].payment, {
+    method: 'crypto',
+    provider: 'wallet',
+    category: 'crypto',
+    amount: '0.09',
+    amountValue: '0.09',
+    currency: 'USDT'
+  });
   assert.equal(history.payments[0].txRequest, null);
   assert.ok(history.payments[0].createdAt);
   assert.equal(history.payments[1].paymentId, firstPayment.paymentId);
@@ -751,6 +764,55 @@ test('POST /api/donations/stars/create creates Telegram Stars order and returns 
   await server.close();
 });
 
+test('POST /api/donations/stars/create returns controlled 503 for Telegram bot token misconfiguration', async () => {
+  process.env.TELEGRAM_BOT_TOKEN = 'bad-token';
+  const { server, baseUrl } = await startServer();
+  const initData = buildTelegramInitData({ id: 777002, first_name: 'Broken' }, 'bad-token');
+
+  const res = await fetch(`${baseUrl}/api/donations/stars/create`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ productKey: 'basic_pack', telegramInitData: initData })
+  });
+
+  assert.equal(res.status, 503);
+  const body = await res.json();
+  assert.equal(body.code, 'telegram_stars_invalid_bot_token');
+  assert.match(body.error, /TELEGRAM_BOT_TOKEN format is invalid/i);
+
+  await server.close();
+});
+
+test('POST /api/donations/stars/create returns Telegram setup errors instead of opaque 502 body', async () => {
+  process.env.TELEGRAM_BOT_TOKEN = '123456:stars-token';
+  setTelegramStarsClientForTests({
+    async createInvoiceLink() {
+      const error = new Error('Telegram Stars invoice creation failed: Bad Request: STARS_INVOICE_INVALID');
+      error.statusCode = 502;
+      error.code = 'telegram_stars_upstream_rejected';
+      error.details = { operation: 'createInvoiceLink', responseStatus: 400, description: 'Bad Request: STARS_INVOICE_INVALID' };
+      throw error;
+    },
+    async answerPreCheckoutQuery() { return true; }
+  });
+
+  const { server, baseUrl } = await startServer();
+  const initData = buildTelegramInitData({ id: 777003, first_name: 'Upstream' }, process.env.TELEGRAM_BOT_TOKEN);
+
+  const res = await fetch(`${baseUrl}/api/donations/stars/create`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ productKey: 'basic_pack', telegramInitData: initData })
+  });
+
+  assert.equal(res.status, 502);
+  const body = await res.json();
+  assert.equal(body.code, 'telegram_stars_upstream_rejected');
+  assert.equal(body.details.description, 'Bad Request: STARS_INVOICE_INVALID');
+
+  await server.close();
+});
+
 test('POST /api/telegram/webhook processes successful_payment idempotently', async () => {
   process.env.TELEGRAM_BOT_TOKEN = '123456:stars-token';
   const { server, baseUrl } = await startServer();
@@ -807,9 +869,21 @@ test('POST /api/telegram/webhook processes successful_payment idempotently', asy
   assert.equal(historyRes.status, 200);
   const history = await historyRes.json();
   assert.equal(history.payments[0].paymentMethod, 'telegram_stars');
+  assert.equal(history.payments[0].paymentProvider, 'telegram');
+  assert.equal(history.payments[0].paymentCategory, 'stars');
   assert.equal(history.payments[0].status, 'paid');
   assert.equal(history.payments[0].starsAmount, 2);
+  assert.equal(history.payments[0].amount, 2);
+  assert.equal(history.payments[0].amountValue, '2');
   assert.equal(history.payments[0].currency, 'XTR');
+  assert.deepEqual(history.payments[0].payment, {
+    method: 'telegram_stars',
+    provider: 'telegram',
+    category: 'stars',
+    amount: 2,
+    amountValue: '2',
+    currency: 'XTR'
+  });
 
   await server.close();
 });

--- a/utils/donationService.js
+++ b/utils/donationService.js
@@ -9,7 +9,7 @@ const { normalizeWallet } = require('./security');
 const { verifyDonationTransaction } = require('./donationVerifier');
 const logger = require('./logger');
 const { getOrCreateTelegramAccount } = require('./accountManager');
-const { createTelegramStarsInvoiceLink, answerTelegramPreCheckoutQuery } = require('./telegramStarsService');
+const { createTelegramStarsInvoiceLink, answerTelegramPreCheckoutQuery, getTelegramBotToken, createTelegramStarsError } = require('./telegramStarsService');
 
 let verifierImpl = verifyDonationTransaction;
 const erc20TransferInterface = new ethers.utils.Interface([
@@ -239,6 +239,8 @@ function buildStarsInvoicePayload({ payment, telegramUserId, config }) {
 }
 
 async function createTelegramStarsPayment({ telegramUserId, productKey }) {
+  getTelegramBotToken();
+
   const tgId = String(telegramUserId || '').trim();
   const config = getDonationConfig(productKey);
 
@@ -246,6 +248,14 @@ async function createTelegramStarsPayment({ telegramUserId, productKey }) {
     const err = new Error(!tgId ? 'Missing Telegram user id' : 'Unknown donation product');
     err.statusCode = 400;
     throw err;
+  }
+
+  if (!Number.isInteger(config.starsAmount) || config.starsAmount <= 0) {
+    throw createTelegramStarsError(`Telegram Stars product configuration is invalid for ${config.key}.`, {
+      statusCode: 500,
+      code: 'telegram_stars_invalid_product_config',
+      details: { productKey: config.key, starsAmount: config.starsAmount }
+    });
   }
 
   const account = await getOrCreateTelegramAccount(tgId);
@@ -547,21 +557,35 @@ function serializeDonationPayment(payment, options = {}) {
   }
   const includeTxRequest = options.includeTxRequest !== false;
   const isStars = payment.paymentMethod === 'telegram_stars';
+  const normalizedPaymentMethod = payment.paymentMethod || 'crypto';
+  const amount = isStars ? (payment.starsAmount ?? payment.productSnapshot?.starsAmount ?? null) : payment.expectedAmount;
+  const currency = isStars ? 'XTR' : (payment.currency || payment.tokenSymbol || payment.productSnapshot?.currency || null);
 
   return {
     paymentId: payment.paymentId,
     orderId: payment.paymentId,
     wallet: payment.wallet,
-    paymentMethod: payment.paymentMethod || 'crypto',
+    paymentMethod: normalizedPaymentMethod,
+    paymentProvider: isStars ? 'telegram' : 'wallet',
+    paymentCategory: isStars ? 'stars' : 'crypto',
     telegramUserId: payment.telegramUserId || null,
     status: getPublicStatus(payment.status),
     productKey: payment.productKey,
     productTitle: payment.productSnapshot?.title || null,
     title: payment.productSnapshot?.title || null,
-    amount: isStars ? (payment.starsAmount ?? null) : payment.expectedAmount,
+    amount,
+    amountValue: amount == null ? null : String(amount),
     cryptoAmount: isStars ? null : payment.expectedAmount,
     starsAmount: payment.starsAmount ?? payment.productSnapshot?.starsAmount ?? null,
-    currency: isStars ? 'XTR' : payment.tokenSymbol,
+    currency,
+    payment: {
+      method: normalizedPaymentMethod,
+      provider: isStars ? 'telegram' : 'wallet',
+      category: isStars ? 'stars' : 'crypto',
+      amount,
+      amountValue: amount == null ? null : String(amount),
+      currency
+    },
     network: payment.network,
     tokenContract: payment.tokenContract,
     merchantWallet: payment.merchantWallet,

--- a/utils/telegramStarsService.js
+++ b/utils/telegramStarsService.js
@@ -1,55 +1,144 @@
 const logger = require('./logger');
 
-let telegramStarsClient = {
-  async createInvoiceLink(payload) {
-    const token = process.env.TELEGRAM_BOT_TOKEN;
-    if (!token) {
-      const error = new Error('Telegram bot token is not configured');
-      error.statusCode = 500;
-      throw error;
+function createTelegramStarsError(message, options = {}) {
+  const error = new Error(message);
+  error.statusCode = options.statusCode || 500;
+  error.code = options.code || 'telegram_stars_error';
+  error.details = options.details || null;
+  error.expose = options.expose !== false;
+  return error;
+}
+
+function getTelegramBotToken() {
+  const token = String(process.env.TELEGRAM_BOT_TOKEN || '').trim();
+  if (!token) {
+    throw createTelegramStarsError('Telegram Stars payments are not configured: TELEGRAM_BOT_TOKEN is missing.', {
+      statusCode: 503,
+      code: 'telegram_stars_not_configured'
+    });
+  }
+
+  if (!/^\d{3,}:[A-Za-z0-9_-]{5,}$/.test(token)) {
+    throw createTelegramStarsError('Telegram Stars payments are not configured correctly: TELEGRAM_BOT_TOKEN format is invalid.', {
+      statusCode: 503,
+      code: 'telegram_stars_invalid_bot_token'
+    });
+  }
+
+  return token;
+}
+
+function classifyTelegramApiError(responseStatus, description, operation) {
+  const normalized = String(description || '').toLowerCase();
+  const details = {
+    operation,
+    responseStatus: responseStatus || null,
+    description: description || null
+  };
+
+  if (responseStatus === 401 || normalized.includes('unauthorized') || normalized.includes('bot token')) {
+    return createTelegramStarsError('Telegram Stars payments are unavailable: the bot token is invalid or rejected by Telegram.', {
+      statusCode: 503,
+      code: 'telegram_stars_invalid_bot_token',
+      details
+    });
+  }
+
+  if (
+    normalized.includes('payment')
+    || normalized.includes('invoice')
+    || normalized.includes('provider')
+    || normalized.includes('currency')
+    || normalized.includes('xtr')
+    || normalized.includes('stars')
+  ) {
+    return createTelegramStarsError(`Telegram Stars invoice creation failed: ${description || 'Telegram rejected the invoice request.'}`, {
+      statusCode: 502,
+      code: 'telegram_stars_upstream_rejected',
+      details
+    });
+  }
+
+  return createTelegramStarsError(`Telegram API request failed during ${operation}: ${description || 'Unknown Telegram error.'}`, {
+    statusCode: 502,
+    code: 'telegram_api_error',
+    details
+  });
+}
+
+async function parseTelegramResponse(response, operation) {
+  const contentType = response.headers.get('content-type') || '';
+
+  try {
+    if (contentType.includes('application/json')) {
+      return await response.json();
     }
 
-    const response = await fetch(`https://api.telegram.org/bot${token}/createInvoiceLink`, {
-      method: 'POST',
-      headers: { 'content-type': 'application/json' },
-      body: JSON.stringify(payload)
+    const text = await response.text();
+    return { ok: false, description: text || `Telegram returned non-JSON response for ${operation}` };
+  } catch (error) {
+    logger.error({ err: error, operation }, 'Failed to parse Telegram Bot API response');
+    throw createTelegramStarsError(`Telegram API returned an unreadable response during ${operation}.`, {
+      statusCode: 502,
+      code: 'telegram_api_invalid_response'
     });
+  }
+}
 
-    const data = await response.json();
+let telegramStarsClient = {
+  async createInvoiceLink(payload) {
+    const token = getTelegramBotToken();
+
+    let response;
+    try {
+      response = await fetch(`https://api.telegram.org/bot${token}/createInvoiceLink`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(payload)
+      });
+    } catch (error) {
+      logger.error({ err: error }, 'Telegram createInvoiceLink network failure');
+      throw createTelegramStarsError('Telegram Stars invoice service is temporarily unavailable.', {
+        statusCode: 502,
+        code: 'telegram_stars_network_error'
+      });
+    }
+
+    const data = await parseTelegramResponse(response, 'createInvoiceLink');
     if (!response.ok || !data.ok || !data.result) {
-      logger.error({ status: response.status, response: data }, 'Telegram createInvoiceLink failed');
-      const error = new Error(data.description || 'Failed to create Telegram invoice link');
-      error.statusCode = 502;
-      throw error;
+      logger.error({ status: response.status, response: data, payload }, 'Telegram createInvoiceLink failed');
+      throw classifyTelegramApiError(response.status, data.description, 'createInvoiceLink');
     }
 
     return data.result;
   },
 
   async answerPreCheckoutQuery(preCheckoutQueryId, ok, errorMessage = undefined) {
-    const token = process.env.TELEGRAM_BOT_TOKEN;
-    if (!token) {
-      const error = new Error('Telegram bot token is not configured');
-      error.statusCode = 500;
-      throw error;
+    const token = getTelegramBotToken();
+
+    let response;
+    try {
+      response = await fetch(`https://api.telegram.org/bot${token}/answerPreCheckoutQuery`, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          pre_checkout_query_id: preCheckoutQueryId,
+          ok,
+          ...(ok ? {} : { error_message: errorMessage || 'Payment validation failed' })
+        })
+      });
+    } catch (error) {
+      logger.error({ err: error, preCheckoutQueryId, ok }, 'Telegram answerPreCheckoutQuery network failure');
+      throw createTelegramStarsError('Telegram payment validation service is temporarily unavailable.', {
+        statusCode: 502,
+        code: 'telegram_stars_network_error'
+      });
     }
 
-    const response = await fetch(`https://api.telegram.org/bot${token}/answerPreCheckoutQuery`, {
-      method: 'POST',
-      headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({
-        pre_checkout_query_id: preCheckoutQueryId,
-        ok,
-        ...(ok ? {} : { error_message: errorMessage || 'Payment validation failed' })
-      })
-    });
-
-    const data = await response.json();
+    const data = await parseTelegramResponse(response, 'answerPreCheckoutQuery');
     if (!response.ok || !data.ok) {
       logger.error({ status: response.status, response: data, preCheckoutQueryId, ok }, 'Telegram answerPreCheckoutQuery failed');
-      const error = new Error(data.description || 'Failed to answer Telegram pre-checkout query');
-      error.statusCode = 502;
-      throw error;
+      throw classifyTelegramApiError(response.status, data.description, 'answerPreCheckoutQuery');
     }
 
     return true;
@@ -76,5 +165,7 @@ module.exports = {
   createTelegramStarsInvoiceLink,
   answerTelegramPreCheckoutQuery,
   setTelegramStarsClientForTests,
-  resetTelegramStarsClient
+  resetTelegramStarsClient,
+  getTelegramBotToken,
+  createTelegramStarsError
 };


### PR DESCRIPTION
### Motivation
- The `POST /api/donations/stars/create` flow returned opaque 502 errors when Telegram invoice creation failed, making bot-token or Telegram-setup problems indistinguishable from transient upstream failures. 
- The Telegram client needed production-safe preflight checks and clearer classification of network/upstream/config errors so frontend and ops can react correctly. 
- Donation history responses were inconsistent between Stars and crypto flows, so the API needed a stable, normalized shape for `paymentMethod`/amount/currency data.

### Description
- Added production-safe Telegram preflight validation and error classification in `utils/telegramStarsService.js`, with structured errors (`statusCode`, `code`, `details`) for missing/invalid `TELEGRAM_BOT_TOKEN`, network failures, invalid Telegram responses, and upstream invoice rejections. 
- Made `createTelegramStarsPayment` validate Telegram setup and product config early (`getTelegramBotToken()` + product `starsAmount` check) and left the payment persisted with `paymentMethod: 'telegram_stars'` while handling invoice-link creation errors cleanly. 
- Normalized donation serialization in `utils/donationService.js` by adding `paymentProvider`, `paymentCategory`, `amountValue`, and a nested `payment` object while preserving existing fields (`paymentMethod`, `amount`, `starsAmount`, `currency`) so `history` API returns explicit provider/category and correct amount/currency for both Stars and crypto. 
- Returned structured error payloads from the route `POST /api/donations/stars/create` (`routes/donations.js`) including `code` and optional `details` so the frontend receives actionable failure reasons. 
- Added/updated integration tests in `tests/api.integration.test.js` to cover successful Stars order creation, controlled 503 for bad bot token, controlled 502 for upstream Telegram rejection, webhook idempotency, and normalized history assertions.

### Testing
- Ran the integration test suite with `npm test` and all tests passed (TAP output showed tests completed successfully). 
- Ran `npm run check:syntax` and the syntax check passed without errors. 
- Files changed and endpoints exercised in tests: `utils/telegramStarsService.js`, `utils/donationService.js`, `routes/donations.js`, and `tests/api.integration.test.js`; endpoints changed: `POST /api/donations/stars/create`, `POST /api/telegram/webhook`, and `GET /api/store/donations/history/:wallet`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bfc21a3804832eaf84ffc20c9c09f1)