### PR TITLE
Show "You're still #1" for rank 1 in TOP-3 agitation and add test

### DIFF
--- a/services/gameOverAgitationService.js
+++ b/services/gameOverAgitationService.js
@@ -71,7 +71,11 @@ const AGITATION_RULES = [
       const isBadRun = score < 1000 || score < (ctx.previousBestScore || 0) * 0.5;
       return isBadRun && !ctx.run?.isPersonalBest;
     },
-    build: () => ({ title: 'GOOD RUN!', hook: "You're still TOP 3", boost: "Don't lose your position" })
+    build: ctx => ({
+      title: 'GOOD RUN!',
+      hook: ctx.rank === 1 ? "You're still #1" : "You're still TOP 3",
+      boost: "Don't lose your position"
+    })
   },
   // C: bad run, was in TOP 10 (not TOP 3)
   {

--- a/tests/gameOverAgitation.service.test.js
+++ b/tests/gameOverAgitation.service.test.js
@@ -82,6 +82,19 @@ test('B: auth, prevRank=2, score=400 → GOOD RUN! still TOP 3', () => {
   assert.equal(prompt.boost, "Don't lose your position");
 });
 
+test('B: auth, prevRank=1, score=400 → GOOD RUN! still #1', () => {
+  const prompt = buildAgitationPrompt({
+    rank: 1,
+    run: run({ score: 400 }),
+    previousBestScore: 2000,
+    isAuthenticated: true,
+    prevRank: 1
+  });
+  assert.equal(prompt.title, 'GOOD RUN!');
+  assert.equal(prompt.hook, "You're still #1");
+  assert.equal(prompt.boost, "Don't lose your position");
+});
+
 test('C: auth, prevRank=8, score=400 → GOOD RUN! still currentRank, push TOP 10', () => {
   const prompt = buildAgitationPrompt({
     rank: 8,


### PR DESCRIPTION
### Motivation
- Make the end-of-run agitation prompt more specific for authenticated users who remain #1 after a weaker run instead of always saying "You're still TOP 3".

### Description
- In `services/gameOverAgitationService.js` updated rule B's `build` to inspect `ctx.rank` and return the hook `You're still #1` when `ctx.rank === 1`, otherwise keep `You're still TOP 3`.

### Testing
- Added a unit test in `tests/gameOverAgitation.service.test.js` that calls `buildAgitationPrompt` with `rank: 1`/`prevRank: 1` and asserts the hook is `You're still #1`, and ran the test suite which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0f5f6f2a08320bf4c9e89ee7322cc)