### PR TITLE
Normalize store upgrade defaults and legacy upgrade typing

### DIFF
--- a/models/PlayerUpgrades.js
+++ b/models/PlayerUpgrades.js
@@ -63,6 +63,37 @@ const playerUpgradesSchema = new mongoose.Schema({
   }
 });
 
+function toUpgradeLevel(value) {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (typeof value === 'boolean') return value ? 1 : 0;
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase();
+    if (!normalized || normalized === 'false' || normalized === 'null' || normalized === 'undefined') return 0;
+    if (normalized === 'true') return 1;
+    const parsed = Number(normalized);
+    return Number.isFinite(parsed) ? parsed : 0;
+  }
+  return 0;
+}
+
+playerUpgradesSchema.pre('validate', function normalizeLegacyRadarAndGoldUpgrades(next) {
+  const radarLegacyLevel = toUpgradeLevel(this.radar);
+  const radarGoldLevel = toUpgradeLevel(this.radar_gold);
+
+  if (radarLegacyLevel > 0 && radarGoldLevel < 1) {
+    this.radar_gold = 1;
+  } else {
+    this.radar_gold = radarGoldLevel;
+  }
+
+  this.radar_obstacles = toUpgradeLevel(this.radar_obstacles);
+  this.shield = Math.min(1, toUpgradeLevel(this.shield));
+  this.shield_capacity = Math.min(2, toUpgradeLevel(this.shield_capacity));
+  this.alert = Math.min(2, toUpgradeLevel(this.alert));
+
+  next();
+});
+
 /**
  * Пересчитать бесплатные заезды на основе времени.
  * Вызывается при каждом обращении к данным игрока.

--- a/routes/store.js
+++ b/routes/store.js
@@ -21,6 +21,39 @@ const UPGRADE_KEY_ALIASES = {
   spin_perfect: 'alert'
 };
 
+const NEW_PLAYER_GOLD_UPGRADE_DEFAULTS = {
+  shield: 0,
+  shield_capacity: 0,
+  radar_obstacles: 0,
+  radar_gold: 0,
+  alert: 0
+};
+
+function toUpgradeLevel(value) {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+  if (typeof value === 'boolean') {
+    return value ? 1 : 0;
+  }
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase();
+    if (!normalized || normalized === 'false' || normalized === 'null' || normalized === 'undefined') {
+      return 0;
+    }
+    if (normalized === 'true') {
+      return 1;
+    }
+    const parsed = Number(normalized);
+    return Number.isFinite(parsed) ? parsed : 0;
+  }
+  return 0;
+}
+
+function isNormalizedUpgradeLevel(value) {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0;
+}
+
 function resolveUpgradeKey(upgradeKey) {
   return UPGRADE_KEY_ALIASES[upgradeKey] || upgradeKey;
 }
@@ -31,10 +64,10 @@ function isLevelUpgradeType(type) {
 
 function normalizeShieldUpgrades(upgrades) {
   let changed = false;
-  const legacyShieldLevel = upgrades.shield || 0;
+  const legacyShieldLevel = toUpgradeLevel(upgrades.shield);
+  const currentCapacityLevel = toUpgradeLevel(upgrades.shield_capacity);
 
   if (legacyShieldLevel > 1) {
-    const currentCapacityLevel = typeof upgrades.shield_capacity === 'number' ? upgrades.shield_capacity : 0;
     const migratedCapacityLevel = Math.min(2, legacyShieldLevel - 1);
 
     if (currentCapacityLevel < migratedCapacityLevel) {
@@ -44,7 +77,18 @@ function normalizeShieldUpgrades(upgrades) {
 
     upgrades.shield = 1;
     changed = true;
-  } else if (typeof upgrades.shield_capacity !== 'number') {
+  } else {
+    if (!isNormalizedUpgradeLevel(upgrades.shield) || upgrades.shield !== legacyShieldLevel) {
+      upgrades.shield = legacyShieldLevel;
+      changed = true;
+    }
+    if (!isNormalizedUpgradeLevel(upgrades.shield_capacity) || upgrades.shield_capacity !== currentCapacityLevel) {
+      upgrades.shield_capacity = currentCapacityLevel;
+      changed = true;
+    }
+  }
+
+  if (typeof upgrades.shield_capacity !== 'number') {
     upgrades.shield_capacity = 0;
     changed = true;
   }
@@ -53,20 +97,40 @@ function normalizeShieldUpgrades(upgrades) {
 }
 
 function normalizeRadarUpgrades(upgrades) {
-  const legacyRadarLevel = upgrades.radar || 0;
+  const legacyRadarLevel = toUpgradeLevel(upgrades.radar);
+  const currentRadarGoldLevel = toUpgradeLevel(upgrades.radar_gold);
+  let changed = false;
 
-  if (legacyRadarLevel > 0 && (!upgrades.radar_gold || upgrades.radar_gold < 1)) {
+  if (legacyRadarLevel > 0 && currentRadarGoldLevel < 1) {
     upgrades.radar_gold = 1;
-    return true;
+    changed = true;
+  } else if (!isNormalizedUpgradeLevel(upgrades.radar_gold) || upgrades.radar_gold !== currentRadarGoldLevel) {
+    upgrades.radar_gold = currentRadarGoldLevel;
+    changed = true;
   }
 
+  const radarObstaclesLevel = toUpgradeLevel(upgrades.radar_obstacles);
+  if (!isNormalizedUpgradeLevel(upgrades.radar_obstacles) || upgrades.radar_obstacles !== radarObstaclesLevel) {
+    upgrades.radar_obstacles = radarObstaclesLevel;
+    changed = true;
+  }
+
+  return changed;
+}
+
+function normalizeAlertUpgrade(upgrades) {
+  const alertLevel = toUpgradeLevel(upgrades.alert);
+  if (!isNormalizedUpgradeLevel(upgrades.alert) || upgrades.alert !== alertLevel) {
+    upgrades.alert = alertLevel;
+    return true;
+  }
   return false;
 }
 
 async function getOrCreatePlayerUpgrades(wallet) {
   let upgrades = await PlayerUpgrades.findOne({ wallet });
   if (!upgrades) {
-    upgrades = new PlayerUpgrades({ wallet });
+    upgrades = new PlayerUpgrades({ wallet, ...NEW_PLAYER_GOLD_UPGRADE_DEFAULTS });
     await upgrades.save();
   }
   return upgrades;
@@ -76,8 +140,9 @@ async function prepareUpgrades(upgrades, { persist = false } = {}) {
   const ridesChanged = upgrades.refreshFreeRides();
   const shieldChanged = normalizeShieldUpgrades(upgrades);
   const radarChanged = normalizeRadarUpgrades(upgrades);
+  const alertChanged = normalizeAlertUpgrade(upgrades);
 
-  if (persist && (ridesChanged || shieldChanged || radarChanged)) {
+  if (persist && (ridesChanged || shieldChanged || radarChanged || alertChanged)) {
     await upgrades.save();
   }
 
@@ -263,7 +328,7 @@ router.get('/upgrades/:wallet', readLimiter, async (req, res) => {
       const config = UPGRADES_CONFIG[key];
 
       if (config.type === "tiered" || config.type === "permanent") {
-        const currentLevel = upgrades[key] || 0;
+        const currentLevel = Math.max(0, toUpgradeLevel(upgrades[key]));
         upgradesData[key] = {
           type: config.type,
           currency: config.currency,

--- a/tests/api.integration.test.js
+++ b/tests/api.integration.test.js
@@ -886,6 +886,111 @@ test('GET /api/store/upgrades/:wallet returns ai_mode_access=true for whiteliste
   await server.close();
 });
 
+test('GET /api/store/upgrades/:wallet for new wallet returns zeroed gold upgrades and disabled effects', async () => {
+  const wallet = Wallet.createRandom().address.toLowerCase();
+  let createdUpgrades = null;
+
+  Player.findOne = () => queryResult({
+    totalGoldCoins: 0,
+    totalSilverCoins: 0
+  });
+  PlayerUpgrades.findOne = () => queryResult(null);
+  PlayerUpgrades.prototype.save = async function save() {
+    createdUpgrades = this;
+    return this;
+  };
+
+  const { server, baseUrl } = await startServer();
+  const res = await fetch(`${baseUrl}/api/store/upgrades/${wallet}`);
+  assert.equal(res.status, 200);
+  const body = await res.json();
+
+  assert.equal(createdUpgrades.shield, 0);
+  assert.equal(createdUpgrades.shield_capacity, 0);
+  assert.equal(createdUpgrades.radar_obstacles, 0);
+  assert.equal(createdUpgrades.radar_gold, 0);
+  assert.equal(createdUpgrades.alert, 0);
+
+  assert.equal(body.upgrades.shield.currentLevel, 0);
+  assert.equal(body.upgrades.shield_capacity.currentLevel, 0);
+  assert.equal(body.upgrades.radar_obstacles.currentLevel, 0);
+  assert.equal(body.upgrades.radar_gold.currentLevel, 0);
+  assert.equal(body.upgrades.alert.currentLevel, 0);
+
+  assert.equal(body.activeEffects.start_with_shield, false);
+  assert.equal(body.activeEffects.start_with_radar_obstacles, false);
+  assert.equal(body.activeEffects.start_with_radar_gold, false);
+  assert.equal(body.activeEffects.start_with_radar, false);
+  assert.equal(body.activeEffects.start_with_alert, false);
+  assert.equal(typeof body.activeEffects.start_with_shield, 'boolean');
+  assert.equal(typeof body.activeEffects.start_with_radar_obstacles, 'boolean');
+  assert.equal(typeof body.activeEffects.start_with_radar_gold, 'boolean');
+  assert.equal(typeof body.activeEffects.start_with_alert, 'boolean');
+  assert.equal(typeof body.activeEffects.shield_level, 'number');
+  assert.equal(typeof body.activeEffects.shield_capacity_level, 'number');
+  assert.equal(typeof body.activeEffects.alert_level, 'number');
+
+  await server.close();
+});
+
+test('GET /api/store/upgrades/:wallet normalizes legacy string levels and radar fallback', async () => {
+  const wallet = Wallet.createRandom().address.toLowerCase();
+  let saveCalls = 0;
+
+  Player.findOne = () => queryResult({
+    totalGoldCoins: 0,
+    totalSilverCoins: 0
+  });
+  PlayerUpgrades.findOne = () => queryResult({
+    shield: 'false',
+    shield_capacity: '0',
+    radar: '1',
+    radar_gold: '0',
+    radar_obstacles: 'false',
+    alert: '2',
+    x2_duration: '0',
+    score_plus_300_mult: '0',
+    score_plus_500_mult: '0',
+    score_minus_300_mult: '0',
+    score_minus_500_mult: '0',
+    invert_score: '0',
+    speed_up_mult: '0',
+    speed_down_mult: '0',
+    magnet_duration: '0',
+    spin_cooldown: '0',
+    freeRidesRemaining: 3,
+    paidRidesRemaining: 0,
+    freeRidesResetAt: new Date(),
+    refreshFreeRides() { return false; },
+    getTotalRides() { return 3; },
+    save: async function save() { saveCalls += 1; return this; }
+  });
+
+  const { server, baseUrl } = await startServer();
+  const res = await fetch(`${baseUrl}/api/store/upgrades/${wallet}`);
+  assert.equal(res.status, 200);
+  const body = await res.json();
+
+  assert.equal(saveCalls, 1);
+  assert.equal(body.upgrades.shield.currentLevel, 0);
+  assert.equal(body.upgrades.shield_capacity.currentLevel, 0);
+  assert.equal(body.upgrades.radar_obstacles.currentLevel, 0);
+  assert.equal(body.upgrades.radar_gold.currentLevel, 1);
+  assert.equal(body.upgrades.alert.currentLevel, 2);
+
+  assert.equal(body.activeEffects.start_with_shield, false);
+  assert.equal(body.activeEffects.start_with_radar_obstacles, false);
+  assert.equal(body.activeEffects.start_with_radar_gold, true);
+  assert.equal(body.activeEffects.start_with_radar, true);
+  assert.equal(body.activeEffects.alert_level, 2);
+  assert.equal(body.activeEffects.perfect_spin_enabled, true);
+  assert.equal(typeof body.activeEffects.start_with_radar_gold, 'boolean');
+  assert.equal(typeof body.activeEffects.start_with_alert, 'boolean');
+  assert.equal(typeof body.activeEffects.alert_level, 'number');
+
+  await server.close();
+});
+
 test('GET /api/store/upgrades/:wallet returns ai_mode_access=false for regular wallet', async () => {
   const wallet = '0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
   Player.findOne = () => queryResult({

--- a/utils/upgradesConfig.js
+++ b/utils/upgradesConfig.js
@@ -5,6 +5,30 @@ function goldPrice(defaultPrice) {
   return isTestEnv ? TEST_GOLD_PRICE : defaultPrice;
 }
 
+function toUpgradeLevel(value) {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    return value;
+  }
+
+  if (typeof value === 'boolean') {
+    return value ? 1 : 0;
+  }
+
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase();
+    if (!normalized || normalized === 'false' || normalized === 'null' || normalized === 'undefined') {
+      return 0;
+    }
+    if (normalized === 'true') {
+      return 1;
+    }
+    const parsed = Number(normalized);
+    return Number.isFinite(parsed) ? parsed : 0;
+  }
+
+  return 0;
+}
+
 const UPGRADES_CONFIG = {
 
   // === SILVER — TIERED ===
@@ -155,52 +179,69 @@ const UPGRADES_CONFIG = {
 };
 
 function calculateEffects(upgrades) {
-  const legacyShieldLevel = upgrades.shield || 0;
-  const hasSeparateShieldCapacity = typeof upgrades.shield_capacity === "number";
+  const x2DurationLevel = toUpgradeLevel(upgrades.x2_duration);
+  const scorePlus300Level = toUpgradeLevel(upgrades.score_plus_300_mult);
+  const scorePlus500Level = toUpgradeLevel(upgrades.score_plus_500_mult);
+  const scoreMinus300Level = toUpgradeLevel(upgrades.score_minus_300_mult);
+  const scoreMinus500Level = toUpgradeLevel(upgrades.score_minus_500_mult);
+  const invertScoreLevel = toUpgradeLevel(upgrades.invert_score);
+  const speedUpLevel = toUpgradeLevel(upgrades.speed_up_mult);
+  const speedDownLevel = toUpgradeLevel(upgrades.speed_down_mult);
+  const magnetDurationLevel = toUpgradeLevel(upgrades.magnet_duration);
+  const spinCooldownLevel = toUpgradeLevel(upgrades.spin_cooldown);
+  const legacyShieldLevel = toUpgradeLevel(upgrades.shield);
+  const shieldCapacityLevel = toUpgradeLevel(upgrades.shield_capacity);
+  const radarObstaclesLevel = toUpgradeLevel(upgrades.radar_obstacles);
+  const radarGoldLevel = toUpgradeLevel(upgrades.radar_gold);
+  const legacyRadarLevel = toUpgradeLevel(upgrades.radar);
+  const alertLevel = toUpgradeLevel(upgrades.alert);
+
+  const hasSeparateShieldCapacity = Number.isFinite(shieldCapacityLevel);
   const normalizedShieldLevel = legacyShieldLevel > 0 ? 1 : 0;
   const normalizedShieldCapacityLevel = hasSeparateShieldCapacity
-    ? upgrades.shield_capacity
+    ? shieldCapacityLevel
     : Math.max(0, legacyShieldLevel - 1);
+  const normalizedRadarGoldLevel = radarGoldLevel > 0 ? radarGoldLevel : legacyRadarLevel;
 
   return {
-    x2_duration_bonus: upgrades.x2_duration > 0
-      ? UPGRADES_CONFIG.x2_duration.effects[upgrades.x2_duration - 1]
+    x2_duration_bonus: x2DurationLevel > 0
+      ? UPGRADES_CONFIG.x2_duration.effects[x2DurationLevel - 1]
       : 0,
 
-    score_plus_300_multiplier: upgrades.score_plus_300_mult > 0
-      ? UPGRADES_CONFIG.score_plus_300_mult.effects[upgrades.score_plus_300_mult - 1]
+    score_plus_300_multiplier: scorePlus300Level > 0
+      ? UPGRADES_CONFIG.score_plus_300_mult.effects[scorePlus300Level - 1]
       : 1.0,
 
-    score_plus_500_multiplier: upgrades.score_plus_500_mult > 0
-      ? UPGRADES_CONFIG.score_plus_500_mult.effects[upgrades.score_plus_500_mult - 1]
+    score_plus_500_multiplier: scorePlus500Level > 0
+      ? UPGRADES_CONFIG.score_plus_500_mult.effects[scorePlus500Level - 1]
       : 1.0,
 
-    score_minus_300_multiplier: upgrades.score_minus_300_mult > 0
-      ? UPGRADES_CONFIG.score_minus_300_mult.effects[upgrades.score_minus_300_mult - 1]
+    score_minus_300_multiplier: scoreMinus300Level > 0
+      ? UPGRADES_CONFIG.score_minus_300_mult.effects[scoreMinus300Level - 1]
       : 1.0,
 
-    score_minus_500_multiplier: upgrades.score_minus_500_mult > 0
-      ? UPGRADES_CONFIG.score_minus_500_mult.effects[upgrades.score_minus_500_mult - 1]
+    score_minus_500_multiplier: scoreMinus500Level > 0
+      ? UPGRADES_CONFIG.score_minus_500_mult.effects[scoreMinus500Level - 1]
       : 1.0,
 
-    invert_score_multiplier: upgrades.invert_score > 0
-      ? UPGRADES_CONFIG.invert_score.effects[upgrades.invert_score - 1]
+    invert_score_multiplier: invertScoreLevel > 0
+      ? UPGRADES_CONFIG.invert_score.effects[invertScoreLevel - 1]
       : 1.0,
 
-    speed_up_multiplier: upgrades.speed_up_mult > 0
-      ? UPGRADES_CONFIG.speed_up_mult.effects[upgrades.speed_up_mult - 1]
+    speed_up_multiplier: speedUpLevel > 0
+      ? UPGRADES_CONFIG.speed_up_mult.effects[speedUpLevel - 1]
       : 1.0,
 
-    speed_down_multiplier: upgrades.speed_down_mult > 0
-      ? UPGRADES_CONFIG.speed_down_mult.effects[upgrades.speed_down_mult - 1]
+    speed_down_multiplier: speedDownLevel > 0
+      ? UPGRADES_CONFIG.speed_down_mult.effects[speedDownLevel - 1]
       : 1.0,
 
-    magnet_duration_bonus: upgrades.magnet_duration > 0
-      ? UPGRADES_CONFIG.magnet_duration.effects[upgrades.magnet_duration - 1]
+    magnet_duration_bonus: magnetDurationLevel > 0
+      ? UPGRADES_CONFIG.magnet_duration.effects[magnetDurationLevel - 1]
       : 0,
 
-    spin_cooldown_reduction: upgrades.spin_cooldown > 0
-      ? UPGRADES_CONFIG.spin_cooldown.effects[upgrades.spin_cooldown - 1]
+    spin_cooldown_reduction: spinCooldownLevel > 0
+      ? UPGRADES_CONFIG.spin_cooldown.effects[spinCooldownLevel - 1]
       : 0,
 
     shield_level: normalizedShieldLevel,
@@ -209,16 +250,16 @@ function calculateEffects(upgrades) {
       ? UPGRADES_CONFIG.shield_capacity.effects[normalizedShieldCapacityLevel - 1]
       : 1,
     start_with_shield: normalizedShieldLevel > 0,
-    start_with_radar_obstacles: upgrades.radar_obstacles > 0,
-    start_with_radar_gold: (upgrades.radar_gold || upgrades.radar || 0) > 0,
+    start_with_radar_obstacles: radarObstaclesLevel > 0,
+    start_with_radar_gold: normalizedRadarGoldLevel > 0,
     // Backward compatibility for clients that still read `start_with_radar`.
-    start_with_radar: (upgrades.radar_gold || upgrades.radar || 0) > 0,
-    alert_level: upgrades.alert || 0,
-    spin_alert_mode: upgrades.alert > 0
-      ? UPGRADES_CONFIG.alert.effects[upgrades.alert - 1]
+    start_with_radar: normalizedRadarGoldLevel > 0,
+    alert_level: alertLevel,
+    spin_alert_mode: alertLevel > 0
+      ? UPGRADES_CONFIG.alert.effects[alertLevel - 1]
       : null,
-    start_with_alert: upgrades.alert > 0,
-    perfect_spin_enabled: upgrades.alert >= 2
+    start_with_alert: alertLevel > 0,
+    perfect_spin_enabled: alertLevel >= 2
   };
 }
 


### PR DESCRIPTION
### Motivation

- Гарантировать корректные и типобезопасные значения апгрейдов/эффектов для новых и legacy игроков, чтобы API всегда отдавал булевы `start_with_*` и числовые уровни/множители вместо строк.
- Синхронизировать модель `PlayerUpgrades` и конфиг апгрейдов (`UPGRADES_CONFIG`) и добавить миграцию legacy `radar` → `radar_gold` на уровне схемы.

### Description

- Добавлен универсальный парсер уровней `toUpgradeLevel` и применён в `utils/upgradesConfig.js` внутри `calculateEffects()` для получения типобезопасных числовых уровней и булевых `start_with_*` эффектов (включая fallback `radar_gold` от legacy `radar`).
- В `routes/store.js` добавлены: `NEW_PLAYER_GOLD_UPGRADE_DEFAULTS`, `toUpgradeLevel`, `isNormalizedUpgradeLevel` и функции нормализации `normalizeShieldUpgrades`, `normalizeRadarUpgrades`, `normalizeAlertUpgrade`; при создании новых записей `PlayerUpgrades` теперь явно выставляются `shield=0`, `shield_capacity=0`, `radar_obstacles=0`, `radar_gold=0`, `alert=0`, а при подготовке апгрейдов производится нормализация/миграция и безопасный расчёт `currentLevel` для ответа API.
- В `models/PlayerUpgrades.js` добавлен `pre('validate')` хук, который нормализует legacy/строковые поля, мигрирует `radar` → `radar_gold` и ограничивает значения `shield`, `shield_capacity`, `alert` в допустимых пределах.
- Добавлены интеграционные тесты в `tests/api.integration.test.js` на поведение `GET /api/store/upgrades/:wallet` для нового кошелька (проверка нулевых gold-апгрейдов и отключённых эффектов) и регресс-тест, где БД возвращает legacy строковые значения/`radar` и API всё равно отдаёт нормализованные типы и уровни.

### Testing

- Запущены интеграционные тесты командой `NODE_ENV=test node --test tests/api.integration.test.js`.
- Все тесты прошли успешно: `45 passed, 0 failed`.
- Тесты покрывают новые сценарии: создание апгрейдов для нового кошелька и нормализацию legacy строк/радара; все assertions в новых тестах прошли.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3762822c08320ad727679b6e7f375)