### PR TITLE
Harden production startup config and API security headers

### DIFF
--- a/app.js
+++ b/app.js
@@ -13,6 +13,7 @@ const { metricsMiddleware, renderMetricsText } = require('./middleware/requestMe
 function createApp() {
   const app = express();
 
+  app.disable('x-powered-by');
   app.set('trust proxy', 1);
 
   const extraAllowedOrigins = (process.env.CORS_ALLOWED_ORIGINS || '')
@@ -71,6 +72,21 @@ function createApp() {
     }
     next();
   });
+
+  app.use((req, res, next) => {
+    res.setHeader('X-Content-Type-Options', 'nosniff');
+    res.setHeader('X-Frame-Options', 'DENY');
+    res.setHeader('Referrer-Policy', 'no-referrer');
+    res.setHeader('X-DNS-Prefetch-Control', 'off');
+    res.setHeader('Permissions-Policy', 'camera=(), microphone=(), geolocation=()');
+
+    if ((process.env.NODE_ENV || '').toLowerCase() === 'production') {
+      res.setHeader('Strict-Transport-Security', 'max-age=31536000; includeSubDomains');
+    }
+
+    next();
+  });
+
   app.use(express.json({ limit: '1mb' }));
   app.use(metricsMiddleware);
 

--- a/server.js
+++ b/server.js
@@ -4,8 +4,22 @@ const { initBot } = require('./bot');
 const logger = require('./utils/logger');
 const { createApp } = require('./app');
 const { startDonationPaymentRecheckLoop } = require('./utils/donationService');
+const { validateStartupConfig } = require('./utils/startupConfig');
 
 const app = createApp();
+
+
+const startupValidation = validateStartupConfig();
+startupValidation.warnings.forEach((warning) => {
+  logger.warn({ warning }, 'Startup configuration warning');
+});
+
+if (startupValidation.errors.length > 0) {
+  startupValidation.errors.forEach((error) => {
+    logger.error({ error }, 'Startup configuration error');
+  });
+  process.exit(1);
+}
 
 const runBotInProcess = process.env.BOT_MODE !== 'worker' && process.env.START_BOT_IN_PROCESS !== 'false';
 

--- a/tests/securityHeaders.test.js
+++ b/tests/securityHeaders.test.js
@@ -1,0 +1,33 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { createApp } = require('../app');
+
+async function startServer() {
+  const app = createApp();
+  return new Promise((resolve) => {
+    const server = app.listen(0, '127.0.0.1', () => {
+      resolve({
+        server,
+        url: `http://127.0.0.1:${server.address().port}`
+      });
+    });
+  });
+}
+
+test('security headers are included in API responses', async () => {
+  const { server, url } = await startServer();
+
+  try {
+    const response = await fetch(`${url}/health`);
+
+    assert.equal(response.status, 200);
+    assert.equal(response.headers.get('x-content-type-options'), 'nosniff');
+    assert.equal(response.headers.get('x-frame-options'), 'DENY');
+    assert.equal(response.headers.get('referrer-policy'), 'no-referrer');
+    assert.equal(response.headers.get('x-dns-prefetch-control'), 'off');
+    assert.equal(response.headers.get('permissions-policy'), 'camera=(), microphone=(), geolocation=()');
+  } finally {
+    await new Promise((resolve) => server.close(resolve));
+  }
+});

--- a/tests/startupConfig.test.js
+++ b/tests/startupConfig.test.js
@@ -1,0 +1,28 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { validateStartupConfig } = require('../utils/startupConfig');
+
+test('validateStartupConfig returns production errors for missing required vars', () => {
+  const result = validateStartupConfig({ NODE_ENV: 'production' });
+
+  assert.equal(result.isProduction, true);
+  assert.ok(result.errors.some((item) => item.includes('MONGO_URL')));
+  assert.ok(result.errors.some((item) => item.includes('TELEGRAM_BOT_TOKEN')));
+  assert.ok(result.errors.some((item) => item.includes('TELEGRAM_BOT_SECRET')));
+  assert.ok(result.errors.some((item) => item.includes('TELEGRAM_WEBHOOK_SECRET')));
+});
+
+test('validateStartupConfig warns on localhost origins', () => {
+  const result = validateStartupConfig({
+    NODE_ENV: 'production',
+    MONGO_URL: 'mongodb://localhost:27017/db',
+    TELEGRAM_BOT_TOKEN: 'token',
+    TELEGRAM_BOT_SECRET: 'secret',
+    TELEGRAM_WEBHOOK_SECRET: 'webhook-secret',
+    CORS_ALLOWED_ORIGINS: 'https://example.com,http://localhost:3000'
+  });
+
+  assert.equal(result.errors.length, 0);
+  assert.ok(result.warnings.some((item) => item.includes('localhost')));
+});

--- a/utils/startupConfig.js
+++ b/utils/startupConfig.js
@@ -1,0 +1,50 @@
+function normalizeList(value) {
+  return String(value || '')
+    .split(',')
+    .map((item) => item.trim())
+    .filter(Boolean);
+}
+
+function validateStartupConfig(env = process.env) {
+  const mode = String(env.NODE_ENV || 'development').toLowerCase();
+  const isProduction = mode === 'production';
+
+  const errors = [];
+  const warnings = [];
+
+  const requiredInProduction = [
+    'MONGO_URL',
+    'TELEGRAM_BOT_TOKEN',
+    'TELEGRAM_BOT_SECRET',
+    'TELEGRAM_WEBHOOK_SECRET'
+  ];
+
+  if (isProduction) {
+    requiredInProduction.forEach((name) => {
+      if (!String(env[name] || '').trim()) {
+        errors.push(`Missing required env var in production: ${name}`);
+      }
+    });
+  }
+
+  const allowedOrigins = normalizeList(env.CORS_ALLOWED_ORIGINS);
+  const localhostOrigins = allowedOrigins.filter((origin) => origin.includes('localhost') || origin.includes('127.0.0.1'));
+
+  if (isProduction && allowedOrigins.length === 0) {
+    warnings.push('CORS_ALLOWED_ORIGINS is empty in production; only built-in origins will be accepted.');
+  }
+
+  if (localhostOrigins.length > 0) {
+    warnings.push(`Local origins present in CORS_ALLOWED_ORIGINS: ${localhostOrigins.join(', ')}`);
+  }
+
+  return {
+    isProduction,
+    errors,
+    warnings
+  };
+}
+
+module.exports = {
+  validateStartupConfig
+};


### PR DESCRIPTION
### Motivation
- Prevent accidental startup in production without critical secrets and reduce attack surface by enabling sensible HTTP security defaults.

### Description
- Add `utils/startupConfig.js` with `validateStartupConfig()` to check required production env vars (`MONGO_URL`, `TELEGRAM_BOT_TOKEN`, `TELEGRAM_BOT_SECRET`, `TELEGRAM_WEBHOOK_SECRET`) and warn about risky `CORS_ALLOWED_ORIGINS` (e.g., localhost entries).
- Enforce startup validation in `server.js` by logging warnings and failing fast with `process.exit(1)` when production-required vars are missing.
- Harden Express defaults in `app.js` by calling `app.disable('x-powered-by')` and adding baseline security headers (`X-Content-Type-Options`, `X-Frame-Options`, `Referrer-Policy`, `X-DNS-Prefetch-Control`, `Permissions-Policy`) and conditional `Strict-Transport-Security` in production.
- Add tests `tests/startupConfig.test.js` and `tests/securityHeaders.test.js` that assert the startup validation behavior and presence of security headers.

### Testing
- Ran the test suite with `npm test`, all tests passed (`49` tests, `0` failures).
- Ran syntax validation with `npm run check:syntax`, which completed successfully and reported no syntax issues.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d416858cd88320983714756fc715c2)