### PR TITLE
Allow ursasstube subdomains in backend CORS

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,8 @@ Versioned aliases are also available under `/api/v1/*` (backward-compatible with
 ## Frontend Integration Note
 
 - `https://bageus-github-io.vercel.app` is a frontend origin and is allowed by CORS.
-- `https://ursasstube.fun` (and `https://www.ursasstube.fun`) are also allowed by CORS.
+- `https://ursasstube.fun`, `https://www.ursasstube.fun`, and `https://play.ursasstube.fun` are allowed by CORS.
+- `https://api.ursasstube.fun` is also whitelisted (useful for same-site tooling / dashboards that call the API from that origin).
 - API requests must target the deployed backend host (for example, Railway), not the frontend host itself.
 - If you send `POST https://bageus-github-io.vercel.app/api/analytics/events`, Vercel frontend hosting may return `404 Not Found` because that route is not served there.
 

--- a/app.js
+++ b/app.js
@@ -28,6 +28,8 @@ function createApp() {
     'https://ursass-tube.vercel.app',
     'https://ursasstube.fun',
     'https://www.ursasstube.fun',
+    'https://play.ursasstube.fun',
+    'https://api.ursasstube.fun',
     'http://localhost:3000',
     'http://localhost:5173',
     ...extraAllowedOrigins

--- a/tests/api.integration.test.js
+++ b/tests/api.integration.test.js
@@ -893,6 +893,21 @@ test('CORS rejects non-whitelisted *.vercel.app origins', async () => {
   await server.close();
 });
 
+test('GET /health allows play.ursasstube.fun origin via CORS', async () => {
+  const { server, baseUrl } = await startServer();
+
+  const res = await fetch(`${baseUrl}/health`, {
+    headers: {
+      Origin: 'https://play.ursasstube.fun'
+    }
+  });
+
+  assert.equal(res.status, 200);
+  assert.equal(res.headers.get('access-control-allow-origin'), 'https://play.ursasstube.fun');
+
+  await server.close();
+});
+
 test('OPTIONS /api/donations/stars/create allows Telegram Mini App header in CORS preflight', async () => {
   const { server, baseUrl } = await startServer();
 


### PR DESCRIPTION
### Motivation

- The game frontend runs on `play.ursasstube.fun` and some same-site tooling or dashboards may call the API from `api.ursasstube.fun`, so those origins must be whitelisted to avoid CORS failures.

### Description

- Added `https://play.ursasstube.fun` and `https://api.ursasstube.fun` to the backend CORS allowlist in `app.js` by extending the `allowedOrigins` array.
- Updated the Frontend Integration Note in `README.md` to document that `play.ursasstube.fun` and `api.ursasstube.fun` are allowed origins.
- Added an integration test to `tests/api.integration.test.js` (`GET /health allows play.ursasstube.fun origin via CORS`) to assert that the `/health` endpoint returns the correct `Access-Control-Allow-Origin` header for the `play.ursasstube.fun` origin.

### Testing

- Ran `npm test -- --test tests/api.integration.test.js --test tests/securityHeaders.test.js` and the test run completed successfully with all tests passing (56 tests, 0 failures).
- The added integration test `GET /health allows play.ursasstube.fun origin via CORS` passed as part of the suite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7d98692848320b635473229c712f6)