### PR TITLE
Add /api/telemetry alias routes for analytics ingestion

### DIFF
--- a/app.js
+++ b/app.js
@@ -97,6 +97,7 @@ function createApp() {
   app.use('/api/game', gameRoutes);
   app.use('/api', donationsRoutes);
   app.use('/api/analytics', analyticsRoutes);
+  app.use('/api/telemetry', analyticsRoutes);
 
   app.use('/api/v1/leaderboard', leaderboardRoutes);
   app.use('/api/v1/store', storeRoutes);
@@ -104,6 +105,7 @@ function createApp() {
   app.use('/api/v1/game', gameRoutes);
   app.use('/api/v1', donationsRoutes);
   app.use('/api/v1/analytics', analyticsRoutes);
+  app.use('/api/v1/telemetry', analyticsRoutes);
 
   app.get('/health', (req, res) => {
     const mongoStates = {

--- a/tests/api.integration.test.js
+++ b/tests/api.integration.test.js
@@ -1404,6 +1404,35 @@ test('POST /api/analytics/events accepts valid analytics batch', async () => {
   await server.close();
 });
 
+test('POST /api/telemetry/events aliases analytics ingestion route', async () => {
+  const inserted = [];
+  AnalyticsEvent.insertMany = async (docs) => {
+    inserted.push(...docs);
+    return docs;
+  };
+
+  const { server, baseUrl } = await startServer();
+  const sentAt = Date.now();
+  const res = await fetch(`${baseUrl}/api/telemetry/events`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      sentAt,
+      events: [{ name: 'game_start', timestamp: sentAt - 1000, payload: { sessionId: 'telemetry' } }]
+    })
+  });
+
+  assert.equal(res.status, 202);
+  const body = await res.json();
+  assert.equal(body.ok, true);
+  assert.equal(body.accepted, 1);
+  assert.equal(inserted.length, 1);
+  assert.equal(inserted[0].eventType, 'game_start');
+  assert.equal(inserted[0].payload.sessionId, 'telemetry');
+
+  await server.close();
+});
+
 test('POST /api/analytics/events rejects unsupported event type', async () => {
   AnalyticsEvent.insertMany = async () => {
     throw new Error('insertMany should not be called for invalid payload');


### PR DESCRIPTION
### Motivation
- Provide a drop-in alias so clients calling `/api/telemetry/events` hit the same ingestion handler as `analytics` and stop receiving `404` responses.
- Preserve the existing `/api/analytics/*` endpoints for backwards compatibility while supporting new telemetry URL used by frontends.
- Also expose the alias under the versioned prefix to match existing `/api/v1/analytics` behavior.

### Description
- Mounted the existing analytics router under `/api/telemetry` so telemetry requests reuse the analytics ingestion logic by adding `app.use('/api/telemetry', analyticsRoutes);` in `app.js`.
- Added the same alias for versioned routes with `app.use('/api/v1/telemetry', analyticsRoutes);` in `app.js`.
- Kept legacy `/api/analytics` and `/api/v1/analytics` routes unchanged.
- Added an integration test in `tests/api.integration.test.js` that posts to `POST /api/telemetry/events` and verifies a `202` response and that events are persisted via the analytics ingestion flow.

### Testing
- Ran `npm test -- tests/api.integration.test.js` which executed the integration suite and the new test; all tests passed.
- Test summary: `55` tests run, `0` failures (integration suite succeeded including the new telemetry alias test).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d798bbbe6083208428e8768e046d9f)