### PR TITLE
Use compact `v1:orderId` invoice payload for Telegram Stars and improve parsing/validation

### DIFF
--- a/tests/api.integration.test.js
+++ b/tests/api.integration.test.js
@@ -72,7 +72,11 @@ test.beforeEach(() => {
     return this;
   };
   setTelegramStarsClientForTests({
-    async createInvoiceLink(payload) { return `https://t.me/invoice/${JSON.parse(payload.payload).orderId}`; },
+    async createInvoiceLink(payload) {
+      const rawPayload = String(payload.payload || '');
+      const orderId = rawPayload.startsWith('v1:') ? rawPayload.slice(3) : JSON.parse(rawPayload).orderId;
+      return `https://t.me/invoice/${orderId}`;
+    },
     async answerPreCheckoutQuery() { return true; }
   });
   donationPayments = [];
@@ -784,6 +788,8 @@ test('POST /api/donations/stars/create creates Telegram Stars order and returns 
   assert.equal(created.telegramUserId, '777001');
   assert.equal(created.starsAmount, 9);
   assert.equal(created.currency, 'XTR');
+  assert.equal(created.invoicePayload, `v1:${body.orderId}`);
+  assert.ok(Buffer.byteLength(created.invoicePayload, 'utf8') <= 128);
 
   await server.close();
 });

--- a/utils/donationService.js
+++ b/utils/donationService.js
@@ -228,14 +228,8 @@ async function createDonationPayment(wallet, productKey) {
   return payment;
 }
 
-function buildStarsInvoicePayload({ payment, telegramUserId, config }) {
-  return JSON.stringify({
-    version: 1,
-    orderId: payment.paymentId,
-    telegramUserId: String(telegramUserId),
-    productKey: config.key,
-    starsAmount: config.starsAmount
-  });
+function buildStarsInvoicePayload({ payment }) {
+  return `v1:${payment.paymentId}`;
 }
 
 async function createTelegramStarsPayment({ telegramUserId, productKey }) {
@@ -646,6 +640,14 @@ function serializeDonationPayment(payment, options = {}) {
 }
 
 function parseStarsPayload(payload) {
+  if (typeof payload === 'string') {
+    const trimmed = payload.trim();
+    if (trimmed.startsWith('v1:')) {
+      const orderId = trimmed.slice(3).trim();
+      return orderId ? { version: 1, orderId } : null;
+    }
+  }
+
   try {
     return JSON.parse(payload);
   } catch (error) {
@@ -732,7 +734,11 @@ async function handleTelegramSuccessfulPayment(update) {
     throw err;
   }
 
-  if (String(parsedPayload.telegramUserId) !== String(order.telegramUserId)) {
+  const successfulPaymentUserId = update?.message?.from?.id
+    || parsedPayload?.telegramUserId
+    || order.telegramUserId;
+
+  if (String(successfulPaymentUserId) !== String(order.telegramUserId)) {
     const err = new Error('Telegram user mismatch');
     err.statusCode = 400;
     throw err;


### PR DESCRIPTION
### Motivation
- Reduce invoice payload size to satisfy Telegram length limits and simplify payload format for Telegram Stars orders.
- Make payload parsing robust to both the new compact format and the legacy JSON format.
- Improve validation of successful payments by deriving the payer id more reliably from the incoming Telegram update.

### Description
- Replace JSON invoice payload generation with a compact string format `v1:<paymentId>` in `buildStarsInvoicePayload`.
- Add `parseStarsPayload` support for the `v1:` prefix and keep a JSON fallback for backward compatibility.
- Adjust successful payment handling in `handleTelegramSuccessfulPayment` to obtain the payer id from `update.message.from.id` first, then fall back to parsed payload or order values before validating the user.
- Update test helpers and integration tests in `tests/api.integration.test.js` to accept/create the `v1:` payload and assert that `invoicePayload` is stored and is within the expected byte length.

### Testing
- Ran the automated test suite including the modified integration tests in `tests/api.integration.test.js` (via `npm test`) and confirmed the updated tests passed.
- Verified the new parsing and payment flow by exercising `handleTelegramPreCheckoutQuery` and `handleTelegramSuccessfulPayment` through the integration cases, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bfcf599e8c832e82078521f55fcb58)