### PR TITLE
Fix CORS allowlist and public unauth API behavior for production frontend

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const cors = require('cors');
 const mongoose = require('mongoose');
+const crypto = require('crypto');
 const leaderboardRoutes = require('./routes/leaderboard');
 const storeRoutes = require('./routes/store');
 const accountRoutes = require('./routes/account');
@@ -21,38 +22,55 @@ function createApp() {
 
   const allowedOrigins = [
     'https://bageus.github.io',
+    'https://bageus-github-io.vercel.app',
     'https://ursass-tube.vercel.app',
     'http://localhost:3000',
     'http://localhost:5173',
     ...extraAllowedOrigins
   ];
 
+  const allowedOriginSet = new Set(allowedOrigins);
+
+  const isAllowedOrigin = (origin) => !origin || allowedOriginSet.has(origin);
+
+  app.use((req, res, next) => {
+    const requestId = req.get('x-request-id') || crypto.randomUUID();
+    req.requestId = requestId;
+    res.setHeader('X-Request-Id', requestId);
+    next();
+  });
+
   const corsOptions = {
     origin: function(origin, callback) {
-      if (!origin) {
+      if (isAllowedOrigin(origin)) {
         callback(null, true);
         return;
       }
 
-      if (allowedOrigins.includes(origin)) {
-        callback(null, true);
-        return;
-      }
-
-
-      logger.warn({ origin }, 'CORS blocked');
+      logger.warn({ origin }, 'CORS blocked: origin mismatch');
       const corsError = new Error('Not allowed by CORS');
       corsError.statusCode = 403;
       corsError.expose = true;
+      corsError.code = 'CORS_ORIGIN_MISMATCH';
       callback(corsError);
     },
     credentials: true,
     methods: ['GET', 'POST', 'OPTIONS'],
-    allowedHeaders: ['Content-Type', 'X-Wallet', 'X-Primary-Id', 'X-Telegram-Init-Data', 'x-telegram-init-data']
+    allowedHeaders: ['Content-Type', 'X-Wallet', 'X-Primary-Id', 'X-Telegram-Init-Data', 'x-telegram-init-data', 'X-Request-Id'],
+    optionsSuccessStatus: 204
   };
 
   app.use(cors(corsOptions));
   app.options('*', cors(corsOptions));
+  app.use((req, res, next) => {
+    const origin = req.get('origin');
+    if (origin && isAllowedOrigin(origin)) {
+      res.setHeader('Access-Control-Allow-Origin', origin);
+      res.setHeader('Vary', 'Origin');
+      res.setHeader('Access-Control-Allow-Credentials', 'true');
+    }
+    next();
+  });
   app.use(express.json({ limit: '1mb' }));
   app.use(metricsMiddleware);
 
@@ -95,12 +113,34 @@ function createApp() {
   });
 
   app.use((err, req, res, next) => {
-    logger.error({ err }, 'Unhandled error');
+    const origin = req.get('origin');
+    if (origin && isAllowedOrigin(origin) && !res.getHeader('Access-Control-Allow-Origin')) {
+      res.setHeader('Access-Control-Allow-Origin', origin);
+      res.setHeader('Vary', 'Origin');
+      res.setHeader('Access-Control-Allow-Credentials', 'true');
+    }
+
     const statusCode = err.statusCode || err.status || 500;
     const shouldExposeMessage = Boolean(err.expose) || statusCode < 500;
+    const errorCode = err.code || 'UNHANDLED_ERROR';
+
+    logger.error({
+      requestId: req.requestId,
+      statusCode,
+      errorCode,
+      origin,
+      path: req.originalUrl,
+      method: req.method,
+      err: err.message
+    }, 'Request failed');
+
     res
       .status(statusCode)
-      .json({ error: shouldExposeMessage ? (err.message || 'Request failed') : 'Internal server error' });
+      .json({
+        error: shouldExposeMessage ? (err.message || 'Request failed') : 'Internal server error',
+        code: errorCode,
+        requestId: req.requestId
+      });
   });
 
   return app;

--- a/routes/game.js
+++ b/routes/game.js
@@ -7,18 +7,26 @@ const { getGameModeConfig } = require('../utils/gameModeConfig');
 router.get('/config', readLimiter, async (req, res) => {
   try {
     const requestedMode = req.query.mode || 'unauth';
+
+    if (String(requestedMode).trim().toLowerCase() === 'unauth') {
+      // Public guest mode: no auth/signature/wallet checks required.
+      const config = getGameModeConfig('unauth');
+      return res.json(config);
+    }
+
     const config = getGameModeConfig(requestedMode);
 
     if (!config) {
       return res.status(404).json({
-        error: `Unknown game mode config: ${requestedMode}`
+        error: `Unknown game mode config: ${requestedMode}`,
+        requestId: req.requestId
       });
     }
 
     res.json(config);
   } catch (error) {
-    logger.error({ err: error }, 'GET /config error');
-    res.status(500).json({ error: 'Server error' });
+    logger.error({ err: error.message, requestId: req.requestId }, 'GET /config error');
+    res.status(500).json({ error: 'Server error', requestId: req.requestId });
   }
 });
 

--- a/routes/leaderboard.js
+++ b/routes/leaderboard.js
@@ -61,10 +61,23 @@ function buildLeaderboardEntry(player, displayName, position) {
   };
 }
 
+function isValidWalletAddress(wallet) {
+  return /^0x[a-fA-F0-9]{40}$/.test(wallet);
+}
+
 // ✅ GET: Top 10 players
 router.get('/top', readLimiter, async (req, res) => {
   try {
-    const wallet = req.query.wallet?.toLowerCase();
+    const walletQuery = typeof req.query.wallet === 'string' ? req.query.wallet.trim() : '';
+    const wallet = walletQuery ? walletQuery.toLowerCase() : null;
+
+    if (wallet && !isValidWalletAddress(wallet)) {
+      logger.warn({ wallet: walletQuery, requestId: req.requestId }, 'GET /top rejected: invalid wallet format');
+      return res.status(400).json({
+        error: 'Invalid wallet format. Expected EVM wallet like 0x... (40 hex chars).',
+        requestId: req.requestId
+      });
+    }
 
     const topPlayers = await Player.find({ bestScore: { $gt: 0 } })
       .sort({ bestScore: -1 })
@@ -117,8 +130,8 @@ router.get('/top', readLimiter, async (req, res) => {
     });
 
   } catch (error) {
-    logger.error({ err: error }, 'GET /top error');
-    res.status(500).json({ error: 'Server error' });
+    logger.error({ err: error.message, requestId: req.requestId }, 'GET /top error');
+    res.status(500).json({ error: 'Server error', requestId: req.requestId });
   }
 });
 

--- a/tests/api.integration.test.js
+++ b/tests/api.integration.test.js
@@ -773,6 +773,61 @@ test('GET /api/game/config returns unauth preset built from backend config', asy
   await server.close();
 });
 
+test('GET /api/leaderboard/top allows empty wallet query and keeps public response contract', async () => {
+  Player.find = () => ({
+    sort() { return this; },
+    limit() { return this; },
+    select() {
+      return Promise.resolve([
+        {
+          wallet: '0x1111111111111111111111111111111111111111',
+          bestScore: 1000,
+          bestDistance: 200,
+          averageScore: 500,
+          scoreToAverageRatio: 2,
+          totalGoldCoins: 10,
+          totalSilverCoins: 20,
+          gamesPlayed: 3
+        }
+      ]);
+    }
+  });
+  AccountLink.find = async () => [];
+  Player.findOne = () => queryResult(null);
+
+  const { server, baseUrl } = await startServer();
+
+  const res = await fetch(`${baseUrl}/api/leaderboard/top?wallet=`, {
+    headers: { Origin: 'https://bageus-github-io.vercel.app' }
+  });
+
+  assert.equal(res.status, 200);
+  assert.equal(res.headers.get('access-control-allow-origin'), 'https://bageus-github-io.vercel.app');
+  const body = await res.json();
+  assert.ok(Array.isArray(body.leaderboard));
+  assert.equal(body.playerPosition, null);
+  assert.equal(body.leaderboard[0].position, 1);
+
+  await server.close();
+});
+
+test('GET /api/leaderboard/top rejects invalid wallet with 400 and CORS headers', async () => {
+  const { server, baseUrl } = await startServer();
+
+  const res = await fetch(`${baseUrl}/api/leaderboard/top?wallet=invalid-wallet`, {
+    headers: { Origin: 'https://bageus-github-io.vercel.app' }
+  });
+
+  assert.equal(res.status, 400);
+  assert.equal(res.headers.get('access-control-allow-origin'), 'https://bageus-github-io.vercel.app');
+  assert.ok(res.headers.get('x-request-id'));
+  const body = await res.json();
+  assert.match(body.error, /Invalid wallet format/i);
+  assert.ok(body.requestId);
+
+  await server.close();
+});
+
 test('GET /api/game/config rejects unknown mode', async () => {
   const { server, baseUrl } = await startServer();
 
@@ -781,6 +836,27 @@ test('GET /api/game/config rejects unknown mode', async () => {
   assert.equal(res.status, 404);
   const body = await res.json();
   assert.match(body.error, /Unknown game mode config/i);
+
+  await server.close();
+});
+
+test('GET /api/v1/game/config?mode=unauth is public and CORS-enabled for production frontend origin', async () => {
+  const { server, baseUrl } = await startServer();
+
+  const res = await fetch(`${baseUrl}/api/v1/game/config?mode=unauth`, {
+    headers: { Origin: 'https://bageus-github-io.vercel.app' }
+  });
+
+  assert.equal(res.status, 200);
+  assert.equal(res.headers.get('access-control-allow-origin'), 'https://bageus-github-io.vercel.app');
+  const body = await res.json();
+  assert.equal(body.mode, 'unauth');
+  assert.equal(body.storeEnabled, false);
+  assert.equal(body.saveProgress, false);
+  assert.equal(body.eligibleForLeaderboard, false);
+  assert.ok(body.rides);
+  assert.ok(body.balance);
+  assert.ok(body.activeEffects);
 
   await server.close();
 });


### PR DESCRIPTION
### Motivation
- Browser requests from the production frontend `https://bageus-github-io.vercel.app` were blocked by CORS (no `Access-Control-Allow-Origin`) and caused `Failed to fetch` errors. 
- CORS headers were missing on non-200 responses which made preflight/4xx/5xx responses unusable by the frontend. 
- `/api/leaderboard/top` and `/api/v1/game/config?mode=unauth` needed deterministic public behavior so guest flows do not get blocked by auth/wallet validation. 
- Better request correlation and logging were required to diagnose future origin/auth failures quickly.

### Description
- Added `https://bageus-github-io.vercel.app` to the backend CORS allowlist and preserved dynamic additions from `CORS_ALLOWED_ORIGINS`. 
- Introduced a request correlation middleware that sets/propagates `X-Request-Id` (`req.requestId`) and includes it in responses and error payloads. 
- Hardened CORS handling: replaced origin checks with an `isAllowedOrigin` helper, added `X-Request-Id` to allowed headers, set `optionsSuccessStatus: 204`, and added middleware to ensure `Access-Control-Allow-*` headers are present for allowed origins (including on error responses). 
- Updated error handler to log structured context (`requestId`, `origin`, `path`, `method`, `statusCode`, `code`) and return `{ error, code, requestId }` in JSON responses. 
- Changed `/api/leaderboard/top` to accept empty/missing `wallet` as public (returns `playerPosition: null`), validate wallet format and return `400` for invalid wallet input (instead of `403`), and include `requestId` on errors. 
- Made `GET /api/v1/game/config?mode=unauth` explicitly public with an early-return guest config so unauth requests are not blocked by auth checks. 
- Added integration tests covering the acceptance criteria for CORS and public endpoints, and small helper `isValidWalletAddress` validation.

### Testing
- Ran `npm run check:syntax` which passed successfully. 
- Ran full test suite with `npm test` and all tests passed (`46` tests, `0` failures). 
- Performed local HTTP verification with a mock server and `curl` showing expected headers and bodies: `GET /api/leaderboard/top?wallet=` returned `200` + `Access-Control-Allow-Origin`, `GET /api/leaderboard/top?wallet=bad` returned `400` + `Access-Control-Allow-Origin`, and `GET /api/v1/game/config?mode=unauth` returned `200` + `Access-Control-Allow-Origin`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d2eaefa3608324b4890cb13d9f0813)