### PR TITLE
Harden API error exposure and fix Telegram /status handler typo

### DIFF
--- a/app.js
+++ b/app.js
@@ -97,7 +97,11 @@ function createApp() {
 
   app.use((err, req, res, next) => {
     logger.error({ err }, 'Unhandled error');
-    res.status(err.status || 500).json({ error: err.message || 'Internal server error' });
+    const statusCode = err.statusCode || err.status || 500;
+    const shouldExposeMessage = Boolean(err.expose) || statusCode < 500;
+    res
+      .status(statusCode)
+      .json({ error: shouldExposeMessage ? (err.message || 'Request failed') : 'Internal server error' });
   });
 
   return app;

--- a/bot.js
+++ b/bot.js
@@ -70,7 +70,7 @@ function registerHandlers(currentBot) {
       const link = await AccountLink.findOne({ telegramId });
 
       if (!link) {
-        currentBbot.sendMessage(msg.chat.id,
+        currentBot.sendMessage(msg.chat.id,
           `❌ No account found.\n\nOpen the game first to create an account!`
         );
         return;


### PR DESCRIPTION
### Motivation
- Prevent leaking internal server error details to clients and fix a bug in the Telegram bot that could crash the `/status` no-account branch.

### Description
- Replace typo `currentBbot` → `currentBot` in `bot.js` so the bot replies correctly when no account is found.
- Harden global Express error middleware in `app.js` to use `err.statusCode`/`err.status` and only expose `err.message` when `err.expose` is true or for non-5xx responses.

### Testing
- Ran `npm run check:syntax` which passed successfully.
- Ran `npm test` and all tests passed (`35` tests, `0` failures).
- Attempted `npm audit --json` which failed in this environment with `403 Forbidden`, so dependency CVE auditing should be run in CI or locally with proper npm access.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d19a183998832497690b4e6b2788cd)