### PR TITLE
Add backward-compatible /api/analytics/event ingest route

### DIFF
--- a/routes/analytics.js
+++ b/routes/analytics.js
@@ -57,18 +57,27 @@ function validateAndNormalizeEvent(inputEvent) {
   };
 }
 
-router.post('/events', readLimiter, async (req, res, next) => {
-  try {
-    const sentAt = parseNonNegativeNumber(req.body?.sentAt);
-    const events = req.body?.events;
+function buildEventsBatch(body, isSingleEventRoute = false) {
+  const sentAt = parseNonNegativeNumber(body?.sentAt);
+  if (sentAt === null) {
+    const err = new Error('sentAt is required and must be a non-negative number');
+    err.statusCode = 400;
+    err.code = 'ANALYTICS_INVALID_SENT_AT';
+    err.expose = true;
+    throw err;
+  }
 
-    if (sentAt === null) {
-      const err = new Error('sentAt is required and must be a non-negative number');
-      err.statusCode = 400;
-      err.code = 'ANALYTICS_INVALID_SENT_AT';
-      err.expose = true;
-      throw err;
-    }
+  if (isSingleEventRoute) {
+    const singleEvent = body?.event && typeof body.event === 'object' && !Array.isArray(body.event) ? body.event : body;
+    return { sentAt, events: [singleEvent] };
+  }
+
+  return { sentAt, events: body?.events };
+}
+
+async function ingestEvents(req, res, next, isSingleEventRoute = false) {
+  try {
+    const { sentAt, events } = buildEventsBatch(req.body, isSingleEventRoute);
 
     if (!Array.isArray(events) || events.length === 0) {
       const err = new Error('events must be a non-empty array');
@@ -122,6 +131,14 @@ router.post('/events', readLimiter, async (req, res, next) => {
 
     next(error);
   }
+}
+
+router.post('/events', readLimiter, async (req, res, next) => {
+  await ingestEvents(req, res, next, false);
+});
+
+router.post('/event', readLimiter, async (req, res, next) => {
+  await ingestEvents(req, res, next, true);
 });
 
 module.exports = router;

--- a/tests/api.integration.test.js
+++ b/tests/api.integration.test.js
@@ -1430,3 +1430,34 @@ test('POST /api/analytics/events rejects unsupported event type', async () => {
 
   await server.close();
 });
+
+test('POST /api/analytics/event accepts a single analytics event payload', async () => {
+  const inserted = [];
+  AnalyticsEvent.insertMany = async (docs) => {
+    inserted.push(...docs);
+    return docs;
+  };
+
+  const { server, baseUrl } = await startServer();
+  const sentAt = Date.now();
+  const res = await fetch(`${baseUrl}/api/analytics/event`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      sentAt,
+      name: 'game_start',
+      timestamp: sentAt - 1000,
+      payload: { sessionId: 'single-route' }
+    })
+  });
+
+  assert.equal(res.status, 202);
+  const body = await res.json();
+  assert.equal(body.ok, true);
+  assert.equal(body.accepted, 1);
+  assert.equal(inserted.length, 1);
+  assert.equal(inserted[0].eventType, 'game_start');
+  assert.equal(inserted[0].payload.sessionId, 'single-route');
+
+  await server.close();
+});


### PR DESCRIPTION
### Motivation
- Frontend and backend had a mismatch for single-event ingestion path so clients sending one analytics event need a compatible route.
- Share validation, metrics and persistence logic between batch and single-event flows to avoid divergent behavior.

### Description
- Refactored ingestion to shared helpers by adding `buildEventsBatch` and `ingestEvents` and moved common validation/metrics/persistence into them (`routes/analytics.js`).
- Added a backward-compatible `POST /api/analytics/event` endpoint that accepts either top-level event fields (`sentAt`, `name`, `timestamp`, `payload`) or `{ sentAt, event: {...} }` and delegates to the common ingest path.
- Kept existing `POST /api/analytics/events` behavior but now routed through the same `ingestEvents` function to preserve metric labels and error handling.
- Added an integration test for the new single-event route in `tests/api.integration.test.js` to assert `202`, `accepted=1` and correct normalization/storage.

### Testing
- Ran the integration test suite with `NODE_ENV=test node --test tests/api.integration.test.js`, which completed successfully.
- All tests passed: 37 tests ran and 0 failed, including the new `POST /api/analytics/event` test.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6b076827c83249b8f44e12fac778d)