### PR TITLE
Support Bearer auth identity fallback in requireAuth

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,18 +116,20 @@ Versioned aliases are also available under `/api/v1/*` (backward-compatible with
 
 ## Auth Headers
 
-Authenticated endpoints resolve the caller identity from one of three request headers (checked in order):
+Authenticated endpoints resolve the caller identity from one of four auth inputs (checked in order):
 
 | Header | Description |
 |---|---|
 | `X-Primary-Id` | **Preferred.** The canonical `primaryId` of the AccountLink record (e.g. `tg_123` or `0xabc`). |
 | `X-Wallet` | **Fallback.** Wallet address *or* telegram primaryId (e.g. `tg_123`). The middleware tries `wallet` field first, then `primaryId` field. |
+| `Authorization: Bearer <id>` | Bearer token treated as `primaryId`/wallet identifier with cross-field fallback lookup. Useful when frontend auth is token-based. |
 | `X-Telegram-Init-Data` | Raw Telegram WebApp `initData` string. Validated via HMAC; account looked up by `telegramId`. |
 
 The auth middleware (`middleware/requireAuth.js`) performs cross-field lookups for robustness:
 
 - When `X-Primary-Id` is provided: tries `{ primaryId }` first, then `{ wallet }` as fallback.
 - When `X-Wallet` is provided: tries `{ wallet }` first, then `{ primaryId }` as fallback.
+- When `Authorization: Bearer <id>` is provided: tries `{ primaryId }` first, then `{ wallet }` as fallback.
 
 This ensures Telegram-only users (whose `primaryId` is `tg_<id>`) can authenticate even when the frontend sends their identifier in the `X-Wallet` header.
 

--- a/app.js
+++ b/app.js
@@ -65,7 +65,7 @@ function createApp() {
     },
     credentials: true,
     methods: ['GET', 'POST', 'OPTIONS'],
-    allowedHeaders: ['Content-Type', 'X-Wallet', 'X-Primary-Id', 'X-Telegram-Init-Data', 'x-telegram-init-data', 'X-Request-Id'],
+    allowedHeaders: ['Content-Type', 'Authorization', 'X-Wallet', 'X-Primary-Id', 'X-Telegram-Init-Data', 'x-telegram-init-data', 'X-Request-Id'],
     optionsSuccessStatus: 204
   };
 

--- a/middleware/requireAuth.js
+++ b/middleware/requireAuth.js
@@ -5,7 +5,8 @@
  * Resolves primaryId from request using:
  *   1. X-Primary-Id header → findOne({ primaryId }) with fallback to findOne({ wallet })
  *   2. X-Wallet header → findOne({ wallet }) with fallback to findOne({ primaryId })
- *   3. X-Telegram-Init-Data header → validate and look up AccountLink by telegramId
+ *   3. Authorization: Bearer <primaryId|wallet> → same cross-field lookup as above
+ *   4. X-Telegram-Init-Data header → validate and look up AccountLink by telegramId
  *
  * Sets req.primaryId and req.authLink on success.
  * Returns 401 on failure.
@@ -21,10 +22,11 @@ const logger = require('../utils/logger');
  *
  * @param {string} rawPrimaryId - Value from X-Primary-Id header (trimmed, lowercased)
  * @param {string} rawWallet    - Value from X-Wallet header (trimmed, lowercased)
+ * @param {string} rawBearerId  - Parsed Bearer token (trimmed, lowercased)
  * @param {string} initData     - Raw X-Telegram-Init-Data header value
  * @returns {object|null} AccountLink document, { __invalid: 'initdata' } on bad initData, or null
  */
-async function findLink(rawPrimaryId, rawWallet, initData) {
+async function findLink(rawPrimaryId, rawWallet, rawBearerId, initData) {
   if (rawPrimaryId) {
     const byPrimary = await AccountLink.findOne({ primaryId: rawPrimaryId });
     if (byPrimary) return byPrimary;
@@ -37,6 +39,13 @@ async function findLink(rawPrimaryId, rawWallet, initData) {
     if (byWallet) return byWallet;
     const byPrimary = await AccountLink.findOne({ primaryId: rawWallet });
     if (byPrimary) return byPrimary;
+  }
+
+  if (rawBearerId) {
+    const byPrimary = await AccountLink.findOne({ primaryId: rawBearerId });
+    if (byPrimary) return byPrimary;
+    const byWallet = await AccountLink.findOne({ wallet: rawBearerId });
+    if (byWallet) return byWallet;
   }
 
   if (initData) {
@@ -61,12 +70,15 @@ async function requireAuth(req, res, next) {
   try {
     const rawPrimaryId = (req.get('x-primary-id') || '').trim().toLowerCase();
     const rawWallet = (req.get('x-wallet') || '').trim().toLowerCase();
+    const authorization = req.get('authorization') || '';
+    const bearerMatch = authorization.match(/^Bearer\s+(.+)$/i);
+    const rawBearerId = bearerMatch ? bearerMatch[1].trim().toLowerCase() : '';
     const initData = req.get('x-telegram-init-data') || req.get('X-Telegram-Init-Data') || '';
 
-    const link = await findLink(rawPrimaryId, rawWallet, initData);
+    const link = await findLink(rawPrimaryId, rawWallet, rawBearerId, initData);
 
     if (!link) {
-      logger.warn({ rawWallet, rawPrimaryId, hasInitData: !!initData }, 'requireAuth: no AccountLink found');
+      logger.warn({ rawWallet, rawPrimaryId, rawBearerId, hasInitData: !!initData }, 'requireAuth: no AccountLink found');
       return res.status(401).json({ error: 'Unauthorized: no valid auth credentials' });
     }
 

--- a/tests/requireAuth.test.js
+++ b/tests/requireAuth.test.js
@@ -100,7 +100,7 @@ test('findLink: wallet-auth user — X-Wallet 0xabc → found by wallet field', 
       if (q.wallet === '0xabc') return link;
       return null;
     };
-    const result = await findLink('', '0xabc', '');
+    const result = await findLink('', '0xabc', '', '');
     assert.ok(result, 'should find a link');
     assert.equal(result.wallet, '0xabc');
     assert.equal(result.primaryId, 'tg_abc');
@@ -118,7 +118,7 @@ test('findLink: telegram-auth user without wallet — X-Wallet: tg_123 → fallb
       if (q.primaryId === 'tg_123') return link; // found by primaryId (fallback)
       return null;
     };
-    const result = await findLink('', 'tg_123', '');
+    const result = await findLink('', 'tg_123', '', '');
     assert.ok(result, 'should find a link via primaryId fallback');
     assert.equal(result.primaryId, 'tg_123');
   } finally {
@@ -134,7 +134,7 @@ test('findLink: legacy wallet-only — X-Primary-Id: 0xabc → found by primaryI
       if (q.primaryId === '0xabc') return link;
       return null;
     };
-    const result = await findLink('0xabc', '', '');
+    const result = await findLink('0xabc', '', '', '');
     assert.ok(result, 'should find a link by primaryId');
     assert.equal(result.primaryId, '0xabc');
   } finally {
@@ -151,7 +151,7 @@ test('findLink: X-Primary-Id set but not in primaryId field → fallback to wall
       if (q.wallet === '0xfallback') return link;    // found by wallet fallback
       return null;
     };
-    const result = await findLink('0xfallback', '', '');
+    const result = await findLink('0xfallback', '', '', '');
     assert.ok(result, 'should find a link via wallet fallback');
     assert.equal(result.primaryId, 'tg_fallback');
   } finally {
@@ -163,7 +163,7 @@ test('findLink: no match → returns null', async () => {
   const origFindOne = AccountLink.findOne;
   try {
     AccountLink.findOne = async () => null;
-    const result = await findLink('nobody', 'nobody', '');
+    const result = await findLink('nobody', 'nobody', '', '');
     assert.equal(result, null);
   } finally {
     AccountLink.findOne = origFindOne;
@@ -174,7 +174,7 @@ test('findLink: no identifiers provided → returns null', async () => {
   const origFindOne = AccountLink.findOne;
   try {
     AccountLink.findOne = async () => null;
-    const result = await findLink('', '', '');
+    const result = await findLink('', '', '', '');
     assert.equal(result, null);
   } finally {
     AccountLink.findOne = origFindOne;
@@ -195,11 +195,27 @@ test('findLink: valid Telegram initData → found by telegramId', async () => {
       return null;
     };
     const initData = makeValidInitData(userId, botToken);
-    const result = await findLink('', '', initData);
+    const result = await findLink('', '', '', initData);
     assert.ok(result, 'should find a link by telegramId');
     assert.equal(result.telegramId, String(userId));
   } finally {
     process.env.TELEGRAM_BOT_TOKEN = origBotToken;
+    AccountLink.findOne = origFindOne;
+  }
+});
+
+test('findLink: Authorization bearer value mapped to primaryId works', async () => {
+  const link = makeLink({ primaryId: 'tg_bearer', wallet: null });
+  const origFindOne = AccountLink.findOne;
+  try {
+    AccountLink.findOne = async (q) => {
+      if (q.primaryId === 'tg_bearer') return link;
+      return null;
+    };
+    const result = await findLink('', '', 'tg_bearer', '');
+    assert.ok(result, 'should find a link using bearer id as primaryId');
+    assert.equal(result.primaryId, 'tg_bearer');
+  } finally {
     AccountLink.findOne = origFindOne;
   }
 });
@@ -209,7 +225,7 @@ test('findLink: invalid Telegram initData → returns { __invalid: "initdata" }'
   try {
     AccountLink.findOne = async () => null;
     // 'bad_init_data' has no hash field → will fail validation
-    const result = await findLink('', '', 'bad_init_data');
+    const result = await findLink('', '', '', 'bad_init_data');
     assert.ok(result, 'should return sentinel object');
     assert.equal(result.__invalid, 'initdata');
   } finally {
@@ -231,6 +247,24 @@ test('requireAuth: sets req.primaryId and req.authLink on success', async () => 
     await requireAuth(req, res, next);
     assert.ok(isNextCalled(), 'next() should be called');
     assert.equal(req.primaryId, 'tg_mw1');
+    assert.deepStrictEqual(req.authLink, link);
+  } finally {
+    AccountLink.findOne = origFindOne;
+  }
+});
+
+test('requireAuth: Authorization Bearer header authenticates user', async () => {
+  const link = makeLink({ primaryId: 'tg_token', wallet: '0xtoken' });
+  const origFindOne = AccountLink.findOne;
+  try {
+    AccountLink.findOne = async (q) => {
+      if (q.primaryId === 'tg_token') return link;
+      return null;
+    };
+    const { req, res, next, isNextCalled } = makeReqRes({ authorization: 'Bearer tg_token' });
+    await requireAuth(req, res, next);
+    assert.ok(isNextCalled(), 'next() should be called');
+    assert.equal(req.primaryId, 'tg_token');
     assert.deepStrictEqual(req.authLink, link);
   } finally {
     AccountLink.findOne = origFindOne;


### PR DESCRIPTION
### Motivation

- Frontends may send caller identity using standard `Authorization: Bearer <id>` instead of custom `X-Primary-Id`/`X-Wallet` headers, which caused valid requests to be treated as unauthorized. 
- Allowing Bearer tokens to map to `primaryId`/`wallet` with the same cross-field fallback increases robustness and reduces 401s.
- CORS preflights must allow `Authorization` so browsers can send Bearer tokens from the frontend.

### Description

- `middleware/requireAuth.js` now parses `Authorization: Bearer <id>`, passes the parsed token into `findLink`, and tries lookups by `{ primaryId }` then `{ wallet }` for that token. 
- `findLink` signature updated to accept the bearer id (`rawBearerId`) and includes the same cross-field fallback logic for the bearer token as for `X-Primary-Id`/`X-Wallet`, and failure logging now includes the parsed bearer id. 
- `app.js` CORS `allowedHeaders` updated to include `Authorization` so preflight requests permit Bearer headers. 
- `README.md` updated to document `Authorization: Bearer <id>` as an auth input and its lookup order, and `tests/requireAuth.test.js` updated to the new `findLink` signature and to include unit tests for bearer-based flows.

### Testing

- Ran the unit tests for the modified module with `node --test tests/requireAuth.test.js`, and all tests passed. 
- Ran a broader test invocation `npm test -- tests/requireAuth.test.js tests/securityHeaders.test.js` which exercised many integration tests; the requireAuth-related tests passed but an unrelated integration test (`GET /api/leaderboard/share/image/:wallet.png`) failed with a 500 due to a missing image asset in the test environment. 
- The changes are covered by the new/updated unit tests in `tests/requireAuth.test.js` which assert both `findLink` and `requireAuth` behaviors for Bearer flows.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0fed1ec2c8320b0c9da179225ced5)