### PR TITLE
docs: clarify analytics endpoint host usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,15 @@ Versioned aliases are also available under `/api/v1/*` (backward-compatible with
 | `POST` | `/api/account/link/request-code` | Generate a 6-character code to link Telegram to a wallet |
 | `GET` | `/api/account/info` | Get account info |
 | `GET` | `/api/game/config?mode=unauth` | Get runtime config for non-persistent game modes |
+| `POST` | `/api/analytics/events` | Ingest analytics events batch (`{ sentAt, events: [...] }`) |
+| `POST` | `/api/analytics/event` | Ingest a single analytics event (`{ sentAt, event: {...} }`) |
+
+
+## Frontend Integration Note
+
+- `https://bageus-github-io.vercel.app` is a frontend origin and is allowed by CORS.
+- API requests must target the deployed backend host (for example, Railway), not the frontend host itself.
+- If you send `POST https://bageus-github-io.vercel.app/api/analytics/events`, Vercel frontend hosting may return `404 Not Found` because that route is not served there.
 
 
 


### PR DESCRIPTION
### Motivation
- Prevent confusion about where analytics POSTs should be sent by documenting the ingest endpoints and explaining why posting to the frontend Vercel domain can produce a `404 Not Found`.

### Description
- Added `/api/analytics/events` and `/api/analytics/event` entries to the API endpoints table in `README.md` and added a "Frontend Integration Note" clarifying that `https://bageus-github-io.vercel.app` is an allowed browser origin (CORS) but is not the backend API host and that API requests must target the deployed backend (for example, Railway), otherwise Vercel may return 404.

### Testing
- Ran `npm run check:syntax` which completed successfully (syntax check passed for all project JS files).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6cf1ba3688320901384bf75992fc6)