### PR TITLE
Fix game-over boost delta to use leaderboard best score

### DIFF
--- a/services/gameOverAgitationService.js
+++ b/services/gameOverAgitationService.js
@@ -251,11 +251,12 @@ async function buildGameOverPayload({ insights, run, previousBestScore, isAuthen
   const nextBucket = pickNextBucket(rank);
   const bucketTarget = nextBucket ? await getScoreAtRank(nextBucket) : null;
 
-  const top1Delta = top1?.bestScore ? Math.max(1, top1.bestScore - (run.score || 0) + 1) : null;
-  const top3Delta = top3?.bestScore ? Math.max(1, top3.bestScore - (run.score || 0) + 1) : null;
-  const nextRankDelta = next?.bestScore ? Math.max(1, next.bestScore - (run.score || 0) + 1) : null;
+  const playerLeaderboardScore = Math.max(run.score || 0, previousBestScore || 0);
+  const top1Delta = top1?.bestScore ? Math.max(1, top1.bestScore - playerLeaderboardScore + 1) : null;
+  const top3Delta = top3?.bestScore ? Math.max(1, top3.bestScore - playerLeaderboardScore + 1) : null;
+  const nextRankDelta = next?.bestScore ? Math.max(1, next.bestScore - playerLeaderboardScore + 1) : null;
   const nextBucketDelta = bucketTarget?.bestScore
-    ? Math.max(1, bucketTarget.bestScore - (run.score || 0) + 1)
+    ? Math.max(1, bucketTarget.bestScore - playerLeaderboardScore + 1)
     : null;
 
   const prompt = buildAgitationPrompt({

--- a/tests/gameOverAgitation.service.test.js
+++ b/tests/gameOverAgitation.service.test.js
@@ -4,9 +4,11 @@ const assert = require('node:assert/strict');
 const Player = require('../models/Player');
 const {
   buildAgitationPrompt,
+  buildGameOverPayload,
   buildGameOverLeaderboardSlice,
   resolvePersonalBestHook
 } = require('../services/gameOverAgitationService');
+const mongoose = require('mongoose');
 
 test('buildAgitationPrompt returns NEW LEADER for #1 rank', () => {
   const prompt = buildAgitationPrompt({
@@ -104,4 +106,52 @@ test('buildGameOverLeaderboardSlice returns player context rows with dim flags',
   assert.equal(slice.rows[1].isCurrentPlayerRow, true);
   assert.equal(slice.rows[0].isDimmed, true);
   assert.equal(slice.rows[2].isDimmed, true);
+});
+
+
+test('buildGameOverPayload computes #1 delta from leaderboard score, not weaker current run', async () => {
+  const originalFind = Player.find;
+  const originalReadyState = mongoose.connection.readyState;
+
+  Player.find = () => {
+    const query = {
+      _skip: 0,
+      _limit: 0,
+      sort() { return this; },
+      skip(value) { this._skip = value; return this; },
+      limit(value) { this._limit = value; return this; },
+      select() {
+        if (this._limit === 1) {
+          const rank = this._skip + 1;
+          const map = {
+            1: { wallet: '0x1', bestScore: 1000 },
+            3: { wallet: '0x3', bestScore: 900 }
+          };
+          return Promise.resolve([map[rank]].filter(Boolean));
+        }
+
+        return Promise.resolve([
+          { wallet: '0x1', bestScore: 1000 },
+          { wallet: '0x2', bestScore: 950 },
+          { wallet: '0x3', bestScore: 900 }
+        ]);
+      }
+    };
+
+    return query;
+  };
+
+  mongoose.connection.readyState = 1;
+
+  const payload = await buildGameOverPayload({
+    insights: { rank: 2, recommendedTarget: null },
+    run: { score: 600, isFirstRun: false, isPersonalBest: false },
+    previousBestScore: 950,
+    isAuthenticated: true
+  });
+
+  assert.equal(payload.boost, 'Next +51 to #1');
+
+  Player.find = originalFind;
+  mongoose.connection.readyState = originalReadyState;
 });


### PR DESCRIPTION
### Motivation
- The game-over boost messages were computed from the current run score even when the player’s leaderboard position is determined by a stronger historical best, causing misleading suggestions.
- Deltas shown for targets like `#1` or the next bucket must reflect the player’s effective leaderboard score rather than a weaker current run.

### Description
- In `services/gameOverAgitationService.js` compute `playerLeaderboardScore = Math.max(run.score || 0, previousBestScore || 0)` and use it for all delta calculations (`top1Delta`, `top3Delta`, `nextRankDelta`, `nextBucketDelta`).
- This replaces prior logic that always subtracted from `run.score`, ensuring boosts align with the leaderboard context.
- Added a regression unit test in `tests/gameOverAgitation.service.test.js` that verifies `buildGameOverPayload` computes `#1` delta from the leaderboard score when the current run is weaker.

### Testing
- Ran the test suite with `npm test -- tests/gameOverAgitation.service.test.js` and all tests passed (including the new regression test).
- The added test `buildGameOverPayload computes #1 delta from leaderboard score, not weaker current run` succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ed42fc7e8c83209e33db13d6845b4b)