### PR TITLE
feat(leaderboard): add player insights & realistic target recommendations

### DIFF
--- a/docs/api/leaderboard-insights-v2.md
+++ b/docs/api/leaderboard-insights-v2.md
@@ -1,0 +1,93 @@
+# Leaderboard API v2 (backward-compatible extension)
+
+## Feature flag
+
+Insights are controlled by `LEADERBOARD_INSIGHTS_ENABLED` (default: enabled unless explicitly `false`).
+
+## GET `/api/leaderboard/top`
+
+### Backward compatibility
+
+Existing fields are preserved:
+
+- `leaderboard`
+- `playerPosition`
+
+### Optional v2 fields
+
+Enable with query parameter:
+
+- `?v=2&wallet=0x...`
+- or `?includeInsights=true&wallet=0x...`
+
+Response adds:
+
+- `playerInsights` (optional)
+
+### `playerInsights` schema
+
+```json
+{
+  "isFirstRun": true,
+  "isPersonalBest": true,
+  "enteredTop10": false,
+  "rank": 42,
+  "totalRankedPlayers": 125000,
+  "percentileOverall": 99.97,
+  "percentileFirstRunScore": 91.5,
+  "percentileFirstRunDistance": 89.2,
+  "percentileFirstRunCoins": 75.0,
+  "comparisonMode": "first_run_score",
+  "comparisonTextFallbackType": "normal",
+  "nextTargets": [
+    {
+      "targetType": "rank",
+      "targetRank": 10,
+      "scoreToReach": 8450,
+      "delta": 120,
+      "priority": 1
+    }
+  ],
+  "recommendedTarget": {
+    "targetType": "rank",
+    "label": "TOP 10",
+    "delta": 120
+  }
+}
+```
+
+## GET `/api/leaderboard/insights?wallet=0x...`
+
+Returns personalized insights without leaderboard list.
+
+```json
+{
+  "wallet": "0x...",
+  "playerInsights": { "...": "same schema as above" }
+}
+```
+
+## Comparison/fallback behavior
+
+- Backend tries meaningful percentile from first-run cohorts (`score`, `distance`, `coins`).
+- If segment sample size is below `LEADERBOARD_INSIGHTS_MIN_SEGMENT_SIZE`, mode becomes `none`.
+- If percentile is weak (`< LEADERBOARD_INSIGHTS_WEAK_PERCENTILE`):
+  - first run => `weak_first_run`
+  - repeat run => `weak_repeat_run`
+
+## Realistic target selection
+
+Thresholds are configurable by env:
+
+- `LEADERBOARD_INSIGHTS_MAX_DELTA_TOP10`
+- `LEADERBOARD_INSIGHTS_MAX_DELTA_TOP100`
+- `LEADERBOARD_INSIGHTS_MAX_DELTA_TOP1000`
+- `LEADERBOARD_INSIGHTS_MAX_DELTA_TOP10000`
+
+Target logic:
+
+- Top-10 players get higher-rank realistic jumps.
+- Top-100 players prioritize Top-10 but may receive intermediate rank target.
+- Top-1000 players prioritize Top-100.
+- Top-10000 players prioritize Top-1000.
+- Outside Top-10000 players prioritize entering Top-10000.

--- a/models/LeaderboardAggregate.js
+++ b/models/LeaderboardAggregate.js
@@ -1,0 +1,21 @@
+const mongoose = require('mongoose');
+
+const leaderboardAggregateSchema = new mongoose.Schema({
+  key: {
+    type: String,
+    required: true,
+    unique: true,
+    index: true
+  },
+  payload: {
+    type: mongoose.Schema.Types.Mixed,
+    required: true
+  },
+  refreshedAt: {
+    type: Date,
+    default: Date.now,
+    index: true
+  }
+});
+
+module.exports = mongoose.model('LeaderboardAggregate', leaderboardAggregateSchema);

--- a/models/PlayerRun.js
+++ b/models/PlayerRun.js
@@ -1,0 +1,75 @@
+const mongoose = require('mongoose');
+
+const playerRunSchema = new mongoose.Schema({
+  playerId: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'Player',
+    required: true,
+    index: true
+  },
+  wallet: {
+    type: String,
+    required: true,
+    lowercase: true,
+    index: true
+  },
+  runId: {
+    type: String,
+    required: true,
+    unique: true,
+    index: true
+  },
+  score: {
+    type: Number,
+    required: true,
+    min: 0
+  },
+  distance: {
+    type: Number,
+    required: true,
+    min: 0
+  },
+  goldCoins: {
+    type: Number,
+    required: true,
+    default: 0,
+    min: 0
+  },
+  silverCoins: {
+    type: Number,
+    required: true,
+    default: 0,
+    min: 0
+  },
+  isFirstRun: {
+    type: Boolean,
+    default: false,
+    index: true
+  },
+  isPersonalBest: {
+    type: Boolean,
+    default: false
+  },
+  verified: {
+    type: Boolean,
+    default: true,
+    index: true
+  },
+  isValid: {
+    type: Boolean,
+    default: true,
+    index: true
+  },
+  createdAt: {
+    type: Date,
+    default: Date.now,
+    index: true
+  }
+});
+
+playerRunSchema.index({ wallet: 1, createdAt: -1 });
+playerRunSchema.index({ isFirstRun: 1, score: -1 });
+playerRunSchema.index({ isFirstRun: 1, distance: -1 });
+playerRunSchema.index({ isFirstRun: 1, goldCoins: -1, silverCoins: -1 });
+
+module.exports = mongoose.model('PlayerRun', playerRunSchema);

--- a/routes/leaderboard.js
+++ b/routes/leaderboard.js
@@ -5,12 +5,14 @@ const mongoose = require('mongoose');
 const Player = require('../models/Player');
 const GameResult = require('../models/GameResult');
 const AccountLink = require('../models/AccountLink');
+const PlayerRun = require('../models/PlayerRun');
 const { verifySignature, createMessageToVerify } = require('../utils/verifySignature');
 const { saveResultLimiter, readLimiter } = require('../middleware/rateLimiter');
 const logger = require('../utils/logger');
 const { markSuspicious } = require('../middleware/requestMetrics');
 const { logSecurityEvent, normalizeWallet, validateTimestampWindow } = require('../utils/security');
 const { hasAiModeAccess, validateAiSettings } = require('../utils/aiModeAccess');
+const { computePlayerInsights, DEFAULTS: leaderboardInsightsConfig } = require('../services/leaderboardInsightsService');
 
 /**
  * Build display name for a player based on their AccountLink data.
@@ -94,9 +96,11 @@ router.get('/top', readLimiter, async (req, res) => {
     }
 
     let playerPosition = null;
+    let playerRecord = null;
     if (wallet) {
       const playerData = await Player.findOne({ wallet });
       if (playerData) {
+        playerRecord = playerData;
         const playerLink = await AccountLink.findOne({ primaryId: wallet });
 
         if (playerData.bestScore > 0) {
@@ -119,6 +123,15 @@ router.get('/top', readLimiter, async (req, res) => {
       }
     }
 
+    const includeInsights =
+      leaderboardInsightsConfig.insightsEnabled &&
+      wallet &&
+      (req.query.v === '2' || req.query.includeInsights === 'true');
+
+    const insights = includeInsights && playerRecord
+      ? await computePlayerInsights({ wallet, player: playerRecord })
+      : null;
+
     res.json({
       leaderboard: topPlayers.map((player, index) => (
         buildLeaderboardEntry(
@@ -127,7 +140,8 @@ router.get('/top', readLimiter, async (req, res) => {
           index + 1
         )
       )),
-      playerPosition
+      playerPosition,
+      ...(insights ? { playerInsights: insights } : {})
     });
 
   } catch (error) {
@@ -313,6 +327,8 @@ router.post('/save', saveResultLimiter, async (req, res) => {
       }
 
       let player = await playerQuery;
+      const previousBestScore = player?.bestScore || 0;
+      const previousGamesPlayed = player?.gamesPlayed || 0;
 
       if (!player) {
         player = new Player({
@@ -404,6 +420,26 @@ router.post('/save', saveResultLimiter, async (req, res) => {
         await player.save();
       }
 
+      const runPayload = {
+        playerId: player._id,
+        wallet: walletLower,
+        runId: deduplicationToken,
+        score: scoreValue,
+        distance: distanceValue,
+        goldCoins: coins.gold,
+        silverCoins: coins.silver,
+        isFirstRun: previousGamesPlayed === 0,
+        isPersonalBest: scoreValue > previousBestScore,
+        verified: true,
+        isValid: !player.suspiciousScorePattern
+      };
+
+      if (session) {
+        await PlayerRun.create([runPayload], { session });
+      } else {
+        await PlayerRun.create([runPayload]);
+      }
+
       responsePayload = {
         bestScore: player.bestScore,
         averageScore: player.averageScore || 0,
@@ -472,6 +508,34 @@ router.post('/save', saveResultLimiter, async (req, res) => {
 
     logger.error({ err: error }, 'POST /save error');
     res.status(500).json({ error: 'Server error' });
+  }
+});
+
+router.get('/insights', readLimiter, async (req, res) => {
+  try {
+    if (!leaderboardInsightsConfig.insightsEnabled) {
+      return res.status(404).json({ error: 'Insights are disabled by feature flag.' });
+    }
+
+    const walletQuery = typeof req.query.wallet === 'string' ? req.query.wallet.trim() : '';
+    const wallet = walletQuery ? walletQuery.toLowerCase() : null;
+
+    if (!wallet || !isValidWalletAddress(wallet)) {
+      return res.status(400).json({
+        error: 'Invalid wallet format. Expected EVM wallet like 0x... (40 hex chars).'
+      });
+    }
+
+    const player = await Player.findOne({ wallet });
+    if (!player) {
+      return res.json({ wallet, playerInsights: null });
+    }
+
+    const playerInsights = await computePlayerInsights({ wallet, player });
+    return res.json({ wallet, playerInsights });
+  } catch (error) {
+    logger.error({ err: error.message, requestId: req.requestId }, 'GET /insights error');
+    return res.status(500).json({ error: 'Server error', requestId: req.requestId });
   }
 });
 

--- a/scripts/migrations/2026-04-24-leaderboard-insights.js
+++ b/scripts/migrations/2026-04-24-leaderboard-insights.js
@@ -1,0 +1,50 @@
+/* eslint-disable no-console */
+/**
+ * Migration: create run-history + leaderboard insight indexes.
+ *
+ * Usage:
+ *   MONGO_URI='mongodb://localhost:27017/ursass' node scripts/migrations/2026-04-24-leaderboard-insights.js
+ */
+const mongoose = require('mongoose');
+
+async function run() {
+  const mongoUri = process.env.MONGO_URI;
+  if (!mongoUri) {
+    throw new Error('MONGO_URI is required');
+  }
+
+  await mongoose.connect(mongoUri);
+  const db = mongoose.connection.db;
+
+  await db.createCollection('playerruns').catch((err) => {
+    if (err.codeName !== 'NamespaceExists') throw err;
+  });
+
+  await db.collection('playerruns').createIndexes([
+    { key: { runId: 1 }, name: 'runId_1', unique: true },
+    { key: { playerId: 1 }, name: 'playerId_1' },
+    { key: { wallet: 1, createdAt: -1 }, name: 'wallet_1_createdAt_-1' },
+    { key: { isFirstRun: 1, score: -1 }, name: 'isFirstRun_1_score_-1' },
+    { key: { isFirstRun: 1, distance: -1 }, name: 'isFirstRun_1_distance_-1' },
+    { key: { isFirstRun: 1, goldCoins: -1, silverCoins: -1 }, name: 'isFirstRun_1_goldCoins_-1_silverCoins_-1' },
+    { key: { verified: 1, isValid: 1, createdAt: -1 }, name: 'verified_1_isValid_1_createdAt_-1' }
+  ]);
+
+  await db.collection('players').createIndex({ bestScore: -1 }, { name: 'bestScore_-1' });
+  await db.createCollection('leaderboardaggregates').catch((err) => {
+    if (err.codeName !== 'NamespaceExists') throw err;
+  });
+  await db.collection('leaderboardaggregates').createIndexes([
+    { key: { key: 1 }, name: 'key_1', unique: true },
+    { key: { refreshedAt: -1 }, name: 'refreshedAt_-1' }
+  ]);
+
+  console.log('Migration completed: leaderboard insights structures are ready.');
+  await mongoose.disconnect();
+}
+
+run().catch(async (err) => {
+  console.error('Migration failed:', err.message);
+  try { await mongoose.disconnect(); } catch (_) {}
+  process.exit(1);
+});

--- a/services/leaderboardAggregateRefreshService.js
+++ b/services/leaderboardAggregateRefreshService.js
@@ -1,0 +1,22 @@
+const Player = require('../models/Player');
+const PlayerRun = require('../models/PlayerRun');
+const LeaderboardAggregate = require('../models/LeaderboardAggregate');
+
+async function refreshLeaderboardAggregates() {
+  const [totalRankedPlayers, firstRunCount] = await Promise.all([
+    Player.countDocuments({ bestScore: { $gt: 0 } }),
+    PlayerRun.countDocuments({ verified: true, isValid: true, isFirstRun: true })
+  ]);
+
+  await LeaderboardAggregate.findOneAndUpdate(
+    { key: 'leaderboard_core_stats' },
+    {
+      key: 'leaderboard_core_stats',
+      payload: { totalRankedPlayers, firstRunCount },
+      refreshedAt: new Date()
+    },
+    { upsert: true, new: true }
+  );
+}
+
+module.exports = { refreshLeaderboardAggregates };

--- a/services/leaderboardInsightsService.js
+++ b/services/leaderboardInsightsService.js
@@ -1,0 +1,286 @@
+const Player = require('../models/Player');
+const PlayerRun = require('../models/PlayerRun');
+
+const DEFAULTS = {
+  insightsEnabled: process.env.LEADERBOARD_INSIGHTS_ENABLED !== 'false',
+  minimumSegmentSize: Number(process.env.LEADERBOARD_INSIGHTS_MIN_SEGMENT_SIZE || 30),
+  weakPercentileThreshold: Number(process.env.LEADERBOARD_INSIGHTS_WEAK_PERCENTILE || 20),
+  realisticDeltaTop10: Number(process.env.LEADERBOARD_INSIGHTS_MAX_DELTA_TOP10 || 1200),
+  realisticDeltaTop100: Number(process.env.LEADERBOARD_INSIGHTS_MAX_DELTA_TOP100 || 2200),
+  realisticDeltaTop1000: Number(process.env.LEADERBOARD_INSIGHTS_MAX_DELTA_TOP1000 || 3200),
+  realisticDeltaTop10000: Number(process.env.LEADERBOARD_INSIGHTS_MAX_DELTA_TOP10000 || 4500)
+};
+
+async function computeRank(bestScore) {
+  if (!bestScore || bestScore <= 0) {
+    return { rank: null, totalRankedPlayers: await Player.countDocuments({ bestScore: { $gt: 0 } }) };
+  }
+
+  const better = await Player.countDocuments({ bestScore: { $gt: bestScore } });
+  const total = await Player.countDocuments({ bestScore: { $gt: 0 } });
+  return { rank: better + 1, totalRankedPlayers: total };
+}
+
+function computePercentileFromRank(rank, total) {
+  if (!rank || !total || total <= 1) {
+    return null;
+  }
+
+  const percentile = ((total - rank) / (total - 1)) * 100;
+  return Number(percentile.toFixed(2));
+}
+
+async function computeSegmentPercentile({ field, value, query = {} }) {
+  if (typeof value !== 'number') {
+    return { percentile: null, sampleSize: 0 };
+  }
+
+  const baseQuery = { verified: true, isValid: true, ...query };
+  const sampleSize = await PlayerRun.countDocuments(baseQuery);
+  if (sampleSize <= 1) {
+    return { percentile: null, sampleSize };
+  }
+
+  const better = await PlayerRun.countDocuments({ ...baseQuery, [field]: { $gt: value } });
+  const percentile = ((sampleSize - (better + 1)) / (sampleSize - 1)) * 100;
+
+  return {
+    percentile: Number(Math.max(0, percentile).toFixed(2)),
+    sampleSize
+  };
+}
+
+function pickComparisonMode(metrics, cfg = DEFAULTS) {
+  const candidates = [
+    { key: 'first_run_score', percentile: metrics.percentileFirstRunScore, sampleSize: metrics.firstRunScoreSample },
+    { key: 'first_run_distance', percentile: metrics.percentileFirstRunDistance, sampleSize: metrics.firstRunDistanceSample },
+    { key: 'first_run_coins', percentile: metrics.percentileFirstRunCoins, sampleSize: metrics.firstRunCoinsSample }
+  ].filter((item) => item.sampleSize >= cfg.minimumSegmentSize && item.percentile !== null);
+
+  if (!candidates.length) {
+    return 'none';
+  }
+
+  candidates.sort((a, b) => b.percentile - a.percentile);
+  return candidates[0].key;
+}
+
+function buildFallbackType({ isFirstRun, comparisonMode, comparisonPercentile }, cfg = DEFAULTS) {
+  if (comparisonMode === 'none') {
+    return 'normal';
+  }
+
+  if (comparisonPercentile !== null && comparisonPercentile < cfg.weakPercentileThreshold) {
+    return isFirstRun ? 'weak_first_run' : 'weak_repeat_run';
+  }
+
+  return 'normal';
+}
+
+function labelForTarget(target) {
+  if (target.targetType === 'bucket') {
+    if (target.bucket === 'top10') return 'TOP 10';
+    if (target.bucket === 'top100') return 'TOP 100';
+    if (target.bucket === 'top1000') return 'TOP 1000';
+    if (target.bucket === 'top10000') return 'TOP 10000';
+  }
+
+  return `TOP ${target.targetRank}`;
+}
+
+async function getScoreAtRank(targetRank) {
+  if (!targetRank || targetRank < 1) {
+    return null;
+  }
+
+  const rows = await Player.find({ bestScore: { $gt: 0 } })
+    .sort({ bestScore: -1 })
+    .skip(targetRank - 1)
+    .limit(1)
+    .select('bestScore');
+
+  return rows?.[0]?.bestScore ?? null;
+}
+
+function uniqueTargets(targets) {
+  const seen = new Set();
+  return targets.filter((target) => {
+    const key = `${target.targetType}:${target.targetRank || target.bucket}`;
+    if (seen.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+async function buildNextTargets({ rank, playerScore }, cfg = DEFAULTS) {
+  if (!rank || !playerScore || playerScore <= 0) {
+    return [];
+  }
+
+  const targets = [];
+
+  const addRankTarget = async (targetRank, priority) => {
+    if (!targetRank || targetRank >= rank || targetRank < 1) return;
+
+    const scoreAtRank = await getScoreAtRank(targetRank);
+    if (typeof scoreAtRank !== 'number') return;
+
+    const delta = Math.max(0, scoreAtRank - playerScore + 1);
+    targets.push({
+      targetType: 'rank',
+      targetRank,
+      scoreToReach: scoreAtRank + 1,
+      delta,
+      priority
+    });
+  };
+
+  if (rank <= 10) {
+    await addRankTarget(Math.max(1, rank - 2), 1);
+    await addRankTarget(Math.max(1, rank - 1), 2);
+  } else if (rank <= 100) {
+    await addRankTarget(10, 1);
+    await addRankTarget(Math.max(11, rank - 10), 2);
+    targets.push({ targetType: 'bucket', bucket: 'top10', delta: Number.MAX_SAFE_INTEGER, priority: 3 });
+  } else if (rank <= 1000) {
+    await addRankTarget(100, 1);
+    await addRankTarget(Math.max(101, rank - 100), 2);
+    targets.push({ targetType: 'bucket', bucket: 'top100', delta: Number.MAX_SAFE_INTEGER, priority: 3 });
+  } else if (rank <= 10000) {
+    await addRankTarget(1000, 1);
+    await addRankTarget(Math.max(1001, rank - 500), 2);
+    targets.push({ targetType: 'bucket', bucket: 'top1000', delta: Number.MAX_SAFE_INTEGER, priority: 3 });
+  } else {
+    await addRankTarget(10000, 1);
+    targets.push({ targetType: 'bucket', bucket: 'top10000', delta: Number.MAX_SAFE_INTEGER, priority: 2 });
+  }
+
+  const realTargets = uniqueTargets(targets)
+    .filter((item) => !(item.targetType === 'rank' && item.delta === 0))
+    .sort((a, b) => a.priority - b.priority);
+
+  return realTargets;
+}
+
+function pickRecommendedTarget(nextTargets, rank, cfg = DEFAULTS) {
+  if (!nextTargets.length) {
+    return null;
+  }
+
+  const deltaCap = rank <= 10
+    ? cfg.realisticDeltaTop10
+    : rank <= 100
+      ? cfg.realisticDeltaTop100
+      : rank <= 1000
+        ? cfg.realisticDeltaTop1000
+        : cfg.realisticDeltaTop10000;
+
+  const realistic = nextTargets.find((target) => target.targetType === 'rank' && target.delta <= deltaCap)
+    || nextTargets.find((target) => target.targetType === 'rank')
+    || nextTargets[0];
+
+  return {
+    targetType: realistic.targetType,
+    label: labelForTarget(realistic),
+    delta: Number.isFinite(realistic.delta) ? realistic.delta : deltaCap
+  };
+}
+
+async function computePlayerInsights({ wallet, player, latestRun, config = DEFAULTS }) {
+  if (!config.insightsEnabled || !wallet || !player) {
+    return null;
+  }
+
+  const run = latestRun || await PlayerRun.findOne({ wallet, verified: true, isValid: true }).sort({ createdAt: -1 });
+  if (!run) {
+    return {
+      isFirstRun: false,
+      isPersonalBest: false,
+      enteredTop10: false,
+      rank: null,
+      totalRankedPlayers: 0,
+      percentileOverall: null,
+      percentileFirstRunScore: null,
+      percentileFirstRunDistance: null,
+      percentileFirstRunCoins: null,
+      comparisonMode: 'none',
+      comparisonTextFallbackType: 'normal',
+      nextTargets: [],
+      recommendedTarget: null
+    };
+  }
+
+  const { rank, totalRankedPlayers } = await computeRank(player.bestScore);
+  const percentileOverall = computePercentileFromRank(rank, totalRankedPlayers);
+
+  const firstRunScore = await computeSegmentPercentile({
+    field: 'score',
+    value: run.score,
+    query: { isFirstRun: true }
+  });
+
+  const firstRunDistance = await computeSegmentPercentile({
+    field: 'distance',
+    value: run.distance,
+    query: { isFirstRun: true }
+  });
+
+  const firstRunCoins = await computeSegmentPercentile({
+    field: 'goldCoins',
+    value: run.goldCoins,
+    query: { isFirstRun: true }
+  });
+
+  const metrics = {
+    percentileFirstRunScore: firstRunScore.percentile,
+    firstRunScoreSample: firstRunScore.sampleSize,
+    percentileFirstRunDistance: firstRunDistance.percentile,
+    firstRunDistanceSample: firstRunDistance.sampleSize,
+    percentileFirstRunCoins: firstRunCoins.percentile,
+    firstRunCoinsSample: firstRunCoins.sampleSize
+  };
+
+  const comparisonMode = pickComparisonMode(metrics, config);
+  const comparisonPercentile = comparisonMode === 'first_run_score'
+    ? metrics.percentileFirstRunScore
+    : comparisonMode === 'first_run_distance'
+      ? metrics.percentileFirstRunDistance
+      : comparisonMode === 'first_run_coins'
+        ? metrics.percentileFirstRunCoins
+        : percentileOverall;
+
+  const comparisonTextFallbackType = buildFallbackType({
+    isFirstRun: run.isFirstRun,
+    comparisonMode,
+    comparisonPercentile
+  }, config);
+
+  const nextTargets = await buildNextTargets({ rank, playerScore: player.bestScore }, config);
+  const recommendedTarget = pickRecommendedTarget(nextTargets, rank, config);
+
+  return {
+    isFirstRun: Boolean(run.isFirstRun),
+    isPersonalBest: Boolean(run.isPersonalBest),
+    enteredTop10: Boolean(rank && rank <= 10),
+    rank,
+    totalRankedPlayers,
+    percentileOverall,
+    percentileFirstRunScore: metrics.percentileFirstRunScore,
+    percentileFirstRunDistance: metrics.percentileFirstRunDistance,
+    percentileFirstRunCoins: metrics.percentileFirstRunCoins,
+    comparisonMode,
+    comparisonTextFallbackType,
+    nextTargets,
+    recommendedTarget
+  };
+}
+
+module.exports = {
+  DEFAULTS,
+  computePlayerInsights,
+  pickComparisonMode,
+  buildFallbackType,
+  buildNextTargets,
+  pickRecommendedTarget,
+  computePercentileFromRank
+};

--- a/tests/api.integration.test.js
+++ b/tests/api.integration.test.js
@@ -5,6 +5,7 @@ const mongoose = require('mongoose');
 
 const Player = require('../models/Player');
 const GameResult = require('../models/GameResult');
+const PlayerRun = require('../models/PlayerRun');
 const PlayerUpgrades = require('../models/PlayerUpgrades');
 const SecurityEvent = require('../models/SecurityEvent');
 const LinkCode = require('../models/LinkCode');
@@ -60,6 +61,9 @@ test.beforeEach(() => {
   SecurityEvent.create = async () => ({ _id: 'sec' });
   SecurityEvent.countDocuments = async () => 0;
   GameResult.create = async () => ([{ _id: 'gr' }]);
+  PlayerRun.create = async () => ([{ _id: 'run' }]);
+  PlayerRun.findOne = () => ({ sort: async () => null });
+  PlayerRun.countDocuments = async () => 0;
   Player.prototype.save = async function save() { return this; };
   PlayerUpgrades.prototype.save = async function save() { return this; };
   LinkCode.deleteOne = async () => ({ deletedCount: 1 });

--- a/tests/leaderboardInsights.service.test.js
+++ b/tests/leaderboardInsights.service.test.js
@@ -1,0 +1,162 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const Player = require('../models/Player');
+const PlayerRun = require('../models/PlayerRun');
+const {
+  computePlayerInsights,
+  pickComparisonMode,
+  pickRecommendedTarget,
+  computePercentileFromRank
+} = require('../services/leaderboardInsightsService');
+
+function mockRankedScores(scores) {
+  Player.countDocuments = async (query = {}) => {
+    if (!query.bestScore || !query.bestScore.$gt) return scores.length;
+    return scores.filter((score) => score > query.bestScore.$gt).length;
+  };
+
+  Player.find = () => ({
+    sort() { return this; },
+    skip(idx) {
+      this._idx = idx;
+      return this;
+    },
+    limit() { return this; },
+    select() {
+      const score = scores[this._idx];
+      return Promise.resolve(score ? [{ bestScore: score }] : []);
+    }
+  });
+}
+
+test('computePercentileFromRank handles edge-cases', () => {
+  assert.equal(computePercentileFromRank(null, 100), null);
+  assert.equal(computePercentileFromRank(1, 1), null);
+  assert.equal(computePercentileFromRank(1, 101), 100);
+  assert.equal(computePercentileFromRank(101, 101), 0);
+});
+
+test('pickComparisonMode returns none when segment is too small', () => {
+  const mode = pickComparisonMode({
+    percentileFirstRunScore: 50,
+    firstRunScoreSample: 3,
+    percentileFirstRunDistance: 10,
+    firstRunDistanceSample: 3,
+    percentileFirstRunCoins: 90,
+    firstRunCoinsSample: 3
+  }, { minimumSegmentSize: 10 });
+
+  assert.equal(mode, 'none');
+});
+
+test('computePlayerInsights: first run + personal best + top10 segment', async () => {
+  mockRankedScores([12000, 10000, 9000, 8500, 8000, 7700, 7400, 7100, 7000, 6800, 6000]);
+
+  PlayerRun.findOne = () => ({
+    sort: async () => ({ isFirstRun: true, isPersonalBest: true, score: 7000, distance: 300, goldCoins: 10 })
+  });
+
+  PlayerRun.countDocuments = async (query = {}) => {
+    if (query.isFirstRun && query.score && query.score.$gt !== undefined) return 3;
+    if (query.isFirstRun && query.distance && query.distance.$gt !== undefined) return 4;
+    if (query.isFirstRun && query.goldCoins && query.goldCoins.$gt !== undefined) return 2;
+    if (query.isFirstRun) return 100;
+    return 100;
+  };
+
+  const insights = await computePlayerInsights({
+    wallet: '0xabc',
+    player: { bestScore: 7000 },
+    config: {
+    minimumSegmentSize: 10,
+    weakPercentileThreshold: 10,
+    realisticDeltaTop10: 2000,
+    realisticDeltaTop100: 3000,
+    realisticDeltaTop1000: 4000,
+    realisticDeltaTop10000: 5000,
+      insightsEnabled: true
+    }
+  });
+
+  assert.equal(insights.isFirstRun, true);
+  assert.equal(insights.isPersonalBest, true);
+  assert.equal(insights.rank, 9);
+  assert.equal(insights.enteredTop10, true);
+  assert.equal(insights.comparisonMode, 'first_run_coins');
+  assert.ok(insights.recommendedTarget);
+});
+
+test('computePlayerInsights: repeat run with weak percentile fallback', async () => {
+  mockRankedScores([5000, 4500, 4300, 4100, 3900, 3700, 3500, 3300, 3000, 2800, 2500, 2200]);
+
+  PlayerRun.findOne = () => ({
+    sort: async () => ({ isFirstRun: false, isPersonalBest: false, score: 2200, distance: 80, goldCoins: 1 })
+  });
+
+  PlayerRun.countDocuments = async (query = {}) => {
+    if (query.isFirstRun && query.score && query.score.$gt !== undefined) return 94;
+    if (query.isFirstRun && query.distance && query.distance.$gt !== undefined) return 95;
+    if (query.isFirstRun && query.goldCoins && query.goldCoins.$gt !== undefined) return 98;
+    if (query.isFirstRun) return 100;
+    return 100;
+  };
+
+  const insights = await computePlayerInsights({
+    wallet: '0xabc',
+    player: { bestScore: 2200 },
+    config: {
+    minimumSegmentSize: 10,
+    weakPercentileThreshold: 25,
+    realisticDeltaTop10: 200,
+    realisticDeltaTop100: 400,
+    realisticDeltaTop1000: 900,
+    realisticDeltaTop10000: 3000,
+      insightsEnabled: true
+    }
+  });
+
+  assert.equal(insights.comparisonTextFallbackType, 'weak_repeat_run');
+  assert.equal(insights.isFirstRun, false);
+});
+
+test('recommended target supports top100/top1000/top10000 buckets', () => {
+  const top100 = pickRecommendedTarget([
+    { targetType: 'rank', targetRank: 10, delta: 1500 },
+    { targetType: 'rank', targetRank: 50, delta: 300 }
+  ], 80, { realisticDeltaTop100: 400 });
+  assert.equal(top100.label, 'TOP 50');
+
+  const top1000 = pickRecommendedTarget([
+    { targetType: 'rank', targetRank: 100, delta: 900 },
+    { targetType: 'bucket', bucket: 'top100', delta: Number.MAX_SAFE_INTEGER }
+  ], 600, { realisticDeltaTop1000: 1000 });
+  assert.equal(top1000.label, 'TOP 100');
+
+  const top10000 = pickRecommendedTarget([
+    { targetType: 'rank', targetRank: 1000, delta: 1200 }
+  ], 9000, { realisticDeltaTop10000: 1300 });
+  assert.equal(top10000.label, 'TOP 1000');
+});
+
+test('computePlayerInsights ignores invalid statistical segment data', async () => {
+  mockRankedScores([100]);
+
+  PlayerRun.findOne = () => ({
+    sort: async () => ({ isFirstRun: false, isPersonalBest: true, score: 100, distance: 10, goldCoins: 0 })
+  });
+
+  PlayerRun.countDocuments = async (query = {}) => {
+    if (query.score || query.distance || query.goldCoins) return 0;
+    return 1;
+  };
+
+  const insights = await computePlayerInsights({
+    wallet: '0xabc',
+    player: { bestScore: 100 },
+    config: { insightsEnabled: true, minimumSegmentSize: 10, weakPercentileThreshold: 20 }
+  });
+
+  assert.equal(insights.comparisonMode, 'none');
+  assert.equal(insights.percentileOverall, null);
+});


### PR DESCRIPTION
### Motivation
- Provide frontend with server-computed personalized Game Over copy (record labels, percentiles, realistic next-rank targets) instead of doing fragile client-side heuristics. 
- Support robust analytics and motivational UX while preserving the public leaderboard contract and protecting against edge-cases and cheating. 
- Make percentile/rank/targets deterministic, configurable, and efficient via run history and aggregates. 

### Description
- Added a persistent run history model `PlayerRun` and write path integration into `POST /api/leaderboard/save` (saved in the same transactional/fallback flow with `playerId`, `runId`, `isFirstRun`, `isPersonalBest`, `verified`, `isValid`).
- Extended `GET /api/leaderboard/top` to optionally include `playerInsights` when the feature is enabled and the client requests v2 (`?v=2` or `?includeInsights=true`), while keeping the original `leaderboard` and `playerPosition` fields intact.
- Introduced `GET /api/leaderboard/insights?wallet=...` to fetch personalized insights without the leaderboard list.
- Implemented `services/leaderboardInsightsService.js` providing rank/percentile computation, first-run cohort percentile selection, `comparisonMode` and weak-run fallbacks, `nextTargets` generation and `recommendedTarget` selection with configurable realistic delta thresholds via env vars (e.g. `LEADERBOARD_INSIGHTS_*`).
- Added `LeaderboardAggregate` model and `services/leaderboardAggregateRefreshService.js` scaffolding for precomputed aggregates plus a DB migration script `scripts/migrations/2026-04-24-leaderboard-insights.js` to create collections and indexes optimized for rank/percentile queries.
- Added API docs `docs/api/leaderboard-insights-v2.md` describing the optional v2 contract and example `playerInsights` schema, and added unit tests `tests/leaderboardInsights.service.test.js` plus integration test stubs to cover run persistence.

### Testing
- Added unit tests for percentile/rank edge-cases, `comparisonMode` selection, recommended target logic and insufficient-segment fallbacks in `tests/leaderboardInsights.service.test.js` which exercise the service behavior. 
- Updated integration test stubs to account for `PlayerRun` persistence and ran the full test suite with `npm test`. 
- All automated tests passed: `npm test` completed with 68/68 tests green.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebe5a162a08320a8db0b1581c70390)