### PR TITLE
Add analytics batch ingest endpoint and observability metrics

### DIFF
--- a/app.js
+++ b/app.js
@@ -7,6 +7,7 @@ const storeRoutes = require('./routes/store');
 const accountRoutes = require('./routes/account');
 const gameRoutes = require('./routes/game');
 const donationsRoutes = require('./routes/donations');
+const analyticsRoutes = require('./routes/analytics');
 const logger = require('./utils/logger');
 const { metricsMiddleware, renderMetricsText } = require('./middleware/requestMetrics');
 
@@ -95,12 +96,14 @@ function createApp() {
   app.use('/api/account', accountRoutes);
   app.use('/api/game', gameRoutes);
   app.use('/api', donationsRoutes);
+  app.use('/api/analytics', analyticsRoutes);
 
   app.use('/api/v1/leaderboard', leaderboardRoutes);
   app.use('/api/v1/store', storeRoutes);
   app.use('/api/v1/account', accountRoutes);
   app.use('/api/v1/game', gameRoutes);
   app.use('/api/v1', donationsRoutes);
+  app.use('/api/v1/analytics', analyticsRoutes);
 
   app.get('/health', (req, res) => {
     const mongoStates = {
@@ -123,9 +126,13 @@ function createApp() {
     });
   });
 
-  app.get('/metrics', (req, res) => {
-    res.set('Content-Type', 'text/plain; version=0.0.4; charset=utf-8');
-    res.end(renderMetricsText());
+  app.get('/metrics', async (req, res, next) => {
+    try {
+      res.set('Content-Type', 'text/plain; version=0.0.4; charset=utf-8');
+      res.end(await renderMetricsText());
+    } catch (error) {
+      next(error);
+    }
   });
 
   app.use((err, req, res, next) => {

--- a/docs/backend-prod-alignment-2026-04-07-ru.md
+++ b/docs/backend-prod-alignment-2026-04-07-ru.md
@@ -1,0 +1,27 @@
+# Backend alignment plan к прод-выводу (07.04.2026)
+
+## Что синхронизировано в этом PR
+
+### P1.2 Аналитика (обязательно)
+- Реализован ingest endpoint `POST /api/analytics/events`.
+- Поддержан батч-контракт фронтенда: корневые поля `sentAt` и `events[]`.
+- Валидация/нормализация событий:
+  - допускаются `game_start`, `game_end`, `session_length`, `run_duration`, `upgrade_purchase`, `currency_spent`;
+  - обязательны `name` и `timestamp`;
+  - payload очищается от `undefined` и функций.
+- Добавлено сохранение событий в Mongo (`AnalyticsEvent`) через `insertMany`.
+- Добавлены метрики ingest-надежности для observability gate:
+  - `app_analytics_ingest_total{status="accepted|invalid|stored|failed"}`.
+
+### Контрактная совместимость API (P1.3/P0/P1.1)
+- Проверена совместимость существующих backend endpoint’ов, активно используемых frontend:
+  - auth: `/api/account/auth/*`;
+  - store/donation: `/api/store/*`, `/api/donations/*`;
+  - leaderboard: `/api/leaderboard/*`.
+- Регрессионные integration-тесты оставлены обязательными в `npm test`.
+
+## Ближайшие шаги (после merge)
+1. Подключить экспорт analytics из Mongo в warehouse/reporting (cron/stream).
+2. Добавить SLO/алерты на `failed > 0` и `invalid` всплески.
+3. В CI окружении с доступом к advisories сделать обязательный security gate (`npm audit --omit=dev --audit-level=moderate`).
+4. Добавить CI parity check Node major-version (22+) по аналогии с frontend release gates.

--- a/middleware/requestMetrics.js
+++ b/middleware/requestMetrics.js
@@ -2,6 +2,12 @@ const state = {
   requestCount: 0,
   byRoute: {},
   suspiciousEvents: {},
+  analyticsIngest: {
+    accepted: 0,
+    invalid: 0,
+    stored: 0,
+    failed: 0
+  },
   durationBuckets: {
     le_50: 0,
     le_100: 0,
@@ -70,6 +76,13 @@ function markSuspicious(type = 'generic') {
   state.suspiciousEvents[type] = (state.suspiciousEvents[type] || 0) + 1;
 }
 
+function markAnalyticsIngest({ accepted = 0, invalid = 0, stored = 0, failed = 0 } = {}) {
+  state.analyticsIngest.accepted += Math.max(0, Number(accepted) || 0);
+  state.analyticsIngest.invalid += Math.max(0, Number(invalid) || 0);
+  state.analyticsIngest.stored += Math.max(0, Number(stored) || 0);
+  state.analyticsIngest.failed += Math.max(0, Number(failed) || 0);
+}
+
 async function renderMetricsText() {
   const lines = [];
   lines.push('# TYPE app_requests_total counter');
@@ -91,6 +104,11 @@ async function renderMetricsText() {
     lines.push(`app_request_duration_buckets_total{bucket="${bucket}"} ${count}`);
   }
 
+  lines.push('# TYPE app_analytics_ingest_total counter');
+  for (const [type, count] of Object.entries(state.analyticsIngest)) {
+    lines.push(`app_analytics_ingest_total{status="${type}"} ${count}`);
+  }
+
   lines.push('# TYPE app_suspicious_events_total counter');
   for (const [type, count] of Object.entries(state.suspiciousEvents)) {
     const safeType = type.replace(/"/g, '\\"');
@@ -103,5 +121,6 @@ async function renderMetricsText() {
 module.exports = {
   metricsMiddleware,
   markSuspicious,
+  markAnalyticsIngest,
   renderMetricsText
 };

--- a/models/AnalyticsEvent.js
+++ b/models/AnalyticsEvent.js
@@ -1,0 +1,47 @@
+const mongoose = require('mongoose');
+
+const ANALYTICS_EVENT_TYPES = Object.freeze([
+  'game_start',
+  'game_end',
+  'session_length',
+  'run_duration',
+  'upgrade_purchase',
+  'currency_spent'
+]);
+
+const analyticsEventSchema = new mongoose.Schema({
+  eventType: {
+    type: String,
+    required: true,
+    enum: ANALYTICS_EVENT_TYPES,
+    index: true
+  },
+  timestamp: {
+    type: Number,
+    required: true,
+    min: 0,
+    index: true
+  },
+  sentAt: {
+    type: Number,
+    required: true,
+    min: 0,
+    index: true
+  },
+  payload: {
+    type: mongoose.Schema.Types.Mixed,
+    default: {}
+  },
+  receivedAt: {
+    type: Date,
+    default: Date.now,
+    index: true
+  }
+}, { minimize: false });
+
+analyticsEventSchema.index({ eventType: 1, timestamp: -1 });
+
+module.exports = {
+  AnalyticsEvent: mongoose.model('AnalyticsEvent', analyticsEventSchema),
+  ANALYTICS_EVENT_TYPES
+};

--- a/routes/analytics.js
+++ b/routes/analytics.js
@@ -1,0 +1,127 @@
+const express = require('express');
+
+const { AnalyticsEvent, ANALYTICS_EVENT_TYPES } = require('../models/AnalyticsEvent');
+const { readLimiter } = require('../middleware/rateLimiter');
+const logger = require('../utils/logger');
+const { markAnalyticsIngest } = require('../middleware/requestMetrics');
+
+const router = express.Router();
+
+const MAX_BATCH_SIZE = 100;
+
+function normalizePayload(payload) {
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
+    return {};
+  }
+
+  const normalized = {};
+  for (const [key, value] of Object.entries(payload)) {
+    if (value === undefined || typeof value === 'function') {
+      continue;
+    }
+    normalized[key] = value;
+  }
+
+  return normalized;
+}
+
+function parseNonNegativeNumber(value) {
+  const normalized = typeof value === 'number' ? value : Number(value);
+  if (!Number.isFinite(normalized) || normalized < 0) {
+    return null;
+  }
+  return normalized;
+}
+
+function validateAndNormalizeEvent(inputEvent) {
+  if (!inputEvent || typeof inputEvent !== 'object' || Array.isArray(inputEvent)) {
+    return { error: 'Each event must be an object' };
+  }
+
+  const eventType = String(inputEvent.name || '').trim();
+  if (!ANALYTICS_EVENT_TYPES.includes(eventType)) {
+    return { error: `Unsupported analytics event type: ${eventType || 'empty'}` };
+  }
+
+  const timestamp = parseNonNegativeNumber(inputEvent.timestamp);
+  if (timestamp === null) {
+    return { error: `Invalid event timestamp for ${eventType}` };
+  }
+
+  const payload = normalizePayload(inputEvent.payload);
+
+  return {
+    eventType,
+    timestamp,
+    payload
+  };
+}
+
+router.post('/events', readLimiter, async (req, res, next) => {
+  try {
+    const sentAt = parseNonNegativeNumber(req.body?.sentAt);
+    const events = req.body?.events;
+
+    if (sentAt === null) {
+      const err = new Error('sentAt is required and must be a non-negative number');
+      err.statusCode = 400;
+      err.code = 'ANALYTICS_INVALID_SENT_AT';
+      err.expose = true;
+      throw err;
+    }
+
+    if (!Array.isArray(events) || events.length === 0) {
+      const err = new Error('events must be a non-empty array');
+      err.statusCode = 400;
+      err.code = 'ANALYTICS_INVALID_EVENTS_BATCH';
+      err.expose = true;
+      throw err;
+    }
+
+    if (events.length > MAX_BATCH_SIZE) {
+      const err = new Error(`events batch is too large (max ${MAX_BATCH_SIZE})`);
+      err.statusCode = 413;
+      err.code = 'ANALYTICS_BATCH_TOO_LARGE';
+      err.expose = true;
+      throw err;
+    }
+
+    const normalizedEvents = [];
+    for (let index = 0; index < events.length; index += 1) {
+      const normalized = validateAndNormalizeEvent(events[index]);
+      if (normalized.error) {
+        markAnalyticsIngest({ invalid: 1 });
+        const err = new Error(`Invalid event at index ${index}: ${normalized.error}`);
+        err.statusCode = 400;
+        err.code = 'ANALYTICS_INVALID_EVENT';
+        err.expose = true;
+        throw err;
+      }
+
+      normalizedEvents.push({
+        ...normalized,
+        sentAt
+      });
+    }
+
+    markAnalyticsIngest({ accepted: normalizedEvents.length });
+
+    await AnalyticsEvent.insertMany(normalizedEvents, { ordered: false });
+    markAnalyticsIngest({ stored: normalizedEvents.length });
+
+    res.status(202).json({
+      ok: true,
+      accepted: normalizedEvents.length,
+      dropped: 0
+    });
+  } catch (error) {
+    if (error.code !== 'ANALYTICS_INVALID_EVENT' && error.code !== 'ANALYTICS_INVALID_SENT_AT' && error.code !== 'ANALYTICS_INVALID_EVENTS_BATCH' && error.code !== 'ANALYTICS_BATCH_TOO_LARGE') {
+      markAnalyticsIngest({ failed: 1 });
+      logger.error({ err: error.message, route: '/api/analytics/events' }, 'Failed to persist analytics events');
+    }
+
+    next(error);
+  }
+});
+
+module.exports = router;

--- a/tests/api.integration.test.js
+++ b/tests/api.integration.test.js
@@ -10,6 +10,7 @@ const SecurityEvent = require('../models/SecurityEvent');
 const LinkCode = require('../models/LinkCode');
 const DonationPayment = require('../models/DonationPayment');
 const AccountLink = require('../models/AccountLink');
+const { AnalyticsEvent } = require('../models/AnalyticsEvent');
 const { setDonationVerifierForTests, resetDonationVerifier } = require('../utils/donationService');
 const { setTelegramStarsClientForTests } = require('../utils/telegramStarsService');
 const { resetTelegramWebhookReplayStore } = require('../utils/telegramWebhookReplay');
@@ -169,6 +170,7 @@ test.beforeEach(() => {
     return chain;
   };
   resetDonationVerifier();
+  AnalyticsEvent.insertMany = async (docs) => docs;
 });
 
 test('POST /api/leaderboard/save rejects invalid signature', async () => {
@@ -1362,4 +1364,69 @@ test('POST /api/account/link/request-code does not log plaintext verification co
       await server.close();
     }
   }
+});
+
+
+test('POST /api/analytics/events accepts valid analytics batch', async () => {
+  const inserted = [];
+  AnalyticsEvent.insertMany = async (docs) => {
+    inserted.push(...docs);
+    return docs;
+  };
+
+  const { server, baseUrl } = await startServer();
+  const sentAt = Date.now();
+  const res = await fetch(`${baseUrl}/api/analytics/events`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      sentAt,
+      events: [
+        { name: 'game_start', timestamp: sentAt - 1000, payload: { sessionId: 's1' } },
+        { name: 'currency_spent', timestamp: sentAt - 500, payload: { amount: 50, currency: 'coins' } }
+      ]
+    })
+  });
+
+  assert.equal(res.status, 202);
+  const body = await res.json();
+  assert.equal(body.ok, true);
+  assert.equal(body.accepted, 2);
+  assert.equal(inserted.length, 2);
+  assert.equal(inserted[0].eventType, 'game_start');
+  assert.equal(inserted[0].sentAt, sentAt);
+
+  const metricsRes = await fetch(`${baseUrl}/metrics`);
+  const metricsText = await metricsRes.text();
+  assert.match(metricsText, /app_analytics_ingest_total\{status="accepted"\} 2/);
+  assert.match(metricsText, /app_analytics_ingest_total\{status="stored"\} 2/);
+
+  await server.close();
+});
+
+test('POST /api/analytics/events rejects unsupported event type', async () => {
+  AnalyticsEvent.insertMany = async () => {
+    throw new Error('insertMany should not be called for invalid payload');
+  };
+
+  const { server, baseUrl } = await startServer();
+  const sentAt = Date.now();
+  const res = await fetch(`${baseUrl}/api/analytics/events`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      sentAt,
+      events: [{ name: 'unknown_event', timestamp: sentAt }]
+    })
+  });
+
+  assert.equal(res.status, 400);
+  const body = await res.json();
+  assert.equal(body.code, 'ANALYTICS_INVALID_EVENT');
+
+  const metricsRes = await fetch(`${baseUrl}/metrics`);
+  const metricsText = await metricsRes.text();
+  assert.match(metricsText, /app_analytics_ingest_total\{status="invalid"\} 1/);
+
+  await server.close();
 });


### PR DESCRIPTION
### Motivation
- Frontend now sends analytics batches to `/api/analytics/events` for P1.2, so the backend must accept, validate, persist and expose ingest reliability metrics for the production release gate. 
- Ensure backend remains compatible with existing auth/store/donation/leaderboard API contracts while adding minimal infra for observability and CI/security follow-ups.

### Description
- Added a new `AnalyticsEvent` model (`models/AnalyticsEvent.js`) to store `eventType`, `timestamp`, `sentAt`, `payload` and `receivedAt` with appropriate indexes and allowed event types. 
- Implemented `POST /api/analytics/events` endpoint (`routes/analytics.js`) with batch validation, normalization, capped batch size (`MAX_BATCH_SIZE = 100`), per-event validation for supported types and reliable `insertMany` persistence. 
- Wired analytics routes under both `/api/analytics` and `/api/v1/analytics`, extended `/metrics` rendering to be `async` and added ingest counters plus `markAnalyticsIngest` in `middleware/requestMetrics.js` to expose `app_analytics_ingest_total{status=

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d59591656c8320b3b0c666f7151d96)