### PR TITLE
Prioritize next-player boost on non-personal-best game-over runs

### DIFF
--- a/services/gameOverAgitationService.js
+++ b/services/gameOverAgitationService.js
@@ -159,7 +159,9 @@ function buildAgitationPrompt({
     return {
       title: 'GOON RUN!',
       hook: 'You can go further',
-      boost: `Beat your best score +${Math.max(1, previousBestScore - (run.score || 0) + 1)}`
+      boost: typeof nextRankDelta === 'number'
+        ? `+${nextRankDelta} points to pass the next player`
+        : `Beat your best score +${Math.max(1, previousBestScore - (run.score || 0) + 1)}`
     };
   }
 

--- a/tests/gameOverAgitation.service.test.js
+++ b/tests/gameOverAgitation.service.test.js
@@ -80,6 +80,23 @@ test('buildAgitationPrompt for unauthenticated run', () => {
   assert.match(prompt.boost, /Better than 68% of new players/);
 });
 
+test('buildAgitationPrompt prefers next-player target for non-PB authenticated runs', () => {
+  const prompt = buildAgitationPrompt({
+    rank: 25,
+    run: { isFirstRun: false, isPersonalBest: false, score: 11959 },
+    previousBestScore: 127443,
+    recommendedTarget: { targetType: 'score', label: 'your best', delta: 115485 },
+    top1Delta: null,
+    top3Delta: null,
+    nextRankDelta: 3719,
+    percentileFirstRunScore: null,
+    isAuthenticated: true
+  });
+
+  assert.equal(prompt.title, 'GOON RUN!');
+  assert.equal(prompt.boost, '+3719 points to pass the next player');
+});
+
 test('resolvePersonalBestHook maps rank buckets', () => {
   assert.equal(resolvePersonalBestHook(50), 'You’re in TOP 100!');
   assert.equal(resolvePersonalBestHook(500), 'You’re in TOP 1000!');


### PR DESCRIPTION
### Motivation
- Prevent showing an inflated "beat your best" target when a realistic leaderboard progression target exists for authenticated, non-first, non-personal-best runs.
- The previous behavior could display the player's historical best (e.g. `127443`) instead of a realistic `nextRankDelta` (e.g. the points to pass the next player), which is confusing and not motivating.

### Description
- Change `buildAgitationPrompt` in `services/gameOverAgitationService.js` to prefer `nextRankDelta` when `run.isFirstRun === false`, `run.isPersonalBest === false` and `previousBestScore > 0`, returning `+{nextRankDelta} points to pass the next player` if available instead of always showing `Beat your best score +X`.
- Added a regression test in `tests/gameOverAgitation.service.test.js` that covers a non-personal-best authenticated run with a large `previousBestScore` and a valid `nextRankDelta` to ensure the `boost` message is the next-player target.

### Testing
- Ran the tests with `npm test -- tests/gameOverAgitation.service.test.js` and the suite passed; all tests succeeded (86/86 passing).
- The new regression test specifically asserting the `boost` becomes `+{nextRankDelta} points to pass the next player` passed in the CI run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee05619498832093ed5949948040d0)