### PR TITLE
Harden CORS, Telegram webhook/auth, rate limiting and remove sensitive logging

### DIFF
--- a/app.js
+++ b/app.js
@@ -39,10 +39,6 @@ function createApp() {
         return;
       }
 
-      if (origin.endsWith('.vercel.app')) {
-        callback(null, true);
-        return;
-      }
 
       logger.warn({ origin }, 'CORS blocked');
       callback(new Error('Not allowed by CORS'));

--- a/docs/next_improvements.md
+++ b/docs/next_improvements.md
@@ -1,0 +1,14 @@
+# Next Improvements Implemented
+
+This iteration implements additional hardening after the initial P0 fixes.
+
+## 1) Strict CORS allowlist
+- Removed permissive wildcard acceptance for all `*.vercel.app` origins.
+- Only explicitly configured origins are allowed.
+
+## 2) Safer IP extraction for rate limiting
+- Normalized `x-forwarded-for` handling to use the first non-empty client IP from the chain.
+- Added fallback to `req.ip`, `remoteAddress`, then `unknown`.
+
+## Validation
+- Added integration coverage to confirm non-whitelisted `*.vercel.app` origins are rejected.

--- a/docs/security_remediation_pipeline.md
+++ b/docs/security_remediation_pipeline.md
@@ -1,0 +1,45 @@
+# Security Remediation Pipeline
+
+## Scope
+This plan addresses the critical findings from the review:
+
+1. Missing Telegram webhook authentication.
+2. Telegram auth route trusting raw `telegramId` from client body.
+3. Sensitive link code value logged in plaintext.
+
+---
+
+## P0 Implementation Plan
+
+### P0.1 Protect Telegram webhook endpoint
+- Add dedicated middleware to validate webhook secret with constant-time comparison.
+- Accept secret from `x-telegram-bot-api-secret-token` (primary) and legacy fallbacks.
+- Fail with `401` when secret is invalid.
+
+### P0.2 Harden Telegram account auth
+- Require Telegram `initData` in `/api/account/auth/telegram`.
+- Validate hash and freshness with `validateTelegramInitData`.
+- Extract user identity only from validated payload.
+
+### P0.3 Stop logging link verification code
+- Remove plaintext `code` from account linking log event.
+- Keep only non-sensitive contextual fields.
+
+---
+
+## Rollout Checklist
+
+1. Configure environment variables in all environments:
+   - `TELEGRAM_BOT_TOKEN`
+   - `TELEGRAM_WEBHOOK_SECRET`
+2. Deploy to staging and run API integration tests.
+3. Verify Telegram Mini App auth login flow.
+4. Verify Telegram webhook pre-checkout and successful payment flow.
+5. Deploy to production with monitoring on 401 rates and payment success rates.
+
+---
+
+## Success Criteria
+- Unauthorized webhook calls cannot reach payment handlers.
+- `/api/account/auth/telegram` rejects invalid or missing Telegram init data.
+- Logs no longer expose one-time link codes.

--- a/middleware/rateLimiter.js
+++ b/middleware/rateLimiter.js
@@ -1,6 +1,21 @@
 const rateLimit = require('express-rate-limit');
 
-const getClientIp = (req) => req.get('x-forwarded-for') || req.ip || req.connection.remoteAddress;
+function getClientIp(req) {
+  const xForwardedFor = req.get('x-forwarded-for');
+
+  if (xForwardedFor && typeof xForwardedFor === 'string') {
+    const firstIp = xForwardedFor
+      .split(',')
+      .map((value) => value.trim())
+      .find(Boolean);
+
+    if (firstIp) {
+      return firstIp;
+    }
+  }
+
+  return req.ip || req.connection.remoteAddress || 'unknown';
+}
 
 // ✅ Строгий лимит для отправки игровых результатов
 const saveResultLimiter = rateLimit({

--- a/middleware/telegramWebhookAuth.js
+++ b/middleware/telegramWebhookAuth.js
@@ -1,0 +1,36 @@
+const crypto = require('crypto');
+
+function timingSafeEqual(a, b) {
+  const left = Buffer.from(String(a || ''));
+  const right = Buffer.from(String(b || ''));
+
+  if (left.length !== right.length) {
+    return false;
+  }
+
+  return crypto.timingSafeEqual(left, right);
+}
+
+function verifyTelegramWebhook(req, res, next) {
+  const expectedSecret = process.env.TELEGRAM_WEBHOOK_SECRET;
+
+  if (!expectedSecret) {
+    return next();
+  }
+
+  const providedSecret = req.get('x-telegram-bot-api-secret-token')
+    || req.get('x-telegram-webhook-secret')
+    || req.query?.secret
+    || req.body?.secret
+    || null;
+
+  if (!providedSecret || !timingSafeEqual(providedSecret, expectedSecret)) {
+    return res.status(401).json({ error: 'Invalid Telegram webhook secret' });
+  }
+
+  return next();
+}
+
+module.exports = {
+  verifyTelegramWebhook
+};

--- a/routes/account.js
+++ b/routes/account.js
@@ -14,8 +14,16 @@ const AccountLink = require('../models/AccountLink');
 const LinkCode = require('../models/LinkCode');
 const logger = require('../utils/logger');
 const { normalizeWallet, validateTimestampWindow } = require('../utils/security');
+const { validateTelegramInitData } = require('../utils/telegramAuth');
 
 const WALLET_TIMESTAMP_WINDOW_MS = Number(process.env.WALLET_AUTH_TIMESTAMP_WINDOW_MS || 10 * 60 * 1000);
+
+function resolveTelegramInitData(req) {
+  return req.body?.telegramInitData
+    || req.body?.initData
+    || req.get('x-telegram-init-data')
+    || '';
+}
 
 /**
  * Generate a random link code like "BEAR-A3F9K2"
@@ -34,11 +42,16 @@ function generateLinkCode() {
  */
 router.post('/auth/telegram', readLimiter, async (req, res) => {
   try {
-    const { telegramId, firstName, username } = req.body;
+    const initData = resolveTelegramInitData(req);
+    const validation = validateTelegramInitData(initData, process.env.TELEGRAM_BOT_TOKEN);
 
-    if (!telegramId) {
-      return res.status(400).json({ error: 'Missing telegramId' });
+    if (!validation.valid) {
+      return res.status(401).json({ error: validation.error });
     }
+
+    const telegramId = String(validation.user.id);
+    const firstName = validation.user.first_name || null;
+    const username = validation.user.username || null;
 
     const account = await getOrCreateTelegramAccount(telegramId);
 
@@ -157,7 +170,7 @@ router.post('/link/request-code', writeLimiter, async (req, res) => {
       expiresAt
     }).save();
 
-    logger.info({ code, primaryId: primaryIdLower }, 'Link code generated');
+    logger.info({ primaryId: primaryIdLower }, 'Link code generated');
 
     res.json({
       success: true,

--- a/routes/donations.js
+++ b/routes/donations.js
@@ -12,6 +12,7 @@ const { validateTelegramInitData } = require('../utils/telegramAuth');
 const { writeLimiter, readLimiter } = require('../middleware/rateLimiter');
 const logger = require('../utils/logger');
 const { logSecurityEvent } = require('../utils/security');
+const { verifyTelegramWebhook } = require('../middleware/telegramWebhookAuth');
 
 function resolveInitData(req) {
   return req.body?.telegramInitData
@@ -125,7 +126,7 @@ router.post('/donations/stars/confirm', writeLimiter, async (req, res) => {
   }
 });
 
-router.post('/telegram/webhook', readLimiter, async (req, res) => {
+router.post('/telegram/webhook', readLimiter, verifyTelegramWebhook, async (req, res) => {
   try {
     const update = req.body || {};
     logger.info({ updateId: update.update_id || null, keys: Object.keys(update) }, 'Telegram payment webhook update received');

--- a/tests/api.integration.test.js
+++ b/tests/api.integration.test.js
@@ -766,6 +766,22 @@ function buildTelegramInitData(user, botToken) {
   return params.toString();
 }
 
+
+test('CORS rejects non-whitelisted *.vercel.app origins', async () => {
+  const { server, baseUrl } = await startServer();
+
+  const res = await fetch(`${baseUrl}/health`, {
+    headers: {
+      Origin: 'https://evil-app.vercel.app'
+    }
+  });
+
+  assert.equal(res.status, 500);
+  assert.equal(res.headers.get('access-control-allow-origin'), null);
+
+  await server.close();
+});
+
 test('OPTIONS /api/donations/stars/create allows Telegram Mini App header in CORS preflight', async () => {
   const { server, baseUrl } = await startServer();
 
@@ -1041,4 +1057,120 @@ test('POST /api/telegram/webhook processes successful_payment idempotently', asy
   assert.equal(history.payments[0].paymentMethodLegacy, 'telegram_stars');
 
   await server.close();
+});
+
+test('POST /api/account/auth/telegram requires valid Telegram init data', async () => {
+  process.env.TELEGRAM_BOT_TOKEN = '123456:stars-token';
+  const { server, baseUrl } = await startServer();
+
+  const invalid = await fetch(`${baseUrl}/api/account/auth/telegram`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ telegramId: '777001' })
+  });
+
+  assert.equal(invalid.status, 401);
+
+  const initData = buildTelegramInitData({ id: 777001, first_name: 'Auth' }, process.env.TELEGRAM_BOT_TOKEN);
+  const valid = await fetch(`${baseUrl}/api/account/auth/telegram`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ telegramInitData: initData })
+  });
+
+  assert.equal(valid.status, 200);
+  const body = await valid.json();
+  assert.equal(body.success, true);
+  assert.equal(body.telegramId, '777001');
+
+  await server.close();
+});
+
+test('POST /api/telegram/webhook rejects requests with missing or invalid secret', async () => {
+  process.env.TELEGRAM_BOT_TOKEN = '123456:stars-token';
+  process.env.TELEGRAM_WEBHOOK_SECRET = 'webhook-secret';
+
+  const { server, baseUrl } = await startServer();
+
+  const missingSecret = await fetch(`${baseUrl}/api/telegram/webhook`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ update_id: 1 })
+  });
+  assert.equal(missingSecret.status, 401);
+
+  const invalidSecret = await fetch(`${baseUrl}/api/telegram/webhook`, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      'x-telegram-bot-api-secret-token': 'wrong-secret'
+    },
+    body: JSON.stringify({ update_id: 2 })
+  });
+  assert.equal(invalidSecret.status, 401);
+
+  const validSecret = await fetch(`${baseUrl}/api/telegram/webhook`, {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      'x-telegram-bot-api-secret-token': process.env.TELEGRAM_WEBHOOK_SECRET
+    },
+    body: JSON.stringify({ update_id: 3 })
+  });
+  assert.equal(validSecret.status, 200);
+
+  delete process.env.TELEGRAM_WEBHOOK_SECRET;
+  await server.close();
+});
+
+test('POST /api/account/link/request-code does not log plaintext verification code', async () => {
+  const logger = require('../utils/logger');
+  const originalInfo = logger.info;
+  const originalDeleteMany = LinkCode.deleteMany;
+  const originalFindOne = LinkCode.findOne;
+
+  const logged = [];
+  let server;
+
+  try {
+    logger.info = (payload, message) => {
+      if (message === 'Link code generated') {
+        logged.push(payload);
+      }
+    };
+
+    LinkCode.deleteMany = async () => ({ deletedCount: 0 });
+    LinkCode.findOne = async () => null;
+    LinkCode.prototype.save = async function save() { return this; };
+
+    const started = await startServer();
+    server = started.server;
+    const { baseUrl } = started;
+
+    const wallet = Wallet.createRandom().address.toLowerCase();
+
+    // Seed wallet account directly for deterministic test
+    await new AccountLink({ primaryId: wallet, wallet }).save();
+
+    const res = await fetch(`${baseUrl}/api/account/link/request-code`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ primaryId: wallet })
+    });
+
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.ok(body.code);
+
+    assert.ok(logged.length >= 1);
+    const latestLog = logged[logged.length - 1] || {};
+    assert.equal(Object.prototype.hasOwnProperty.call(latestLog, 'code'), false);
+  } finally {
+    logger.info = originalInfo;
+    LinkCode.deleteMany = originalDeleteMany;
+    LinkCode.findOne = originalFindOne;
+    if (server) {
+      await server.close();
+    }
+  }
 });


### PR DESCRIPTION
### Motivation
- Close permissive CORS gap that allowed any `*.vercel.app` origin and enforce an explicit allowlist. 
- Protect Telegram webhook endpoint from unauthenticated requests and ensure Telegram auth uses validated init data. 
- Avoid leaking sensitive one-time link codes in logs and make rate-limiter IP extraction more robust. 
- Document the remediation plan and next improvements for rollout clarity.

### Description
- Removed the permissive `origin.endsWith('.vercel.app')` acceptance in `app.js` and rely on an explicit `allowedOrigins` list. 
- Added `middleware/telegramWebhookAuth.js` which validates Telegram webhook secrets using a constant-time comparison and wired it into the `/telegram/webhook` route. 
- Replaced raw `telegramId` trust in `/api/account/auth/telegram` with a `resolveTelegramInitData` helper and `validateTelegramInitData` usage so the route only accepts validated Telegram init payloads and extracts user identity from that payload. 
- Stopped logging plaintext verification `code` in link generation logs, improved client IP extraction in `middleware/rateLimiter.js` to parse the first non-empty IP from `x-forwarded-for` and fallback to `req.ip` or `remoteAddress`, and added documentation files `docs/security_remediation_pipeline.md` and `docs/next_improvements.md` describing the changes and rollout plan. 
- Added integration tests in `tests/api.integration.test.js` covering the new CORS behavior, Telegram auth validation, webhook secret enforcement, and verification that link codes are not logged.

### Testing
- Ran the integration test suite with `npm test`, which includes new tests added to `tests/api.integration.test.js`, and all tests passed. 
- Verified new tests: CORS rejects non-whitelisted `*.vercel.app` origins (passed). 
- Verified Telegram flows: `POST /api/account/auth/telegram` requires valid init data (passed) and `POST /api/telegram/webhook` rejects missing/invalid secret and accepts valid secret (passed). 
- Verified logging change: `POST /api/account/link/request-code` no longer includes the plaintext `code` in the logged payload (passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d2d83b5abc8324bdbf1047a6eb4dbb)