### PR TITLE
Refactor store upgrade/purchase logic, improve account merge, and add detailed /health endpoint

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const cors = require('cors');
+const mongoose = require('mongoose');
 const leaderboardRoutes = require('./routes/leaderboard');
 const storeRoutes = require('./routes/store');
 const accountRoutes = require('./routes/account');
@@ -69,7 +70,24 @@ function createApp() {
   app.use('/api/v1', donationsRoutes);
 
   app.get('/health', (req, res) => {
-    res.json({ status: 'OK', timestamp: new Date(), mongodb: 'connected' });
+    const mongoStates = {
+      0: 'disconnected',
+      1: 'connected',
+      2: 'connecting',
+      3: 'disconnecting'
+    };
+    const readyState = mongoose.connection?.readyState;
+    const mongoStatus = mongoStates[readyState] || 'unknown';
+
+    res.json({
+      status: readyState === 1 ? 'OK' : 'DEGRADED',
+      timestamp: new Date(),
+      mongodb: mongoStatus,
+      mongodbDetails: {
+        readyState,
+        status: mongoStatus
+      }
+    });
   });
 
   app.get('/metrics', (req, res) => {

--- a/middleware/rateLimiter.js
+++ b/middleware/rateLimiter.js
@@ -9,10 +9,7 @@ const saveResultLimiter = rateLimit({
   message: '❌ Слишком много попыток отправки результатов. Подождите минуту.',
   standardHeaders: true,
   legacyHeaders: false,
-  keyGenerator: getClientIp,
-  skip: (req) => {
-    return req.path === '/health';
-  }
+  keyGenerator: getClientIp
 });
 
 // ✅ Умеренный лимит для write-операций, не связанных с сохранением результата

--- a/routes/leaderboard.js
+++ b/routes/leaderboard.js
@@ -46,6 +46,21 @@ function buildDisplayName(link, primaryId) {
   return primaryId || 'Unknown';
 }
 
+function buildLeaderboardEntry(player, displayName, position) {
+  return {
+    position,
+    wallet: player.wallet,
+    displayName,
+    bestScore: player.bestScore,
+    averageScore: player.averageScore || 0,
+    scoreToAverageRatio: player.scoreToAverageRatio || null,
+    bestDistance: player.bestDistance,
+    totalGoldCoins: player.totalGoldCoins,
+    totalSilverCoins: player.totalSilverCoins,
+    gamesPlayed: player.gamesPlayed
+  };
+}
+
 // ✅ GET: Top 10 players
 router.get('/top', readLimiter, async (req, res) => {
   try {
@@ -75,49 +90,29 @@ router.get('/top', readLimiter, async (req, res) => {
             bestScore: { $gt: playerData.bestScore }
           });
 
-          playerPosition = {
-            position: position + 1,
-            wallet: playerData.wallet,
-            displayName: buildDisplayName(playerLink, playerData.wallet),
-            bestScore: playerData.bestScore,
-            averageScore: playerData.averageScore || 0,
-            scoreToAverageRatio: playerData.scoreToAverageRatio || null,
-            bestDistance: playerData.bestDistance,
-            totalGoldCoins: playerData.totalGoldCoins,
-            totalSilverCoins: playerData.totalSilverCoins,
-            gamesPlayed: playerData.gamesPlayed
-          };
+          playerPosition = buildLeaderboardEntry(
+            playerData,
+            buildDisplayName(playerLink, playerData.wallet),
+            position + 1
+          );
         } else {
-          // Player has 0 score — no position
-          playerPosition = {
-            position: null,
-            wallet: playerData.wallet,
-            displayName: buildDisplayName(playerLink, playerData.wallet),
-            bestScore: playerData.bestScore,
-            averageScore: playerData.averageScore || 0,
-            scoreToAverageRatio: playerData.scoreToAverageRatio || null,
-            bestDistance: playerData.bestDistance,
-            totalGoldCoins: playerData.totalGoldCoins,
-            totalSilverCoins: playerData.totalSilverCoins,
-            gamesPlayed: playerData.gamesPlayed
-          };
+          playerPosition = buildLeaderboardEntry(
+            playerData,
+            buildDisplayName(playerLink, playerData.wallet),
+            null
+          );
         }
       }
     }
 
     res.json({
-      leaderboard: topPlayers.map((player, index) => ({
-        position: index + 1,
-        wallet: player.wallet,
-        displayName: buildDisplayName(linkMap[player.wallet], player.wallet),
-        bestScore: player.bestScore,
-        averageScore: player.averageScore || 0,
-        scoreToAverageRatio: player.scoreToAverageRatio || null,
-        bestDistance: player.bestDistance,
-        totalGoldCoins: player.totalGoldCoins,
-        totalSilverCoins: player.totalSilverCoins,
-        gamesPlayed: player.gamesPlayed
-      })),
+      leaderboard: topPlayers.map((player, index) => (
+        buildLeaderboardEntry(
+          player,
+          buildDisplayName(linkMap[player.wallet], player.wallet),
+          index + 1
+        )
+      )),
       playerPosition
     });
 

--- a/routes/store.js
+++ b/routes/store.js
@@ -23,6 +23,10 @@ function resolveUpgradeKey(upgradeKey) {
   return UPGRADE_KEY_ALIASES[upgradeKey] || upgradeKey;
 }
 
+function isLevelUpgradeType(type) {
+  return type === 'tiered' || type === 'permanent';
+}
+
 function normalizeShieldUpgrades(upgrades) {
   let changed = false;
   const legacyShieldLevel = upgrades.shield || 0;
@@ -46,6 +50,177 @@ function normalizeShieldUpgrades(upgrades) {
   return changed;
 }
 
+async function getOrCreatePlayerUpgrades(wallet) {
+  let upgrades = await PlayerUpgrades.findOne({ wallet });
+  if (!upgrades) {
+    upgrades = new PlayerUpgrades({ wallet });
+    await upgrades.save();
+  }
+  return upgrades;
+}
+
+async function prepareUpgrades(upgrades, { persist = false } = {}) {
+  const ridesChanged = upgrades.refreshFreeRides();
+  const shieldChanged = normalizeShieldUpgrades(upgrades);
+
+  if (persist && (ridesChanged || shieldChanged)) {
+    await upgrades.save();
+  }
+
+  return upgrades;
+}
+
+function buildRidesData(upgrades, options = {}) {
+  const now = new Date();
+  const resetAt = upgrades.freeRidesResetAt || now;
+  const msUntilReset = Math.max(0, (8 * 60 * 60 * 1000) - (now - resetAt));
+  const resetInMs = options.resetInMs ?? (upgrades.freeRidesRemaining < 3 ? msUntilReset : 0);
+
+  return {
+    freeRides: options.freeRides ?? upgrades.freeRidesRemaining,
+    paidRides: options.paidRides ?? upgrades.paidRidesRemaining,
+    totalRides: options.totalRides ?? upgrades.getTotalRides(),
+    maxFreeRides: 3,
+    resetInMs,
+    resetInFormatted: options.resetInFormatted ?? formatTimeLeft(resetInMs)
+  };
+}
+
+async function spendPlayerCurrency(player, currency, amount, failPurchase) {
+  const balanceField = currency === 'silver' ? 'totalSilverCoins' : 'totalGoldCoins';
+  const label = currency === 'silver' ? 'silver' : 'gold';
+  const available = player[balanceField];
+
+  if (available < amount) {
+    return failPurchase(
+      400,
+      `insufficient_${label}`,
+      `Not enough ${label}. Need: ${amount}, have: ${available}`,
+      { required: amount, available }
+    );
+  }
+
+  player[balanceField] -= amount;
+  return null;
+}
+
+async function applyLevelUpgrade({
+  upgrades,
+  upgradeKey,
+  nextLevel,
+  maxLevel,
+  price,
+  currency,
+  wallet,
+  player,
+  failPurchase
+}) {
+  const insufficientFundsResponse = await spendPlayerCurrency(player, currency, price, failPurchase);
+  if (insufficientFundsResponse) {
+    return insufficientFundsResponse;
+  }
+
+  upgrades[upgradeKey] = nextLevel;
+  logger.info({ wallet, upgradeKey, tier: nextLevel, maxLevel, price, currency }, 'Upgrade purchased');
+  return null;
+}
+
+async function validateLevelPurchase({ tier, currentLevel, maxLevel, failPurchase }) {
+  if (tier !== currentLevel) {
+    return failPurchase(
+      400,
+      'tier_mismatch',
+      `Must buy tier ${currentLevel}. Current: ${currentLevel}, requested: ${tier}`,
+      { currentLevel }
+    );
+  }
+
+  if (currentLevel >= maxLevel) {
+    return failPurchase(400, 'max_level_reached', 'Already at max level');
+  }
+
+  return null;
+}
+
+function createPurchaseAudit({ wallet, req, res, purchaseDetails }) {
+  const logPurchaseResult = async (status, reason, details = {}) => {
+    await logSecurityEvent({
+      wallet,
+      eventType: 'purchase_result',
+      route: req.path,
+      ipAddress: req.ip,
+      details: {
+        ...purchaseDetails,
+        status,
+        reason,
+        ...details
+      }
+    });
+  };
+
+  const failPurchase = async (statusCode, reason, message, details = {}) => {
+    await logPurchaseResult('fail', reason, details);
+    return res.status(statusCode).json({ error: message });
+  };
+
+  const logPurchaseAttempt = async () => {
+    const recentBuyCount = await SecurityEvent.countDocuments({
+      wallet,
+      eventType: 'purchase_attempt',
+      createdAt: { $gte: new Date(Date.now() - 2 * 60 * 1000) }
+    });
+
+    if (recentBuyCount >= 12) {
+      markSuspicious('rapid_purchases');
+      await logSecurityEvent({
+        wallet,
+        eventType: 'suspicious_rapid_purchases',
+        route: req.path,
+        ipAddress: req.ip,
+        details: { recentBuyCount }
+      });
+      logger.warn({ wallet, recentBuyCount }, 'Suspicious rapid purchase pattern');
+    }
+
+    await logSecurityEvent({
+      wallet,
+      eventType: 'purchase_attempt',
+      route: req.path,
+      ipAddress: req.ip,
+      details: purchaseDetails
+    });
+  };
+
+  const logServerError = async (requestBody, error) => {
+    if (!wallet) {
+      return;
+    }
+
+    await logSecurityEvent({
+      wallet,
+      eventType: 'purchase_result',
+      route: req.path,
+      ipAddress: req.ip,
+      details: {
+        requestedUpgradeKey: String(requestBody?.upgradeKey || '').trim(),
+        resolvedUpgradeKey: resolveUpgradeKey(String(requestBody?.upgradeKey || '').trim()),
+        tier: requestBody?.tier ?? 0,
+        authMode: requestBody?.authMode || 'wallet',
+        status: 'fail',
+        reason: 'server_error',
+        error: error.message
+      }
+    });
+  };
+
+  return {
+    failPurchase,
+    logPurchaseResult,
+    logPurchaseAttempt,
+    logServerError
+  };
+}
+
 /**
  * GET /api/store/upgrades/:wallet
  * Get all upgrades + rides + effects
@@ -58,18 +233,8 @@ router.get('/upgrades/:wallet', readLimiter, async (req, res) => {
       return res.status(400).json({ error: 'Invalid wallet address' });
     }
 
-    let upgrades = await PlayerUpgrades.findOne({ wallet });
-    if (!upgrades) {
-      upgrades = new PlayerUpgrades({ wallet });
-      await upgrades.save();
-    }
-
-    // Refresh free rides + normalize legacy shield progression
-    const changed = upgrades.refreshFreeRides();
-    const shieldChanged = normalizeShieldUpgrades(upgrades);
-    if (changed || shieldChanged) {
-      await upgrades.save();
-    }
+    const upgrades = await getOrCreatePlayerUpgrades(wallet);
+    await prepareUpgrades(upgrades, { persist: true });
 
     const player = await Player.findOne({ wallet });
     const gold = player ? player.totalGoldCoins : 0;
@@ -113,25 +278,11 @@ router.get('/upgrades/:wallet', readLimiter, async (req, res) => {
       upgradesData.start_with_radar = { ...upgradesData.radar };
     }
 
-    // Rides data
-    const now = new Date();
-    const resetAt = upgrades.freeRidesResetAt || now;
-    const msUntilReset = Math.max(0, (8 * 60 * 60 * 1000) - (now - resetAt));
-
-    const ridesData = {
-      freeRides: upgrades.freeRidesRemaining,
-      paidRides: upgrades.paidRidesRemaining,
-      totalRides: upgrades.getTotalRides(),
-      maxFreeRides: 3,
-      resetInMs: upgrades.freeRidesRemaining < 3 ? msUntilReset : 0,
-      resetInFormatted: formatTimeLeft(msUntilReset)
-    };
-
     res.json({
       wallet,
       balance: { gold, silver },
       upgrades: upgradesData,
-      rides: ridesData,
+      rides: buildRidesData(upgrades),
       activeEffects: effects
     });
 
@@ -282,52 +433,19 @@ router.post('/buy', writeLimiter, async (req, res) => {
       tier: tier ?? 0,
       authMode: authMode || 'wallet'
     };
-
-    const logPurchaseResult = async (status, reason, details = {}) => {
-      await logSecurityEvent({
-        wallet: walletLower,
-        eventType: 'purchase_result',
-        route: req.path,
-        ipAddress: req.ip,
-        details: {
-          ...purchaseDetails,
-          status,
-          reason,
-          ...details
-        }
-      });
-    };
-
-    const failPurchase = async (statusCode, reason, message, details = {}) => {
-      await logPurchaseResult('fail', reason, details);
-      return res.status(statusCode).json({ error: message });
-    };
-
-    const recentBuyCount = await SecurityEvent.countDocuments({
-          wallet: walletLower,
-          eventType: 'purchase_attempt',
-          createdAt: { $gte: new Date(Date.now() - 2 * 60 * 1000) }
-        });
-    
-        if (recentBuyCount >= 12) {
-          markSuspicious('rapid_purchases');
-          await logSecurityEvent({
-            wallet: walletLower,
-            eventType: 'suspicious_rapid_purchases',
-            route: req.path,
-            ipAddress: req.ip,
-            details: { recentBuyCount }
-          });
-          logger.warn({ wallet: walletLower, recentBuyCount }, 'Suspicious rapid purchase pattern');
-        }
-
-    await logSecurityEvent({
+    const {
+      failPurchase,
+      logPurchaseResult,
+      logPurchaseAttempt,
+      logServerError
+    } = createPurchaseAudit({
       wallet: walletLower,
-      eventType: 'purchase_attempt',
-      route: req.path,
-      ipAddress: req.ip,
-      details: purchaseDetails
+      req,
+      res,
+      purchaseDetails
     });
+
+    await logPurchaseAttempt();
 
     
     const config = UPGRADES_CONFIG[resolvedUpgradeKey];
@@ -372,100 +490,46 @@ router.post('/buy', writeLimiter, async (req, res) => {
       return failPurchase(404, 'player_not_found', 'Player not found. Play at least one game first.');
     }
 
-    let upgrades = await PlayerUpgrades.findOne({ wallet: walletLower });
-    if (!upgrades) {
-      upgrades = new PlayerUpgrades({ wallet: walletLower });
-    }
-
-    // Refresh free rides + normalize legacy shield progression
-    upgrades.refreshFreeRides();
-    normalizeShieldUpgrades(upgrades);
+    const upgrades = await getOrCreatePlayerUpgrades(walletLower);
+    await prepareUpgrades(upgrades);
 
     // === PURCHASE LOGIC BY TYPE ===
 
-    if (config.type === "tiered") {
+    if (isLevelUpgradeType(config.type)) {
       const currentLevel = upgrades[resolvedUpgradeKey] || 0;
-
-      if (tier !== currentLevel) {
-        return failPurchase(400, 'tier_mismatch', `Must buy tier ${currentLevel}. Current: ${currentLevel}, requested: ${tier}`, {
-          currentLevel
-        });
+      const validationFailure = await validateLevelPurchase({
+        tier,
+        currentLevel,
+        maxLevel: config.maxLevel,
+        failPurchase
+      });
+      if (validationFailure) {
+        return validationFailure;
       }
 
-      if (currentLevel >= config.maxLevel) {
-        return failPurchase(400, 'max_level_reached', 'Already at max level');
+      const priceIndex = config.type === 'tiered' ? tier : currentLevel;
+      const price = config.prices[priceIndex];
+      const failure = await applyLevelUpgrade({
+        upgrades,
+        upgradeKey: resolvedUpgradeKey,
+        nextLevel: currentLevel + 1,
+        maxLevel: config.maxLevel,
+        price,
+        currency: config.currency,
+        wallet: walletLower,
+        player,
+        failPurchase
+      });
+      if (failure) {
+        return failure;
       }
-
-      const price = config.prices[tier];
-
-      if (config.currency === "silver") {
-        if (player.totalSilverCoins < price) {
-          return failPurchase(400, 'insufficient_silver', `Not enough silver. Need: ${price}, have: ${player.totalSilverCoins}`, {
-            required: price,
-            available: player.totalSilverCoins
-          });
-        }
-        player.totalSilverCoins -= price;
-      } else {
-        if (player.totalGoldCoins < price) {
-          return failPurchase(400, 'insufficient_gold', `Not enough gold. Need: ${price}, have: ${player.totalGoldCoins}`, {
-            required: price,
-            available: player.totalGoldCoins
-          });
-        }
-        player.totalGoldCoins -= price;
-      }
-
-      upgrades[resolvedUpgradeKey] = currentLevel + 1;
-      logger.info({ wallet: walletLower, upgradeKey: resolvedUpgradeKey, tier: currentLevel + 1, maxLevel: config.maxLevel, price, currency: config.currency }, 'Upgrade purchased');
-
-    } else if (config.type === "permanent") {
-      const currentLevel = upgrades[resolvedUpgradeKey] || 0;
-
-      if (tier !== currentLevel) {
-        return failPurchase(400, 'tier_mismatch', `Must buy tier ${currentLevel}. Current: ${currentLevel}, requested: ${tier}`, {
-          currentLevel
-        });
-      }
-
-      if (currentLevel >= config.maxLevel) {
-        return failPurchase(400, 'max_level_reached', 'Already at max level');
-      }
-
-      const price = config.prices[currentLevel];
-
-      if (config.currency === "gold") {
-        if (player.totalGoldCoins < price) {
-          return failPurchase(400, 'insufficient_gold', `Not enough gold. Need: ${price}, have: ${player.totalGoldCoins}`, {
-            required: price,
-            available: player.totalGoldCoins
-          });
-        }
-        player.totalGoldCoins -= price;
-      } else {
-        if (player.totalSilverCoins < price) {
-          return failPurchase(400, 'insufficient_silver', `Not enough silver. Need: ${price}, have: ${player.totalSilverCoins}`, {
-            required: price,
-            available: player.totalSilverCoins
-          });
-        }
-        player.totalSilverCoins -= price;
-      }
-
-      upgrades[resolvedUpgradeKey] = currentLevel + 1;
-      logger.info({ wallet: walletLower, upgradeKey: resolvedUpgradeKey, tier: currentLevel + 1, maxLevel: config.maxLevel, price, currency: config.currency }, 'Upgrade purchased');
 
     } else if (config.type === "rides") {
       const price = config.price;
-
-      if (player.totalGoldCoins < price) {
-        return failPurchase(400, 'insufficient_gold', `Not enough gold. Need: ${price}, have: ${player.totalGoldCoins}`, {
-          required: price,
-          available: player.totalGoldCoins
-        });
+      const failure = await spendPlayerCurrency(player, 'gold', price, failPurchase);
+      if (failure) {
+        return failure;
       }
-
-      player.totalGoldCoins -= price;
       upgrades.paidRidesRemaining += config.amount;
 
       logger.info({ wallet: walletLower, ridesBought: config.amount, price, currency: 'gold', paidRidesRemaining: upgrades.paidRidesRemaining }, 'Rides purchased');
@@ -483,11 +547,6 @@ router.post('/buy', writeLimiter, async (req, res) => {
 
     const effects = calculateEffects(upgrades);
 
-    // Rides data
-    const nowDate = new Date();
-    const resetAt = upgrades.freeRidesResetAt || nowDate;
-    const msUntilReset = Math.max(0, (8 * 60 * 60 * 1000) - (nowDate - resetAt));
-
     await logPurchaseResult('success', 'completed');
 
     logger.info({ wallet: walletLower, requestedUpgradeKey, resolvedUpgradeKey, tier: tier ?? 0 }, 'Purchase processed');
@@ -502,35 +561,24 @@ router.post('/buy', writeLimiter, async (req, res) => {
         gold: player.totalGoldCoins,
         silver: player.totalSilverCoins
       },
-      rides: {
-        freeRides: upgrades.freeRidesRemaining,
-        paidRides: upgrades.paidRidesRemaining,
-        totalRides: upgrades.getTotalRides(),
-        resetInMs: upgrades.freeRidesRemaining < 3 ? msUntilReset : 0,
-        resetInFormatted: formatTimeLeft(msUntilReset)
-      },
+      rides: buildRidesData(upgrades),
       activeEffects: effects
     });
 
   } catch (error) {
     const walletLower = typeof req.body?.wallet === 'string' ? req.body.wallet.toLowerCase() : null;
-    if (walletLower) {
-      await logSecurityEvent({
-        wallet: walletLower,
-        eventType: 'purchase_result',
-        route: req.path,
-        ipAddress: req.ip,
-        details: {
-          requestedUpgradeKey: String(req.body?.upgradeKey || '').trim(),
-          resolvedUpgradeKey: resolveUpgradeKey(String(req.body?.upgradeKey || '').trim()),
-          tier: req.body?.tier ?? 0,
-          authMode: req.body?.authMode || 'wallet',
-          status: 'fail',
-          reason: 'server_error',
-          error: error.message
-        }
-      });
-    }
+    const purchaseAudit = createPurchaseAudit({
+      wallet: walletLower,
+      req,
+      res,
+      purchaseDetails: {
+        requestedUpgradeKey: String(req.body?.upgradeKey || '').trim(),
+        resolvedUpgradeKey: resolveUpgradeKey(String(req.body?.upgradeKey || '').trim()),
+        tier: req.body?.tier ?? 0,
+        authMode: req.body?.authMode || 'wallet'
+      }
+    });
+    await purchaseAudit.logServerError(req.body, error);
     logger.error({ err: error }, 'POST /buy error');
     res.status(500).json({ error: 'Server error' });
   }
@@ -557,14 +605,8 @@ const consumeRideHandler = async (req, res) => {
         details: 'Pass a unique rideSessionId for every game start to enable anti-cheat duplicate protection.'
       });
     }
-    let upgrades = await PlayerUpgrades.findOne({ wallet: walletLower });
-    if (!upgrades) {
-      upgrades = new PlayerUpgrades({ wallet: walletLower });
-    }
-
-    // Refresh free rides + normalize legacy shield progression
-    upgrades.refreshFreeRides();
-    normalizeShieldUpgrades(upgrades);
+    const upgrades = await getOrCreatePlayerUpgrades(walletLower);
+    await prepareUpgrades(upgrades);
     
     upgrades.recentRideSessionIds = upgrades.recentRideSessionIds || [];
 
@@ -581,11 +623,7 @@ const consumeRideHandler = async (req, res) => {
       return res.status(409).json({
         error: 'Ride already consumed for this session',
         antiCheatTriggered: true,
-        rides: {
-          freeRides: upgrades.freeRidesRemaining,
-          paidRides: upgrades.paidRidesRemaining,
-          totalRides: upgrades.getTotalRides()
-        }
+        rides: buildRidesData(upgrades)
       });
     }
 
@@ -597,13 +635,13 @@ const consumeRideHandler = async (req, res) => {
 
       return res.status(403).json({
         error: 'No rides remaining',
-        rides: {
+        rides: buildRidesData(upgrades, {
           freeRides: 0,
           paidRides: 0,
           totalRides: 0,
           resetInMs: msUntilReset,
           resetInFormatted: formatTimeLeft(msUntilReset)
-        }
+        })
       });
     }
 
@@ -619,15 +657,8 @@ const consumeRideHandler = async (req, res) => {
         upgrades.recentRideSessionIds = upgrades.recentRideSessionIds.slice(-30);
       }
     }
-
-
-
     upgrades.updatedAt = new Date();
     await upgrades.save();
-
-    const nowDate = new Date();
-    const resetAt = upgrades.freeRidesResetAt || nowDate;
-    const msUntilReset = Math.max(0, (8 * 60 * 60 * 1000) - (nowDate - resetAt));
 
     logger.info({ wallet: walletLower, freeRidesRemaining: upgrades.freeRidesRemaining, paidRidesRemaining: upgrades.paidRidesRemaining }, 'Ride consumed');
     
@@ -639,13 +670,7 @@ const consumeRideHandler = async (req, res) => {
     res.json({
       success: true,
       antiCheat,
-      rides: {
-        freeRides: upgrades.freeRidesRemaining,
-        paidRides: upgrades.paidRidesRemaining,
-        totalRides: upgrades.getTotalRides(),
-        resetInMs: upgrades.freeRidesRemaining < 3 ? msUntilReset : 0,
-        resetInFormatted: formatTimeLeft(msUntilReset)
-      }
+      rides: buildRidesData(upgrades)
     });
 
   } catch (error) {
@@ -665,26 +690,11 @@ router.get('/rides/:wallet', readLimiter, async (req, res) => {
   try {
     const wallet = normalizeWallet(req.params.wallet);
 
-    let upgrades = await PlayerUpgrades.findOne({ wallet });
-    if (!upgrades) {
-      upgrades = new PlayerUpgrades({ wallet });
-      await upgrades.save();
-    }
-
-    upgrades.refreshFreeRides();
-    await upgrades.save();
-
-    const nowDate = new Date();
-    const resetAt = upgrades.freeRidesResetAt || nowDate;
-    const msUntilReset = Math.max(0, (8 * 60 * 60 * 1000) - (nowDate - resetAt));
+    const upgrades = await getOrCreatePlayerUpgrades(wallet);
+    await prepareUpgrades(upgrades, { persist: true });
 
     res.json({
-      freeRides: upgrades.freeRidesRemaining,
-      paidRides: upgrades.paidRidesRemaining,
-      totalRides: upgrades.getTotalRides(),
-      maxFreeRides: 3,
-      resetInMs: upgrades.freeRidesRemaining < 3 ? msUntilReset : 0,
-      resetInFormatted: formatTimeLeft(msUntilReset)
+      ...buildRidesData(upgrades)
     });
     
 } catch (error) {

--- a/tests/accountManager.test.js
+++ b/tests/accountManager.test.js
@@ -1,0 +1,119 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const AccountLink = require('../models/AccountLink');
+const Player = require('../models/Player');
+const PlayerUpgrades = require('../models/PlayerUpgrades');
+const { mergeAccounts } = require('../utils/accountManager');
+
+test('mergeAccounts stores schema-compatible masterSource value', async () => {
+  const originalAccountLinkFindOne = AccountLink.findOne;
+  const originalAccountLinkDeleteOne = AccountLink.deleteOne;
+  const originalPlayerFindOne = Player.findOne;
+  const originalPlayerUpgradesFindOne = PlayerUpgrades.findOne;
+
+  const linkTelegram = {
+    primaryId: 'tg_100',
+    telegramId: '100',
+    wallet: null,
+    masterSource: null,
+    save: async function save() { return this; }
+  };
+  const linkWallet = {
+    primaryId: '0xabc',
+    telegramId: null,
+    wallet: '0xabc',
+    masterSource: null,
+    save: async function save() { return this; }
+  };
+  const playerTelegram = {
+    wallet: 'tg_100',
+    bestScore: 10,
+    bestDistance: 5,
+    totalGoldCoins: 1,
+    totalSilverCoins: 2,
+    gamesPlayed: 1,
+    averageScore: 10,
+    scoreToAverageRatio: 1,
+    gameHistory: [{ score: 10, timestamp: new Date('2024-01-01T00:00:00Z') }],
+    save: async function save() { return this; }
+  };
+  const playerWallet = {
+    wallet: '0xabc',
+    bestScore: 200,
+    bestDistance: 50,
+    totalGoldCoins: 10,
+    totalSilverCoins: 20,
+    gamesPlayed: 5,
+    averageScore: 40,
+    scoreToAverageRatio: 5,
+    gameHistory: [{ score: 200, timestamp: new Date('2024-02-01T00:00:00Z') }],
+    save: async function save() { return this; }
+  };
+  const upgradesTelegram = {
+    x2_duration: 1,
+    shield: 1,
+    freeRidesRemaining: 2,
+    paidRidesRemaining: 2,
+    recentRideSessionIds: ['ride-a'],
+    save: async function save() { return this; }
+  };
+  const upgradesWallet = {
+    x2_duration: 3,
+    shield: 0,
+    freeRidesRemaining: 1,
+    paidRidesRemaining: 7,
+    recentRideSessionIds: ['ride-b'],
+    save: async function save() { return this; }
+  };
+
+  try {
+    AccountLink.findOne = async ({ primaryId }) => {
+      if (primaryId === 'tg_100') return linkTelegram;
+      if (primaryId === '0xabc') return linkWallet;
+      return null;
+    };
+    AccountLink.deleteOne = async ({ primaryId }) => ({ deletedCount: primaryId === 'tg_100' ? 1 : 0 });
+
+    Player.findOne = async ({ wallet }) => {
+      if (wallet === 'tg_100') return playerTelegram;
+      if (wallet === '0xabc') return playerWallet;
+      return null;
+    };
+
+    PlayerUpgrades.findOne = async ({ wallet }) => {
+      if (wallet === 'tg_100') return upgradesTelegram;
+      if (wallet === '0xabc') return upgradesWallet;
+      return null;
+    };
+
+    const result = await mergeAccounts('tg_100', '0xabc');
+
+    assert.equal(result.success, true);
+    assert.equal(result.primaryId, '0xabc');
+    assert.equal(result.wallet, '0xabc');
+    assert.equal(result.telegramId, '100');
+    assert.equal(linkWallet.masterSource, 'wallet');
+    assert.equal(linkWallet.telegramId, '100');
+    assert.equal(playerWallet.totalGoldCoins, 11);
+    assert.equal(playerWallet.totalSilverCoins, 22);
+    assert.equal(playerWallet.gamesPlayed, 6);
+    assert.equal(playerWallet.gameHistory.length, 2);
+    assert.equal(playerWallet.averageScore, 35);
+    assert.equal(playerWallet.bestScore, 200);
+    assert.equal(upgradesWallet.x2_duration, 3);
+    assert.equal(upgradesWallet.shield, 1);
+    assert.equal(upgradesWallet.freeRidesRemaining, 2);
+    assert.equal(upgradesWallet.paidRidesRemaining, 9);
+    assert.deepEqual([...upgradesWallet.recentRideSessionIds].sort(), ['ride-a', 'ride-b']);
+    assert.equal(playerTelegram.bestScore, 0);
+    assert.equal(playerTelegram.gamesPlayed, 0);
+    assert.equal(upgradesTelegram.paidRidesRemaining, 0);
+    assert.deepEqual(upgradesTelegram.recentRideSessionIds, []);
+  } finally {
+    AccountLink.findOne = originalAccountLinkFindOne;
+    AccountLink.deleteOne = originalAccountLinkDeleteOne;
+    Player.findOne = originalPlayerFindOne;
+    PlayerUpgrades.findOne = originalPlayerUpgradesFindOne;
+  }
+});

--- a/tests/api.integration.test.js
+++ b/tests/api.integration.test.js
@@ -191,6 +191,28 @@ test('POST /api/leaderboard/save rejects invalid signature', async () => {
   await server.close();
 });
 
+test('GET /health reports actual mongoose connection state', async () => {
+  const originalReadyState = mongoose.connection.readyState;
+
+  try {
+    mongoose.connection.readyState = 2;
+
+    const { server, baseUrl } = await startServer();
+    const res = await fetch(`${baseUrl}/health`);
+
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.status, 'DEGRADED');
+    assert.equal(body.mongodb, 'connecting');
+    assert.equal(body.mongodbDetails.readyState, 2);
+    assert.equal(body.mongodbDetails.status, 'connecting');
+
+    await server.close();
+  } finally {
+    mongoose.connection.readyState = originalReadyState;
+  }
+});
+
 test('POST /api/leaderboard/save accepts valid signature and blocks replay', async () => {
   const wallet = Wallet.createRandom();
   const seenSignatures = new Set();

--- a/utils/accountManager.js
+++ b/utils/accountManager.js
@@ -3,6 +3,139 @@ const Player = require('../models/Player');
 const PlayerUpgrades = require('../models/PlayerUpgrades');
 const logger = require('./logger');
 
+const UPGRADE_LEVEL_FIELDS = [
+  'x2_duration',
+  'score_plus_300_mult',
+  'score_plus_500_mult',
+  'score_minus_300_mult',
+  'score_minus_500_mult',
+  'invert_score',
+  'speed_up_mult',
+  'speed_down_mult',
+  'magnet_duration',
+  'spin_cooldown',
+  'shield',
+  'shield_capacity',
+  'radar',
+  'alert'
+];
+
+function buildNewPlayer(primaryId) {
+  return new Player({
+    wallet: primaryId,
+    bestScore: 0,
+    bestDistance: 0,
+    totalGoldCoins: 0,
+    totalSilverCoins: 0,
+    gamesPlayed: 0,
+    gameHistory: []
+  });
+}
+
+function buildAccountLink({ primaryId, telegramId = null, wallet = null }) {
+  return new AccountLink({
+    telegramId,
+    wallet,
+    primaryId,
+    masterSource: null,
+    linkedAt: null
+  });
+}
+
+function buildAccountSummary({ primaryId, telegramId = null, wallet = null, isLinked = false }) {
+  return {
+    primaryId,
+    telegramId,
+    wallet,
+    isLinked
+  };
+}
+
+async function ensurePlayerExists(primaryId) {
+  let player = await Player.findOne({ wallet: primaryId });
+  if (!player) {
+    player = buildNewPlayer(primaryId);
+    await player.save();
+  }
+  return player;
+}
+
+async function ensureUpgradesExist(primaryId) {
+  let upgrades = await PlayerUpgrades.findOne({ wallet: primaryId });
+  if (!upgrades) {
+    upgrades = new PlayerUpgrades({ wallet: primaryId });
+    await upgrades.save();
+  }
+  return upgrades;
+}
+
+async function ensureAccountResources(primaryId) {
+  await ensurePlayerExists(primaryId);
+  await ensureUpgradesExist(primaryId);
+}
+
+function resetPlayerState(player) {
+  player.bestScore = 0;
+  player.bestDistance = 0;
+  player.totalGoldCoins = 0;
+  player.totalSilverCoins = 0;
+  player.gamesPlayed = 0;
+  player.gameHistory = [];
+}
+
+function resetUpgradesState(upgrades) {
+  for (const field of UPGRADE_LEVEL_FIELDS) {
+    upgrades[field] = 0;
+  }
+
+  upgrades.freeRidesRemaining = 0;
+  upgrades.paidRidesRemaining = 0;
+  upgrades.recentRideSessionIds = [];
+  upgrades.freeRidesResetAt = new Date();
+}
+
+function mergePlayerState(masterPlayer, slavePlayer) {
+  masterPlayer.bestScore = Math.max(masterPlayer.bestScore || 0, slavePlayer.bestScore || 0);
+  masterPlayer.bestDistance = Math.max(masterPlayer.bestDistance || 0, slavePlayer.bestDistance || 0);
+  masterPlayer.totalGoldCoins = (masterPlayer.totalGoldCoins || 0) + (slavePlayer.totalGoldCoins || 0);
+  masterPlayer.totalSilverCoins = (masterPlayer.totalSilverCoins || 0) + (slavePlayer.totalSilverCoins || 0);
+  masterPlayer.gamesPlayed = (masterPlayer.gamesPlayed || 0) + (slavePlayer.gamesPlayed || 0);
+
+  const masterHistory = Array.isArray(masterPlayer.gameHistory) ? masterPlayer.gameHistory : [];
+  const slaveHistory = Array.isArray(slavePlayer.gameHistory) ? slavePlayer.gameHistory : [];
+  masterPlayer.gameHistory = [...masterHistory, ...slaveHistory]
+    .sort((a, b) => new Date(b.timestamp || 0) - new Date(a.timestamp || 0))
+    .slice(0, 100);
+
+  if (masterPlayer.gamesPlayed > 0) {
+    const totalScore = masterPlayer.gameHistory.reduce((sum, game) => sum + (game.score || 0), 0);
+    masterPlayer.averageScore = totalScore / masterPlayer.gamesPlayed;
+
+    if (masterPlayer.averageScore > 0) {
+      masterPlayer.scoreToAverageRatio = masterPlayer.bestScore / masterPlayer.averageScore;
+    } else {
+      masterPlayer.scoreToAverageRatio = null;
+    }
+  }
+}
+
+function mergeUpgradesState(masterUpgrades, slaveUpgrades) {
+  if (!masterUpgrades || !slaveUpgrades) {
+    return;
+  }
+
+  for (const field of UPGRADE_LEVEL_FIELDS) {
+    masterUpgrades[field] = Math.max(masterUpgrades[field] || 0, slaveUpgrades[field] || 0);
+  }
+
+  masterUpgrades.freeRidesRemaining = Math.max(masterUpgrades.freeRidesRemaining || 0, slaveUpgrades.freeRidesRemaining || 0);
+  masterUpgrades.paidRidesRemaining = (masterUpgrades.paidRidesRemaining || 0) + (slaveUpgrades.paidRidesRemaining || 0);
+
+  const masterRecentSessions = Array.isArray(masterUpgrades.recentRideSessionIds) ? masterUpgrades.recentRideSessionIds : [];
+  const slaveRecentSessions = Array.isArray(slaveUpgrades.recentRideSessionIds) ? slaveUpgrades.recentRideSessionIds : [];
+  masterUpgrades.recentRideSessionIds = [...new Set([...masterRecentSessions, ...slaveRecentSessions])].slice(-30);
+}
+
 /**
  * Получить или создать primaryId для Telegram пользователя
  */
@@ -13,53 +146,22 @@ async function getOrCreateTelegramAccount(telegramId) {
   let link = await AccountLink.findOne({ telegramId: tgIdStr });
 
   if (link) {
-    return {
+    return buildAccountSummary({
       primaryId: link.primaryId,
       telegramId: link.telegramId,
       wallet: link.wallet,
       isLinked: !!link.wallet
-    };
+    });
   }
 
   // Создаём новую
   const primaryId = `tg_${tgIdStr}`;
-  link = new AccountLink({
-    telegramId: tgIdStr,
-    wallet: null,
-    primaryId: primaryId,
-    masterSource: null,
-    linkedAt: null
-  });
+  link = buildAccountLink({ primaryId, telegramId: tgIdStr });
   await link.save();
 
-  // Создаём пустого игрока
-  let player = await Player.findOne({ wallet: primaryId });
-  if (!player) {
-    player = new Player({
-      wallet: primaryId,
-      bestScore: 0,
-      bestDistance: 0,
-      totalGoldCoins: 0,
-      totalSilverCoins: 0,
-      gamesPlayed: 0,
-      gameHistory: []
-    });
-    await player.save();
-  }
+  await ensureAccountResources(primaryId);
 
-  // Создаём пустые апгрейды
-  let upgrades = await PlayerUpgrades.findOne({ wallet: primaryId });
-  if (!upgrades) {
-    upgrades = new PlayerUpgrades({ wallet: primaryId });
-    await upgrades.save();
-  }
-
-  return {
-    primaryId,
-    telegramId: tgIdStr,
-    wallet: null,
-    isLinked: false
-  };
+  return buildAccountSummary({ primaryId, telegramId: tgIdStr });
 }
 
 /**
@@ -71,52 +173,22 @@ async function getOrCreateWalletAccount(walletAddress) {
   let link = await AccountLink.findOne({ wallet });
 
   if (link) {
-    return {
+    return buildAccountSummary({
       primaryId: link.primaryId,
       telegramId: link.telegramId,
       wallet: link.wallet,
       isLinked: !!link.telegramId
-    };
+    });
   }
 
   // Создаём новую связку — primaryId = адрес кошелька
   const primaryId = wallet;
-  link = new AccountLink({
-    telegramId: null,
-    wallet: wallet,
-    primaryId: primaryId,
-    masterSource: null,
-    linkedAt: null
-  });
+  link = buildAccountLink({ primaryId, wallet });
   await link.save();
 
-  // Проверяем/создаём игрока (может уже существовать от старого кода)
-  let player = await Player.findOne({ wallet: primaryId });
-  if (!player) {
-    player = new Player({
-      wallet: primaryId,
-      bestScore: 0,
-      bestDistance: 0,
-      totalGoldCoins: 0,
-      totalSilverCoins: 0,
-      gamesPlayed: 0,
-      gameHistory: []
-    });
-    await player.save();
-  }
+  await ensureAccountResources(primaryId);
 
-  let upgrades = await PlayerUpgrades.findOne({ wallet: primaryId });
-  if (!upgrades) {
-    upgrades = new PlayerUpgrades({ wallet: primaryId });
-    await upgrades.save();
-  }
-
-  return {
-    primaryId,
-    telegramId: null,
-    wallet,
-    isLinked: false
-  };
+  return buildAccountSummary({ primaryId, wallet });
 }
 
 /**
@@ -254,40 +326,30 @@ async function mergeAccounts(primaryIdA, primaryIdB) {
 
   masterLink.linkedAt = new Date();
   masterLink.updatedAt = new Date();
-  masterLink.masterSource = masterLink.primaryId === primaryIdA ? 'a' : 'b';
+  masterLink.masterSource = String(masterLink.primaryId || '').startsWith('tg_') ? 'telegram' : 'wallet';
 
-  // Переносим апгрейды мастера (slave обнуляется)
+  // Объединяем player/upgrades данные в master, затем обнуляем slave
   const masterUpgrades = await PlayerUpgrades.findOne({ wallet: masterLink.primaryId });
   const slaveUpgrades = await PlayerUpgrades.findOne({ wallet: slaveLink.primaryId });
 
+  mergePlayerState(masterPlayer, slavePlayer);
+  masterPlayer.updatedAt = new Date();
+  await masterPlayer.save();
+
+  if (masterUpgrades && slaveUpgrades) {
+    mergeUpgradesState(masterUpgrades, slaveUpgrades);
+    masterUpgrades.updatedAt = new Date();
+    await masterUpgrades.save();
+  }
+
   // Обнуляем slave
   if (slavePlayer) {
-    slavePlayer.bestScore = 0;
-    slavePlayer.bestDistance = 0;
-    slavePlayer.totalGoldCoins = 0;
-    slavePlayer.totalSilverCoins = 0;
-    slavePlayer.gamesPlayed = 0;
-    slavePlayer.gameHistory = [];
+    resetPlayerState(slavePlayer);
     await slavePlayer.save();
   }
 
   if (slaveUpgrades) {
-    slaveUpgrades.x2_duration = 0;
-    slaveUpgrades.score_plus_300_mult = 0;
-    slaveUpgrades.score_plus_500_mult = 0;
-    slaveUpgrades.score_minus_300_mult = 0;
-    slaveUpgrades.score_minus_500_mult = 0;
-    slaveUpgrades.invert_score = 0;
-    slaveUpgrades.speed_up_mult = 0;
-    slaveUpgrades.speed_down_mult = 0;
-    slaveUpgrades.magnet_duration = 0;
-    slaveUpgrades.spin_cooldown = 0;
-    slaveUpgrades.shield = 0;
-    slaveUpgrades.shield_capacity = 0;
-    slaveUpgrades.radar = 0;
-    slaveUpgrades.alert = 0;
-    slaveUpgrades.freeRidesRemaining = 0;
-    slaveUpgrades.paidRidesRemaining = 0;
+    resetUpgradesState(slaveUpgrades);
     await slaveUpgrades.save();
   }
 


### PR DESCRIPTION
### Motivation

- Report real MongoDB readiness on health checks and improve observability for degraded DB states.
- Reduce duplication and hard-to-maintain logic around upgrades, rides and purchases across store routes.
- Improve audit/logging for purchases and strengthen anti-cheat / rate-limiting behavior.
- Make account merge logic clearer and schema-compatible while adding tests for merge behavior.

### Description

- Added `mongoose` to `app.js` and updated `GET /health` to return `mongodb` status mapping, `status` (`OK`/`DEGRADED`), and `mongodbDetails` with `readyState` and human-friendly `status` string.
- Tightened rate limiter configuration by removing special-case `skip` for `/health` and keeping consistent IP-based `keyGenerator` in `middleware/rateLimiter.js`.
- Introduced a small helper `buildLeaderboardEntry` and refactored `/api/leaderboard/top` to reuse it for consistent leaderboard entries in `routes/leaderboard.js`.
- Major refactor in `routes/store.js` extracting helpers: `getOrCreatePlayerUpgrades`, `prepareUpgrades`, `buildRidesData`, `spendPlayerCurrency`, `applyLevelUpgrade`, `validateLevelPurchase`, `createPurchaseAudit`, and `isLevelUpgradeType`, then refactored endpoints (`/upgrades/:wallet`, `/buy`, `/consume-ride`, `/rides/:wallet`) to use these helpers to DRY logic, centralize validation, spending, persistence and purchase auditing.
- Refactored `utils/accountManager.js` to add builders and helpers (`ensurePlayerExists`, `ensureUpgradesExist`, `ensureAccountResources`, `mergePlayerState`, `mergeUpgradesState`, `resetPlayerState`, `resetUpgradesState`) and updated `mergeAccounts` to merge/normalize data uniformly and set `masterSource` to `telegram` or `wallet`.
- Added unit/integration tests: `tests/accountManager.test.js` to validate merge behavior and `tests/api.integration.test.js` extension to assert `/health` reports mongoose connection state.

### Testing

- Ran the new unit test `tests/accountManager.test.js`, which verifies `mergeAccounts` behavior and schema-compatible `masterSource`, and it passed.
- Ran the integration test `tests/api.integration.test.js` addition that verifies `GET /health` reports `mongodbDetails` and overall status, and it passed.
- Ran the existing test suite to ensure no regressions (including leaderboard and save-result flows) and observed no failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c003a448c8832e8a9f3ccd209ddc14)