### PR TITLE
Add coin transaction history, recordCoinReward helper, and coin-history API

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ Players receive referral codes (8 chars, unambiguous alphabet) and can share the
 | Method | Path | Auth | Description |
 |---|---|---|---|
 | `GET` | `/api/account/me/profile` | Required | Player profile: rank, gold, referral URL, streak, canShareToday |
+| `GET` | `/api/account/me/coin-history?limit=50` | Required | Latest accrual history rows: `type`, `gold`, `silver`, `createdAt` |
 | `POST` | `/api/referral/track` | Required | Record that current player was referred (body: `{ ref }`) |
 | `POST` | `/api/share/start` | Required | Start a share session; returns `shareId`, `postText`, `imageUrl`, `intentUrl` |
 | `POST` | `/api/share/confirm` | Required | Confirm share after ≥30s; awards +20 gold (body: `{ shareId }`) |
@@ -318,6 +319,7 @@ For better isolation under load, you can run the bot in a separate worker proces
 | Method | Path | Auth | Description |
 |---|---|---|---|
 | `GET` | `/api/account/me/profile` | `X-Primary-Id` header | Returns rank, bestScore, gold, referralUrl, share streak, connection status, rankDelta, referralCount, nickname, leaderboardDisplay |
+| `GET` | `/api/account/me/coin-history?limit=50` | `X-Primary-Id` header | Returns latest reward accrual history (types: `share`, `ride`, `buy`, `referral`, `refer`, `task`) |
 | `POST` | `/api/account/me/nickname` | `X-Primary-Id` header | Save or update player nickname |
 | `POST` | `/api/account/me/display-mode` | `X-Primary-Id` header | Save leaderboard display mode |
 

--- a/models/CoinTransaction.js
+++ b/models/CoinTransaction.js
@@ -1,0 +1,24 @@
+const mongoose = require('mongoose');
+
+const COIN_TRANSACTION_TYPES = ['share', 'ride', 'buy', 'referral', 'refer', 'task'];
+
+const coinTransactionSchema = new mongoose.Schema({
+  primaryId: { type: String, required: true, index: true, trim: true, lowercase: true },
+  type: { type: String, required: true, enum: COIN_TRANSACTION_TYPES },
+  gold: { type: Number, required: true, min: 0, default: 0 },
+  silver: { type: Number, required: true, min: 0, default: 0 },
+  createdAt: { type: Date, default: Date.now, index: true }
+}, { versionKey: false });
+
+coinTransactionSchema.index({ primaryId: 1, createdAt: -1 });
+
+coinTransactionSchema.pre('validate', function(next) {
+  if ((this.gold || 0) <= 0 && (this.silver || 0) <= 0) {
+    next(new Error('CoinTransaction requires positive gold or silver amount'));
+    return;
+  }
+  next();
+});
+
+module.exports = mongoose.models.CoinTransaction || mongoose.model('CoinTransaction', coinTransactionSchema);
+module.exports.COIN_TRANSACTION_TYPES = COIN_TRANSACTION_TYPES;

--- a/routes/account.js
+++ b/routes/account.js
@@ -13,6 +13,7 @@ const { requireAuth } = require('../middleware/requireAuth');
 const Player = require('../models/Player');
 const AccountLink = require('../models/AccountLink');
 const LinkCode = require('../models/LinkCode');
+const CoinTransaction = require('../models/CoinTransaction');
 const logger = require('../utils/logger');
 const { normalizeWallet, validateTimestampWindow } = require('../utils/security');
 const { validateTelegramInitData } = require('../utils/telegramAuth');
@@ -372,6 +373,36 @@ router.get('/me/profile', readLimiter, requireAuth, async (req, res) => {
   } catch (error) {
     logger.error({ err: error }, 'GET /me/profile error');
     res.status(500).json({ error: 'Server error' });
+  }
+});
+
+/**
+ * GET /api/account/me/coin-history
+ * Returns latest coin reward history (accruals only) for authenticated player.
+ */
+router.get('/me/coin-history', readLimiter, requireAuth, async (req, res) => {
+  try {
+    const primaryId = req.primaryId;
+    const rawLimit = Number(req.query?.limit);
+    const limit = Number.isFinite(rawLimit) ? Math.min(Math.max(Math.floor(rawLimit), 1), 200) : 50;
+
+    const rows = await CoinTransaction
+      .find({ primaryId })
+      .sort({ createdAt: -1 })
+      .limit(limit)
+      .select('type gold silver createdAt');
+
+    return res.json({
+      items: rows.map((row) => ({
+        type: row.type,
+        gold: row.gold || 0,
+        silver: row.silver || 0,
+        createdAt: row.createdAt
+      }))
+    });
+  } catch (error) {
+    logger.error({ err: error }, 'GET /me/coin-history error');
+    return res.status(500).json({ error: 'Server error' });
   }
 });
 

--- a/routes/leaderboard.js
+++ b/routes/leaderboard.js
@@ -18,6 +18,7 @@ const { hasAiModeAccess, validateAiSettings } = require('../utils/aiModeAccess')
 const { computePlayerInsights, computeRank, DEFAULTS: leaderboardInsightsConfig } = require('../services/leaderboardInsightsService');
 const { buildGameOverPayload } = require('../services/gameOverAgitationService');
 const { maybeGrantReferralRewards } = require('../utils/referralRewards');
+const { recordCoinReward } = require('../utils/coinHistory');
 
 const SHARE_COPY_TEMPLATE = 'I scored {score} in Ursass Tube 🐻\nCan you beat me?';
 const SHARE_HASHTAGS = '#UrsassTube #Ursas #Ursasplanet #GameChallenge #HighScore';
@@ -603,6 +604,10 @@ router.post('/save', saveResultLimiter, async (req, res) => {
       totalGoldCoins: responsePayload.totalGoldCoins,
       totalSilverCoins: responsePayload.totalSilverCoins
     }, 'Result saved (VERIFIED)');
+
+    if (coins.gold > 0 || coins.silver > 0) {
+      await recordCoinReward(walletLower, 'ride', { gold: coins.gold, silver: coins.silver }, { requestId: req.requestId });
+    }
 
     // Grant referral rewards on first valid run (non-blocking, errors logged internally)
     try {

--- a/routes/share.js
+++ b/routes/share.js
@@ -8,6 +8,7 @@ const AccountLink = require('../models/AccountLink');
 const { getUtcDayKey, getYesterdayUtcDayKey } = require('../utils/utcDay');
 const { buildReferralUrl } = require('../utils/referral');
 const { addGold } = require('../utils/goldWallet');
+const { recordCoinReward } = require('../utils/coinHistory');
 const logger = require('../utils/logger');
 
 const SHARE_REWARD_DELAY_MS = Number(process.env.SHARE_REWARD_DELAY_MS || 30000);
@@ -268,6 +269,7 @@ router.post('/confirm', shareConfirmLimiter, async (req, res) => {
     const newGoldBalance = await addGold(primaryId, SHARE_DAILY_REWARD_GOLD, 'share_daily', {
       requestId: req.requestId
     });
+    await recordCoinReward(primaryId, 'share', { gold: SHARE_DAILY_REWARD_GOLD }, { requestId: req.requestId });
 
     logger.info(
       { primaryId, shareId, goldAwarded: SHARE_DAILY_REWARD_GOLD, shareStreak: player.shareStreak },

--- a/tests/account-coin-history.test.js
+++ b/tests/account-coin-history.test.js
@@ -1,0 +1,67 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const AccountLink = require('../models/AccountLink');
+const CoinTransaction = require('../models/CoinTransaction');
+const { createApp } = require('../app');
+
+async function startServer() {
+  const app = createApp();
+  return new Promise((resolve) => {
+    const server = app.listen(0, '127.0.0.1', () => {
+      const { port } = server.address();
+      resolve({ server, baseUrl: `http://127.0.0.1:${port}` });
+    });
+  });
+}
+
+async function get(baseUrl, path, headers = {}) {
+  const res = await fetch(`${baseUrl}${path}`, { headers });
+  const json = await res.json().catch(() => ({}));
+  return { status: res.status, body: json };
+}
+
+test('GET /api/account/me/coin-history - requires auth', async () => {
+  const { server, baseUrl } = await startServer();
+  try {
+    const r = await get(baseUrl, '/api/account/me/coin-history');
+    assert.equal(r.status, 401);
+  } finally {
+    server.close();
+  }
+});
+
+test('GET /api/account/me/coin-history - returns rows with default limit', async () => {
+  const { server, baseUrl } = await startServer();
+  try {
+    AccountLink.findOne = async (q) => (q.primaryId === 'tg_hist1'
+      ? { primaryId: 'tg_hist1', telegramId: '1', wallet: null }
+      : null);
+
+    CoinTransaction.find = (query) => {
+      assert.equal(query.primaryId, 'tg_hist1');
+      return {
+        sort: () => ({
+          limit: (value) => {
+            assert.equal(value, 50);
+            return {
+              select: async () => ([
+                { type: 'share', gold: 20, silver: 0, createdAt: new Date('2026-04-28T10:00:00Z') },
+                { type: 'ride', gold: 5, silver: 3, createdAt: new Date('2026-04-28T09:00:00Z') }
+              ])
+            };
+          }
+        })
+      };
+    };
+
+    const r = await get(baseUrl, '/api/account/me/coin-history', { 'X-Primary-Id': 'tg_hist1' });
+    assert.equal(r.status, 200, JSON.stringify(r.body));
+    assert.equal(Array.isArray(r.body.items), true);
+    assert.equal(r.body.items.length, 2);
+    assert.equal(r.body.items[0].type, 'share');
+    assert.equal(r.body.items[1].silver, 3);
+  } finally {
+    server.close();
+  }
+});

--- a/tests/coinHistory.test.js
+++ b/tests/coinHistory.test.js
@@ -1,0 +1,32 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const CoinTransaction = require('../models/CoinTransaction');
+const { recordCoinReward } = require('../utils/coinHistory');
+
+test('recordCoinReward: stores normalized positive reward', async () => {
+  let createdDoc = null;
+  CoinTransaction.create = async (doc) => {
+    createdDoc = doc;
+    return doc;
+  };
+
+  const result = await recordCoinReward('TG_Player_1', 'share', { gold: 20, silver: 0 });
+  assert.ok(result);
+  assert.equal(createdDoc.primaryId, 'tg_player_1');
+  assert.equal(createdDoc.type, 'share');
+  assert.equal(createdDoc.gold, 20);
+  assert.equal(createdDoc.silver, 0);
+});
+
+test('recordCoinReward: skips zero rewards', async () => {
+  let called = false;
+  CoinTransaction.create = async () => {
+    called = true;
+    return null;
+  };
+
+  const result = await recordCoinReward('tg_player_2', 'ride', { gold: 0, silver: 0 });
+  assert.equal(result, null);
+  assert.equal(called, false);
+});

--- a/tests/share.test.js
+++ b/tests/share.test.js
@@ -5,6 +5,7 @@ const crypto = require('crypto');
 const Player = require('../models/Player');
 const AccountLink = require('../models/AccountLink');
 const ShareEvent = require('../models/ShareEvent');
+const CoinTransaction = require('../models/CoinTransaction');
 const { createApp } = require('../app');
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
@@ -164,12 +165,20 @@ test('POST /api/share/confirm - awards 20 gold after 30s', async () => {
       }
       return null;
     };
+    let historyDoc = null;
+    CoinTransaction.create = async (doc) => {
+      historyDoc = doc;
+      return doc;
+    };
 
     const r = await post(baseUrl, '/api/share/confirm', { shareId }, { 'X-Primary-Id': 'tg_gold' });
     assert.equal(r.status, 200, JSON.stringify(r.body));
     assert.equal(r.body.awarded, true);
     assert.equal(r.body.goldAwarded, 20);
     assert.ok(r.body.shareStreak >= 1);
+    assert.equal(historyDoc.type, 'share');
+    assert.equal(historyDoc.gold, 20);
+    assert.equal(historyDoc.silver, 0);
   } finally {
     server.close();
   }

--- a/utils/coinHistory.js
+++ b/utils/coinHistory.js
@@ -1,0 +1,39 @@
+const CoinTransaction = require('../models/CoinTransaction');
+const logger = require('./logger');
+
+async function recordCoinReward(primaryId, type, amounts = {}, opts = {}) {
+  const normalizedPrimaryId = String(primaryId || '').trim().toLowerCase();
+  const gold = Math.floor(Number(amounts.gold || 0));
+  const silver = Math.floor(Number(amounts.silver || 0));
+
+  if (!normalizedPrimaryId || !type) {
+    logger.warn({ primaryId, type, amounts }, 'recordCoinReward: invalid arguments');
+    return null;
+  }
+
+  if (!Number.isFinite(gold) || !Number.isFinite(silver) || gold < 0 || silver < 0) {
+    logger.warn({ primaryId: normalizedPrimaryId, type, gold, silver }, 'recordCoinReward: invalid coin values');
+    return null;
+  }
+
+  if (gold <= 0 && silver <= 0) {
+    return null;
+  }
+
+  try {
+    const entry = await CoinTransaction.create({
+      primaryId: normalizedPrimaryId,
+      type,
+      gold,
+      silver,
+      createdAt: opts.createdAt || new Date()
+    });
+
+    return entry;
+  } catch (error) {
+    logger.error({ err: error, primaryId: normalizedPrimaryId, type, gold, silver, requestId: opts.requestId }, 'recordCoinReward failed');
+    return null;
+  }
+}
+
+module.exports = { recordCoinReward };

--- a/utils/donationService.js
+++ b/utils/donationService.js
@@ -10,6 +10,7 @@ const { verifyDonationTransaction } = require('./donationVerifier');
 const logger = require('./logger');
 const { getOrCreateTelegramAccount } = require('./accountManager');
 const { createTelegramStarsInvoiceLink, answerTelegramPreCheckoutQuery, getTelegramBotToken, createTelegramStarsError } = require('./telegramStarsService');
+const { recordCoinReward } = require('./coinHistory');
 
 let verifierImpl = verifyDonationTransaction;
 const erc20TransferInterface = new ethers.utils.Interface([
@@ -348,6 +349,7 @@ async function creditDonationPayment(payment, options = {}) {
   player.totalSilverCoins += silver;
   player.updatedAt = rewardGrantedAt;
   await player.save();
+  await recordCoinReward(payment.wallet, 'buy', { gold, silver }, { requestId: options.requestId, createdAt: rewardGrantedAt });
 
   return rewardUpdate;
 }

--- a/utils/referralRewards.js
+++ b/utils/referralRewards.js
@@ -1,5 +1,6 @@
 const Player = require('../models/Player');
 const { addGold } = require('./goldWallet');
+const { recordCoinReward } = require('./coinHistory');
 const logger = require('./logger');
 
 const REFERRER_GOLD = Number(process.env.REFERRAL_REWARD_REFERRER_GOLD || 50);
@@ -43,9 +44,11 @@ async function maybeGrantReferralRewards(player, opts = {}) {
 
   // Award gold to referrer
   await addGold(referrer.wallet, REFERRER_GOLD, 'referral_referrer', opts);
+  await recordCoinReward(referrer.wallet, 'refer', { gold: REFERRER_GOLD }, opts);
 
   // Award gold to referee (current player)
   await addGold(player.wallet, REFEREE_GOLD, 'referral_referee', opts);
+  await recordCoinReward(player.wallet, 'referral', { gold: REFEREE_GOLD }, opts);
 
   // Mark as granted
   player.referralRewardGranted = true;


### PR DESCRIPTION
### Motivation
- Track and expose a persistent history of coin accruals (gold/silver) for player-facing UI and auditing because `addGold()` previously only incremented balances without any history. 
- Provide a small, safe API surface to read recent accruals and prepare integrations (share, referral, ride, buy, task) for front-end display.

### Description
- Introduces `models/CoinTransaction.js` with enum types `['share','ride','buy','referral','refer','task']`, validation requiring positive gold or silver, and index `{ primaryId: 1, createdAt: -1 }`.
- Adds `utils/coinHistory.js` exposing `recordCoinReward(primaryId, type, { gold, silver }, opts)` which normalizes `primaryId`, rejects invalid/zero amounts, and safely creates history rows with error logging.
- Integrates history writes using `recordCoinReward` in existing flows: `routes/share.js` (after awarding daily share gold → `share`), `utils/referralRewards.js` (awards `refer` to referrer and `referral` to referee), `routes/leaderboard.js` save flow (`ride` when run coins > 0), and `utils/donationService.js` credit flow (`buy` with `createdAt` set to reward time).
- Adds authenticated endpoint `GET /api/account/me/coin-history?limit=50` (clamped 1..200) returning `[{ type, gold, silver, createdAt }]` sorted by `createdAt desc`, plus README documentation and focused tests for helper, endpoint, and share integration.

### Testing
- Ran syntax check with `npm run check:syntax`, which passed.
- Ran focused unit/integration tests with `NODE_ENV=test node --test tests/coinHistory.test.js tests/account-coin-history.test.js tests/share.test.js tests/referralRewards.test.js`, and these tests passed.
- Executed the full test suite with `npm test`; focused changes are green but the full suite in this environment reported unrelated failures caused by a missing asset (`img/Score_result`) impacting the PNG share-image test.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0af5cc2a08320af29e37098a37e93)