### PR TITLE
Add security remarks closure plan (2026-04-17)

### DIFF
--- a/docs/security_remarks_closure_2026-04-17.md
+++ b/docs/security_remarks_closure_2026-04-17.md
@@ -1,0 +1,77 @@
+# Security Remarks Closure Plan (2026-04-17)
+
+## Context
+This document closes the remarks raised in the quick backend security review on **April 17, 2026**.
+
+## Remarks and closure actions
+
+### 1) Public `/metrics` endpoint
+**Risk:** internal operational metrics may be exposed publicly.
+
+**Closure action:**
+- Protect `/metrics` with one of the following (priority order):
+  1. Private network only (ingress allowlist / internal LB route)
+  2. Static bearer token (`METRICS_TOKEN`) checked in middleware
+  3. Basic Auth at reverse proxy level
+- Return `401` on missing/invalid auth.
+
+**Acceptance criteria:**
+- Anonymous `GET /metrics` returns `401` or `403`.
+- Authenticated/internal request returns `200`.
+- Monitoring scraper uses the approved auth method.
+
+---
+
+### 2) Public account info enumeration (`GET /api/account/info/:identifier`)
+**Risk:** potential leakage of `telegramId/wallet` mapping and profile metadata.
+
+**Closure action:**
+- Restrict endpoint to authenticated owner access OR
+- Reduce response to non-sensitive public fields only.
+- Add stricter rate limit for this endpoint.
+- Add detection/logging for high-cardinality sequential probes.
+
+**Acceptance criteria:**
+- Unauthenticated caller cannot fetch sensitive identity binding fields.
+- Security tests cover enumeration attempts and expected blocks.
+
+---
+
+### 3) `localhost` origins in production allowlist
+**Risk:** unnecessary CORS surface in production configuration.
+
+**Closure action:**
+- Remove hardcoded localhost origins from production runtime.
+- Keep localhost origins only for non-production environments.
+
+**Acceptance criteria:**
+- In production mode, `Origin: http://localhost:3000` and `http://localhost:5173` are rejected.
+- Existing frontend production domains remain allowed.
+
+---
+
+### 4) Telegram config can be warning-only
+**Risk:** deployment may proceed with incomplete Telegram security config.
+
+**Closure action:**
+- Enforce strict startup validation in production:
+  - `TELEGRAM_BOT_TOKEN`
+  - `TELEGRAM_BOT_SECRET`
+  - `TELEGRAM_WEBHOOK_SECRET`
+- Fail fast on missing values when `NODE_ENV=production`.
+
+**Acceptance criteria:**
+- App startup exits with non-zero status if any required Telegram variable is missing in production.
+- CI includes a config validation test for production env matrix.
+
+---
+
+## Verification checklist
+- [ ] Automated tests added/updated for all 4 closure actions.
+- [ ] Staging validation completed with security sign-off.
+- [ ] Production deploy completed with post-deploy smoke checks.
+- [ ] Incident/monitoring dashboards updated for auth failures and probe alerts.
+
+## Owner and target
+- **Owner:** Backend team
+- **Target completion:** 2026-04-24


### PR DESCRIPTION
### Motivation
- Close out findings from the quick backend security review performed on `2026-04-17` by recording required actions and acceptance criteria.
- Ensure clear mitigation steps for four high-priority issues: public `/metrics`, account info enumeration, `localhost` CORS in production, and Telegram configuration validation.
- Provide an owner and target completion date to drive follow-up work.

### Description
- Add `docs/security_remarks_closure_2026-04-17.md` which captures context and a closure plan for the review.
- For `/metrics`, require access controls (internal-only, static bearer token, or reverse-proxy Basic Auth) and returning `401` on missing/invalid auth, with acceptance tests defined.
- For `GET /api/account/info/:identifier`, require owner-auth or reduced public fields, stricter rate limits, and detection/logging for enumeration probes.
- For CORS and Telegram, remove `localhost` from production allowlists and enforce fail-fast startup validation of `TELEGRAM_BOT_TOKEN`, `TELEGRAM_BOT_SECRET`, and `TELEGRAM_WEBHOOK_SECRET` in production, and include a verification checklist and owner/target.

### Testing
- No automated tests were run for this change because it is documentation-only.
- The document includes a verification checklist that mandates adding automated tests for the described closure actions.
- Normal CI runs will include this file in repository checks but no code-level tests were modified or executed as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1727952348320a0584675df53947f)