### PR TITLE
Add Vercel serverless API handler, DB connection management, rewrites, and README updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,15 @@ Versioned aliases are also available under `/api/v1/*` (backward-compatible with
 | `POST` | `/api/account/link/request-code` | Generate a 6-character code to link Telegram to a wallet |
 | `GET` | `/api/account/info` | Get account info |
 | `GET` | `/api/game/config?mode=unauth` | Get runtime config for non-persistent game modes |
+| `POST` | `/api/analytics/events` | Ingest analytics events batch (`{ sentAt, events: [...] }`) |
+| `POST` | `/api/analytics/event` | Ingest a single analytics event (`{ sentAt, event: {...} }`) |
+
+
+## Frontend Integration Note
+
+- `https://bageus-github-io.vercel.app` is a frontend origin and is allowed by CORS.
+- API requests must target the deployed backend host (for example, Railway), not the frontend host itself.
+- If you send `POST https://bageus-github-io.vercel.app/api/analytics/events`, Vercel frontend hosting may return `404 Not Found` because that route is not served there.
 
 
 

--- a/api/[...all].js
+++ b/api/[...all].js
@@ -1,0 +1,1 @@
+module.exports = require('./handler');

--- a/api/handler.js
+++ b/api/handler.js
@@ -1,0 +1,36 @@
+require('dotenv').config();
+
+const mongoose = require('mongoose');
+const connectDB = require('../database');
+const { createApp } = require('../app');
+const logger = require('../utils/logger');
+
+const app = createApp();
+let dbConnectPromise = null;
+
+async function ensureDatabaseConnection() {
+  if (mongoose.connection.readyState === 1) {
+    return;
+  }
+
+  if (!dbConnectPromise) {
+    dbConnectPromise = connectDB().catch((error) => {
+      dbConnectPromise = null;
+      throw error;
+    });
+  }
+
+  await dbConnectPromise;
+}
+
+module.exports = async (req, res) => {
+  try {
+    await ensureDatabaseConnection();
+    return app(req, res);
+  } catch (error) {
+    logger.error({ err: error.message, path: req.url }, 'Failed to initialize API handler on Vercel');
+    res.statusCode = 500;
+    res.setHeader('Content-Type', 'application/json; charset=utf-8');
+    res.end(JSON.stringify({ error: 'Service initialization failed' }));
+  }
+};

--- a/api/index.js
+++ b/api/index.js
@@ -1,0 +1,1 @@
+module.exports = require('./handler');

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,12 @@
+{
+  "rewrites": [
+    {
+      "source": "/health",
+      "destination": "/api/[...all]"
+    },
+    {
+      "source": "/metrics",
+      "destination": "/api/[...all]"
+    }
+  ]
+}


### PR DESCRIPTION
### Motivation

- Provide a single serverless entrypoint for Vercel deployments that initializes the Express/Koa app and ensures a MongoDB connection before handling requests. 
- Document new analytics ingestion endpoints and clarify frontend integration/CORS behavior to avoid misrouting API requests to the frontend host. 
- Expose health and metrics endpoints through Vercel rewrites for platform compatibility.

### Description

- Added a Vercel-compatible API entrypoint in `api/handler.js` that loads environment variables, ensures a persistent MongoDB connection via `connectDB`, and delegates requests to the app created by `createApp`. 
- Exported the handler from `api/index.js` and `api/[...all].js` to support Vercel routing semantics. 
- Added `vercel.json` with rewrites for `/health` and `/metrics` to route those paths to the serverless handler. 
- Updated `README.md` to list two new analytics endpoints (`POST /api/analytics/events` and `POST /api/analytics/event`) and added a Frontend Integration Note explaining allowed frontend origin and proper backend target for API requests.

### Testing

- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d6cf1ba3688320901384bf75992fc6)