### PR TITLE
fix: add Vercel API routing for analytics ingestion

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,15 @@ Versioned aliases are also available under `/api/v1/*` (backward-compatible with
 | `POST` | `/api/account/link/request-code` | Generate a 6-character code to link Telegram to a wallet |
 | `GET` | `/api/account/info` | Get account info |
 | `GET` | `/api/game/config?mode=unauth` | Get runtime config for non-persistent game modes |
+| `POST` | `/api/analytics/events` | Ingest analytics events batch (`{ sentAt, events: [...] }`) |
+| `POST` | `/api/analytics/event` | Ingest a single analytics event (`{ sentAt, event: {...} }`) |
+
+
+## Frontend Integration Note
+
+- `https://bageus-github-io.vercel.app` is a frontend origin and is allowed by CORS.
+- API requests must target the deployed backend host (for example, Railway), not the frontend host itself.
+- If you send `POST https://bageus-github-io.vercel.app/api/analytics/events`, Vercel frontend hosting may return `404 Not Found` because that route is not served there.
 
 
 

--- a/api/index.js
+++ b/api/index.js
@@ -1,0 +1,36 @@
+require('dotenv').config();
+
+const mongoose = require('mongoose');
+const connectDB = require('../database');
+const { createApp } = require('../app');
+const logger = require('../utils/logger');
+
+const app = createApp();
+let dbConnectPromise = null;
+
+async function ensureDatabaseConnection() {
+  if (mongoose.connection.readyState === 1) {
+    return;
+  }
+
+  if (!dbConnectPromise) {
+    dbConnectPromise = connectDB().catch((error) => {
+      dbConnectPromise = null;
+      throw error;
+    });
+  }
+
+  await dbConnectPromise;
+}
+
+module.exports = async (req, res) => {
+  try {
+    await ensureDatabaseConnection();
+    app(req, res);
+  } catch (error) {
+    logger.error({ err: error.message }, 'Failed to initialize API handler on Vercel');
+    res.statusCode = 500;
+    res.setHeader('Content-Type', 'application/json; charset=utf-8');
+    res.end(JSON.stringify({ error: 'Service initialization failed' }));
+  }
+};

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,23 @@
+{
+  "version": 2,
+  "builds": [
+    {
+      "src": "api/index.js",
+      "use": "@vercel/node"
+    }
+  ],
+  "routes": [
+    {
+      "src": "/api/(.*)",
+      "dest": "/api/index.js"
+    },
+    {
+      "src": "/health",
+      "dest": "/api/index.js"
+    },
+    {
+      "src": "/metrics",
+      "dest": "/api/index.js"
+    }
+  ]
+}


### PR DESCRIPTION
### Motivation
- Browser runtime logs showed `POST https://bageus-github-io.vercel.app/api/analytics/events` returning `404 Not Found` because the frontend Vercel host was not routing API requests to the backend handler.
- The backend already implements analytics ingest endpoints, so the platform routing and documentation needed to be added to allow those endpoints to function when deployed on Vercel.

### Description
- Added a Vercel serverless entrypoint `api/index.js` that boots the existing Express app and ensures MongoDB is connected before handling requests, with a shared `dbConnectPromise` to avoid duplicate connect attempts and defensive error handling that returns a JSON 500 on init failure.
- Added `vercel.json` to configure the Vercel build and routes so `/api/*` (including `/api/analytics/events`), `/health`, and `/metrics` are forwarded to the serverless handler.
- Updated `README.md` to document the analytics ingest endpoints (`/api/analytics/events` and `/api/analytics/event`) and added a "Frontend Integration Note" explaining that `https://bageus-github-io.vercel.app` is a frontend origin (CORS-allowed) but is not the backend API host and posting to it may return `404`.

### Testing
- Ran `npm run check:syntax`, which completed successfully (`Syntax check passed for 44 JavaScript files`).
- Ran `npm test`, which executed the test suite and all tests passed (`54` tests, `0` failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6cf1ba3688320901384bf75992fc6)