### PR TITLE
Split radar upgrade into obstacle and gold variants

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,11 +129,16 @@ The store now contains **two parallel product systems**:
 - `alert` (Spin Alert) is now a **2-level permanent progression**:
   - level 1 (`1000 Gold`): `activeEffects.spin_alert_mode = "alert"`
   - level 2 (`3000 Gold`): `activeEffects.spin_alert_mode = "perfect"` and `activeEffects.perfect_spin_enabled = true`
+- `radar_obstacles` is a **1-level permanent progression**:
+  - level 1 (`2000 Gold`): `activeEffects.start_with_radar_obstacles = true`
+- `radar_gold` is a **1-level permanent progression**:
+  - level 1 (`3000 Gold`): `activeEffects.start_with_radar_gold = true`
 - Backward-compatible request aliases for `POST /api/store/buy` are preserved:
   - `spin_alert` → `alert`
   - `spin_perfect` → `alert`
   - `start_with_alert` → `alert`
-  - `start_with_radar` → `radar`
+  - `start_with_radar` → `radar_gold`
+  - `radar` → `radar_gold`
 
 ## Security
 

--- a/models/PlayerUpgrades.js
+++ b/models/PlayerUpgrades.js
@@ -24,7 +24,9 @@ const playerUpgradesSchema = new mongoose.Schema({
   // === GOLD (перманентные/consumable) ===
   shield: { type: Number, default: 0, min: 0, max: 1 },
   shield_capacity: { type: Number, default: 0, min: 0, max: 2 },
-  radar: { type: Number, default: 0, min: 0, max: 1 },
+  radar: { type: Number, default: 0, min: 0, max: 1 }, // legacy: migrated to radar_gold
+  radar_obstacles: { type: Number, default: 0, min: 0, max: 1 },
+  radar_gold: { type: Number, default: 0, min: 0, max: 1 },
   alert: { type: Number, default: 0, min: 0, max: 2 },
 
   // === СИСТЕМА ЗАЕЗДОВ ===

--- a/routes/store.js
+++ b/routes/store.js
@@ -15,7 +15,8 @@ const { logSecurityEvent, normalizeWallet, validateTimestampWindow } = require('
 const UPGRADE_KEY_ALIASES = {
   spin_alert: 'alert',
   start_with_alert: 'alert',
-  start_with_radar: 'radar',
+  start_with_radar: 'radar_gold',
+  radar: 'radar_gold',
   spin_perfect: 'alert'
 };
 
@@ -50,6 +51,17 @@ function normalizeShieldUpgrades(upgrades) {
   return changed;
 }
 
+function normalizeRadarUpgrades(upgrades) {
+  const legacyRadarLevel = upgrades.radar || 0;
+
+  if (legacyRadarLevel > 0 && (!upgrades.radar_gold || upgrades.radar_gold < 1)) {
+    upgrades.radar_gold = 1;
+    return true;
+  }
+
+  return false;
+}
+
 async function getOrCreatePlayerUpgrades(wallet) {
   let upgrades = await PlayerUpgrades.findOne({ wallet });
   if (!upgrades) {
@@ -62,8 +74,9 @@ async function getOrCreatePlayerUpgrades(wallet) {
 async function prepareUpgrades(upgrades, { persist = false } = {}) {
   const ridesChanged = upgrades.refreshFreeRides();
   const shieldChanged = normalizeShieldUpgrades(upgrades);
+  const radarChanged = normalizeRadarUpgrades(upgrades);
 
-  if (persist && (ridesChanged || shieldChanged)) {
+  if (persist && (ridesChanged || shieldChanged || radarChanged)) {
     await upgrades.save();
   }
 
@@ -274,8 +287,8 @@ router.get('/upgrades/:wallet', readLimiter, async (req, res) => {
     if (upgradesData.alert && !upgradesData.spin_alert) {
       upgradesData.spin_alert = { ...upgradesData.alert };
     }
-    if (upgradesData.radar && !upgradesData.start_with_radar) {
-      upgradesData.start_with_radar = { ...upgradesData.radar };
+    if (upgradesData.radar_gold && !upgradesData.start_with_radar) {
+      upgradesData.start_with_radar = { ...upgradesData.radar_gold };
     }
 
     res.json({

--- a/tests/api.integration.test.js
+++ b/tests/api.integration.test.js
@@ -731,6 +731,8 @@ test('GET /api/game/config returns unauth preset built from backend config', asy
   assert.equal(body.preset, 'all_improvements_enabled');
   assert.equal(body.activeEffects.start_with_shield, true);
   assert.equal(body.activeEffects.start_with_radar, true);
+  assert.equal(body.activeEffects.start_with_radar_gold, true);
+  assert.equal(body.activeEffects.start_with_radar_obstacles, true);
   assert.equal(body.activeEffects.perfect_spin_enabled, true);
   assert.equal(body.activeEffects.shield_capacity, 3);
   assert.equal(body.activeEffects.x2_duration_bonus, 15);

--- a/utils/accountManager.js
+++ b/utils/accountManager.js
@@ -16,6 +16,8 @@ const UPGRADE_LEVEL_FIELDS = [
   'spin_cooldown',
   'shield',
   'shield_capacity',
+  'radar_obstacles',
+  'radar_gold',
   'radar',
   'alert'
 ];

--- a/utils/gameModeConfig.js
+++ b/utils/gameModeConfig.js
@@ -13,6 +13,8 @@ const UNAUTH_MAX_UPGRADES = Object.freeze({
   spin_cooldown: 3,
   shield: 1,
   shield_capacity: 2,
+  radar_obstacles: 1,
+  radar_gold: 1,
   radar: 1,
   alert: 2
 });

--- a/utils/upgradesConfig.js
+++ b/utils/upgradesConfig.js
@@ -117,13 +117,22 @@ const UPGRADES_CONFIG = {
     description: "Shield capacity progression: 2 -> 3"
   },
 
-  radar: {
+  radar_obstacles: {
     type: "permanent",
     currency: "gold",
     maxLevel: 1,
-    prices: [goldPrice(1000)],
+    prices: [goldPrice(2000)],
     effects: [true],
-    description: "Radar (permanent)"
+    description: "Obstacle Radar (delayed spawn tracking)"
+  },
+
+  radar_gold: {
+    type: "permanent",
+    currency: "gold",
+    maxLevel: 1,
+    prices: [goldPrice(3000)],
+    effects: [true],
+    description: "Gold Radar (next coin spawn line)"
   },
 
   alert: {
@@ -200,7 +209,10 @@ function calculateEffects(upgrades) {
       ? UPGRADES_CONFIG.shield_capacity.effects[normalizedShieldCapacityLevel - 1]
       : 1,
     start_with_shield: normalizedShieldLevel > 0,
-    start_with_radar: upgrades.radar > 0,
+    start_with_radar_obstacles: upgrades.radar_obstacles > 0,
+    start_with_radar_gold: (upgrades.radar_gold || upgrades.radar || 0) > 0,
+    // Backward compatibility for clients that still read `start_with_radar`.
+    start_with_radar: (upgrades.radar_gold || upgrades.radar || 0) > 0,
     alert_level: upgrades.alert || 0,
     spin_alert_mode: upgrades.alert > 0
       ? UPGRADES_CONFIG.alert.effects[upgrades.alert - 1]


### PR DESCRIPTION
### Motivation
- Separate the single legacy `radar` upgrade into two distinct gameplay improvements so the store can offer an obstacles radar and a gold-coin radar with different prices and behavior.
- Maintain backward compatibility for existing players and clients that still reference the legacy `radar` / `start_with_radar` fields.

### Description
- Replaced single `radar` config with two permanent upgrades: `radar_obstacles` (`2000` Gold) and `radar_gold` (`3000` Gold) in `utils/upgradesConfig.js`, and added `start_with_radar_obstacles` and `start_with_radar_gold` active effects while keeping `start_with_radar` as an alias.
- Added new schema fields `radar_obstacles` and `radar_gold` to `models/PlayerUpgrades.js` and kept legacy `radar` for migration.
- Implemented migration and normalization logic that maps legacy `radar` ownership to `radar_gold` and persists the migration in `routes/store.js`, and updated purchase alias resolution so `start_with_radar` and `radar` resolve to `radar_gold`.
- Propagated new fields to supporting modules and presets by updating `utils/accountManager.js`, `utils/gameModeConfig.js`, `README.md`, and tests (`tests/api.integration.test.js`).

### Testing
- Ran the full test suite with `npm test`, all automated tests passed (`35/35` tests OK).
- Updated integration test `GET /api/game/config` to assert the new `start_with_radar_*` effects and it succeeds under the test run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d17fc315c88324a6c4556168437d4d)