### PR TITLE
Fix Telegram Stars CORS and normalize donation history response

### DIFF
--- a/app.js
+++ b/app.js
@@ -26,7 +26,7 @@ function createApp() {
     ...extraAllowedOrigins
   ];
 
-  app.use(cors({
+  const corsOptions = {
     origin: function(origin, callback) {
       if (!origin) {
         callback(null, true);
@@ -48,10 +48,11 @@ function createApp() {
     },
     credentials: true,
     methods: ['GET', 'POST', 'OPTIONS'],
-    allowedHeaders: ['Content-Type', 'X-Wallet', 'X-Primary-Id']
-  }));
+    allowedHeaders: ['Content-Type', 'X-Wallet', 'X-Primary-Id', 'X-Telegram-Init-Data', 'x-telegram-init-data']
+  };
 
-  app.options('*', cors());
+  app.use(cors(corsOptions));
+  app.options('*', cors(corsOptions));
   app.use(express.json({ limit: '1mb' }));
   app.use(metricsMiddleware);
 

--- a/tests/api.integration.test.js
+++ b/tests/api.integration.test.js
@@ -513,20 +513,24 @@ test('GET /api/store/donations/history/:wallet returns payments sorted by newest
   assert.equal(history.payments.length, 2);
   assert.equal(history.payments[0].paymentId, secondPayment.paymentId);
   assert.equal(history.payments[0].status, 'submitted');
-  assert.equal(history.payments[0].paymentMethod, 'crypto');
+  assert.equal(history.payments[0].paymentMethod, 'wallet');
   assert.equal(history.payments[0].paymentProvider, 'wallet');
   assert.equal(history.payments[0].paymentCategory, 'crypto');
   assert.equal(history.payments[0].title, 'Basic Pack');
   assert.equal(history.payments[0].amount, '0.09');
+  assert.equal(history.payments[0].paymentAmount, '0.09');
   assert.equal(history.payments[0].amountValue, '0.09');
   assert.equal(history.payments[0].currency, 'USDT');
+  assert.equal(history.payments[0].paymentMethodLegacy, 'crypto');
   assert.deepEqual(history.payments[0].payment, {
-    method: 'crypto',
+    method: 'wallet',
     provider: 'wallet',
     category: 'crypto',
     amount: '0.09',
     amountValue: '0.09',
-    currency: 'USDT'
+    currency: 'USDT',
+    amountByMethod: '0.09',
+    unit: 'USDT'
   });
   assert.equal(history.payments[0].txRequest, null);
   assert.ok(history.payments[0].createdAt);
@@ -734,6 +738,26 @@ function buildTelegramInitData(user, botToken) {
   return params.toString();
 }
 
+test('OPTIONS /api/donations/stars/create allows Telegram Mini App header in CORS preflight', async () => {
+  const { server, baseUrl } = await startServer();
+
+  const res = await fetch(`${baseUrl}/api/donations/stars/create`, {
+    method: 'OPTIONS',
+    headers: {
+      Origin: 'https://ursass-tube.vercel.app',
+      'Access-Control-Request-Method': 'POST',
+      'Access-Control-Request-Headers': 'content-type,x-telegram-init-data'
+    }
+  });
+
+  assert.equal(res.status, 204);
+  assert.equal(res.headers.get('access-control-allow-origin'), 'https://ursass-tube.vercel.app');
+  assert.match(res.headers.get('access-control-allow-headers') || '', /x-telegram-init-data/i);
+  assert.match(res.headers.get('access-control-allow-methods') || '', /POST/i);
+
+  await server.close();
+});
+
 test('POST /api/donations/stars/create creates Telegram Stars order and returns invoiceUrl', async () => {
   process.env.TELEGRAM_BOT_TOKEN = '123456:stars-token';
   const { server, baseUrl } = await startServer();
@@ -868,22 +892,26 @@ test('POST /api/telegram/webhook processes successful_payment idempotently', asy
   const historyRes = await fetch(`${baseUrl}/api/store/donations/history/tg_888002`);
   assert.equal(historyRes.status, 200);
   const history = await historyRes.json();
-  assert.equal(history.payments[0].paymentMethod, 'telegram_stars');
+  assert.equal(history.payments[0].paymentMethod, 'telegram-stars');
   assert.equal(history.payments[0].paymentProvider, 'telegram');
   assert.equal(history.payments[0].paymentCategory, 'stars');
   assert.equal(history.payments[0].status, 'paid');
   assert.equal(history.payments[0].starsAmount, 2);
   assert.equal(history.payments[0].amount, 2);
+  assert.equal(history.payments[0].paymentAmount, 2);
   assert.equal(history.payments[0].amountValue, '2');
-  assert.equal(history.payments[0].currency, 'XTR');
+  assert.equal(history.payments[0].currency, 'STARS');
   assert.deepEqual(history.payments[0].payment, {
-    method: 'telegram_stars',
+    method: 'telegram-stars',
     provider: 'telegram',
     category: 'stars',
     amount: 2,
     amountValue: '2',
-    currency: 'XTR'
+    currency: 'STARS',
+    amountByMethod: 2,
+    unit: 'STARS'
   });
+  assert.equal(history.payments[0].paymentMethodLegacy, 'telegram_stars');
 
   await server.close();
 });

--- a/utils/donationService.js
+++ b/utils/donationService.js
@@ -551,23 +551,50 @@ async function getDonationPayment(paymentId, options = {}) {
   return finalizeExpiredPayment(payment);
 }
 
+
+function getPaymentShape(payment) {
+  const isStars = payment.paymentMethod === 'telegram_stars';
+  const method = isStars ? 'telegram-stars' : 'wallet';
+  const provider = isStars ? 'telegram' : 'wallet';
+  const category = isStars ? 'stars' : 'crypto';
+  const amount = isStars ? (payment.starsAmount ?? payment.productSnapshot?.starsAmount ?? null) : payment.expectedAmount;
+  const currency = isStars ? 'STARS' : (payment.currency || payment.tokenSymbol || payment.productSnapshot?.currency || null);
+  const legacyPaymentMethod = payment.paymentMethod || 'crypto';
+
+  return {
+    isStars,
+    method,
+    provider,
+    category,
+    amount,
+    currency,
+    legacyPaymentMethod
+  };
+}
+
 function serializeDonationPayment(payment, options = {}) {
   if (!payment) {
     return null;
   }
   const includeTxRequest = options.includeTxRequest !== false;
-  const isStars = payment.paymentMethod === 'telegram_stars';
-  const normalizedPaymentMethod = payment.paymentMethod || 'crypto';
-  const amount = isStars ? (payment.starsAmount ?? payment.productSnapshot?.starsAmount ?? null) : payment.expectedAmount;
-  const currency = isStars ? 'XTR' : (payment.currency || payment.tokenSymbol || payment.productSnapshot?.currency || null);
+  const {
+    isStars,
+    method,
+    provider,
+    category,
+    amount,
+    currency,
+    legacyPaymentMethod
+  } = getPaymentShape(payment);
 
   return {
     paymentId: payment.paymentId,
     orderId: payment.paymentId,
     wallet: payment.wallet,
-    paymentMethod: normalizedPaymentMethod,
-    paymentProvider: isStars ? 'telegram' : 'wallet',
-    paymentCategory: isStars ? 'stars' : 'crypto',
+    paymentMethod: method,
+    paymentProvider: provider,
+    paymentCategory: category,
+    paymentMethodLegacy: legacyPaymentMethod,
     telegramUserId: payment.telegramUserId || null,
     status: getPublicStatus(payment.status),
     productKey: payment.productKey,
@@ -579,13 +606,18 @@ function serializeDonationPayment(payment, options = {}) {
     starsAmount: payment.starsAmount ?? payment.productSnapshot?.starsAmount ?? null,
     currency,
     payment: {
-      method: normalizedPaymentMethod,
-      provider: isStars ? 'telegram' : 'wallet',
-      category: isStars ? 'stars' : 'crypto',
+      method,
+      provider,
+      category,
       amount,
       amountValue: amount == null ? null : String(amount),
-      currency
+      currency,
+      amountByMethod: amount,
+      unit: currency
     },
+    amountByMethod: amount,
+    paymentAmount: amount,
+    unit: currency,
     network: payment.network,
     tokenContract: payment.tokenContract,
     merchantWallet: payment.merchantWallet,


### PR DESCRIPTION
### Motivation
- Allow Telegram Mini App to call `POST /api/donations/stars/create` by permitting the `x-telegram-init-data` header in CORS preflight and ensuring OPTIONS uses the same policy as the main middleware. 
- Provide a consistent, UI-friendly shape for donation history so clients don't need to guess payment method/amount/currency fields. 
- Preserve existing behavior for reading Telegram init data from body or header and surface Telegram upstream errors clearly (not opaque 502). 

### Description
- Updated `app.js` to reuse a single `corsOptions` object for both the global middleware and `app.options('*', ...)`, and added `X-Telegram-Init-Data` / `x-telegram-init-data` to `allowedHeaders` so preflight accepts the Telegram Mini App header. 
- Added `getPaymentShape` and refactored `serializeDonationPayment` in `utils/donationService.js` to return normalized fields (`paymentMethod` as `telegram-stars`/`wallet`, `paymentAmount`, `amountByMethod`, `unit`/`currency`, nested `payment` object), and preserved legacy info as `paymentMethodLegacy`. 
- Kept existing route logic intact: `routes/donations.js` still resolves init data from body or `x-telegram-init-data`; Telegram upstream failures continue to be reported as structured errors (e.g. `telegram_stars_upstream_rejected`, `telegram_stars_invalid_bot_token`). 
- Added/updated integration tests in `tests/api.integration.test.js` to cover CORS OPTIONS preflight for `x-telegram-init-data`, normalized history response assertions, and preserved Telegram error handling assertions. 

### Testing
- Ran targeted tests: `npm test -- --test-name-pattern='donations|Telegram|history|CORS'` and they passed. 
- Ran full test suite: `npm test` and all tests passed (30/30).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bfc692e8ec832ea0178be58c61562b)