### PR TITLE
Allow ursasstube.fun in default CORS origins

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Versioned aliases are also available under `/api/v1/*` (backward-compatible with
 ## Frontend Integration Note
 
 - `https://bageus-github-io.vercel.app` is a frontend origin and is allowed by CORS.
+- `https://ursasstube.fun` (and `https://www.ursasstube.fun`) are also allowed by CORS.
 - API requests must target the deployed backend host (for example, Railway), not the frontend host itself.
 - If you send `POST https://bageus-github-io.vercel.app/api/analytics/events`, Vercel frontend hosting may return `404 Not Found` because that route is not served there.
 

--- a/app.js
+++ b/app.js
@@ -26,6 +26,8 @@ function createApp() {
     'https://bageus.github.io',
     'https://bageus-github-io.vercel.app',
     'https://ursass-tube.vercel.app',
+    'https://ursasstube.fun',
+    'https://www.ursasstube.fun',
     'http://localhost:3000',
     'http://localhost:5173',
     ...extraAllowedOrigins

--- a/tests/api.integration.test.js
+++ b/tests/api.integration.test.js
@@ -899,14 +899,14 @@ test('OPTIONS /api/donations/stars/create allows Telegram Mini App header in COR
   const res = await fetch(`${baseUrl}/api/donations/stars/create`, {
     method: 'OPTIONS',
     headers: {
-      Origin: 'https://ursass-tube.vercel.app',
+      Origin: 'https://ursasstube.fun',
       'Access-Control-Request-Method': 'POST',
       'Access-Control-Request-Headers': 'content-type,x-telegram-init-data'
     }
   });
 
   assert.equal(res.status, 204);
-  assert.equal(res.headers.get('access-control-allow-origin'), 'https://ursass-tube.vercel.app');
+  assert.equal(res.headers.get('access-control-allow-origin'), 'https://ursasstube.fun');
   assert.match(res.headers.get('access-control-allow-headers') || '', /x-telegram-init-data/i);
   assert.match(res.headers.get('access-control-allow-methods') || '', /POST/i);
 


### PR DESCRIPTION
### Motivation
- Add the new frontend domain `ursasstube.fun` to the backend built-in CORS allowlist so browser requests from the deployed frontend are not blocked by CORS.
- Keep integration tests and documentation aligned with the production frontend origins to avoid regressions and make onboarding of the new domain explicit.

### Description
- Added `https://ursasstube.fun` and `https://www.ursasstube.fun` to the built-in `allowedOrigins` array in `app.js` so the server will accept requests from the new frontend domain.
- Updated the integration test preflight in `tests/api.integration.test.js` to use `Origin: 'https://ursasstube.fun'` and assert `Access-Control-Allow-Origin` is returned for that origin.
- Documented the new allowed frontend origin in `README.md` under the Frontend Integration Note.

### Testing
- Ran `node --test tests/api.integration.test.js` and all integration tests passed (`38` tests passing, `0` failures).
- Ran `npm run check:syntax` and the syntax check passed for `46` JavaScript files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7a28119ec8320a0b39eca752e082b)