### PR TITLE
Add PNG share rendering and X share-publishing endpoints; refactor share flow

### DIFF
--- a/routes/leaderboard.js
+++ b/routes/leaderboard.js
@@ -1,10 +1,8 @@
 const express = require('express');
 const router = express.Router();
 const crypto = require('crypto');
-const path = require('path');
 const mongoose = require('mongoose');
-let sharp;
-try { sharp = require('sharp'); } catch (_) { sharp = null; }
+const { renderScoreSharePng } = require('../utils/shareCard');
 const Player = require('../models/Player');
 const GameResult = require('../models/GameResult');
 const AccountLink = require('../models/AccountLink');
@@ -808,8 +806,6 @@ router.get('/share/image/:wallet.svg', readLimiter, async (req, res) => {
   }
 });
 
-const SCORE_TEMPLATE_PATH = path.join(__dirname, '..', 'img', 'Score_result');
-
 router.get('/share/image/:wallet.png', readLimiter, async (req, res) => {
   try {
     const wallet = String(req.params.wallet || '').trim().toLowerCase();
@@ -822,39 +818,16 @@ router.get('/share/image/:wallet.png', readLimiter, async (req, res) => {
       return res.status(404).json({ error: 'Player not found' });
     }
 
-    if (!sharp) {
-      return res.status(503).json({ error: 'PNG rendering unavailable' });
-    }
-
     const score = shareContext.scoreForShare;
-
-    const templateMeta = await sharp(SCORE_TEMPLATE_PATH).metadata();
-    const w = templateMeta.width || 1254;
-    const h = templateMeta.height || 1254;
-
-    const scoreText = String(score);
-    const fontSize = Math.min(180, Math.floor(w * 0.14));
-    const cx = Math.round(w / 2);
-    const cy = Math.round(h * 0.72);
-
-    const svgOverlay = Buffer.from(
-      `<svg xmlns="http://www.w3.org/2000/svg" width="${w}" height="${h}">` +
-      `<text x="${cx}" y="${cy}" text-anchor="middle"` +
-      ` font-size="${fontSize}" font-weight="900"` +
-      ` font-family="Arial Black, Arial, sans-serif"` +
-      ` fill="#ffffff" stroke="#000000" stroke-width="6">${escapeHtml(scoreText)}</text>` +
-      `</svg>`
-    );
-
-    const pngBuffer = await sharp(SCORE_TEMPLATE_PATH)
-      .composite([{ input: svgOverlay, blend: 'over' }])
-      .png({ compressionLevel: 8 })
-      .toBuffer();
+    const pngBuffer = await renderScoreSharePng(score);
 
     res.setHeader('Content-Type', 'image/png');
     res.setHeader('Cache-Control', 'public, max-age=3600');
     return res.send(pngBuffer);
   } catch (error) {
+    if (error?.code === 'share_png_unavailable') {
+      return res.status(503).json({ error: 'PNG rendering unavailable' });
+    }
     logger.error({ err: error.message, requestId: req.requestId }, 'GET /share/image/:wallet.png error');
     return res.status(500).json({ error: 'Server error', requestId: req.requestId });
   }

--- a/routes/share.js
+++ b/routes/share.js
@@ -107,9 +107,14 @@ router.post('/start', shareStartLimiter, async (req, res) => {
     const imageUrl = walletAddress
       ? `${baseUrl}/api/leaderboard/share/image/${walletAddress}.png`
       : `${baseUrl}/api/leaderboard/share/image/default.svg`;
+    const shareUrl = walletAddress
+      ? `${baseUrl}/api/leaderboard/share/page/${walletAddress}`
+      : '';
 
     const postText = buildSharePostText(scoreAtShare, referralUrl);
-    const intentUrl = `https://twitter.com/intent/tweet?text=${encodeURIComponent(postText)}`;
+    const intentUrl = walletAddress
+      ? `https://twitter.com/intent/tweet?text=${encodeURIComponent(postText)}&url=${encodeURIComponent(shareUrl)}`
+      : `https://twitter.com/intent/tweet?text=${encodeURIComponent(postText)}`;
 
     if (!canShareToday) {
       return res.json({
@@ -118,6 +123,7 @@ router.post('/start', shareStartLimiter, async (req, res) => {
         shareUrl: referralUrl,
         postText,
         imageUrl,
+        previewUrl: shareUrl || null,
         intentUrl,
         eligibleForReward: false,
         secondsUntilReward: 0,
@@ -144,6 +150,7 @@ router.post('/start', shareStartLimiter, async (req, res) => {
       postText,
       referralUrl,
       imageUrl,
+      previewUrl: shareUrl || null,
       intentUrl,
       eligibleForReward: true,
       secondsUntilReward: Math.ceil(SHARE_REWARD_DELAY_MS / 1000)

--- a/routes/x.js
+++ b/routes/x.js
@@ -16,6 +16,8 @@ const OAuthState = require('../models/OAuthState');
 const Player = require('../models/Player');
 const AccountLink = require('../models/AccountLink');
 const xOAuth = require('../utils/xOAuth');
+const { buildReferralUrl } = require('../utils/referral');
+const { renderScoreSharePng } = require('../utils/shareCard');
 const { logSecurityEvent } = require('../utils/security');
 const logger = require('../utils/logger');
 const { findLink } = require('../middleware/requireAuth');
@@ -69,6 +71,31 @@ const statusLimiter = rateLimit({
   legacyHeaders: false,
   keyGenerator: getClientIp
 });
+
+const shareResultLimiter = rateLimit({
+  windowMs: 60 * 1000,
+  max: 10,
+  message: 'Too many share requests. Please wait.',
+  standardHeaders: true,
+  legacyHeaders: false,
+  keyGenerator: getClientIp
+});
+
+const SHARE_COPY_TEMPLATE = 'I scored {score} in Ursass Tube 🐻\nCan you beat me?';
+const SHARE_HASHTAGS = '#UrsassTube #Ursas #Ursasplanet #GameChallenge #HighScore';
+
+function getPublicBaseUrl(req) {
+  const configured = (process.env.PUBLIC_BASE_URL || process.env.APP_BASE_URL || '').trim();
+  if (configured) return configured.replace(/\/+$/, '');
+  return `${req.protocol}://${req.get('host')}`;
+}
+
+function buildSharePostText(score, referralUrl) {
+  const normalizedScore = Math.max(0, Math.floor(Number(score || 0)));
+  const main = SHARE_COPY_TEMPLATE.replace('{score}', normalizedScore);
+  const parts = [main, referralUrl ? referralUrl.trim() : '', SHARE_HASHTAGS].filter(Boolean);
+  return parts.join('\n');
+}
 
 /**
  * Resolve authenticated primaryId from request headers.
@@ -318,6 +345,88 @@ router.get('/status', statusLimiter, requireXOAuth, async (req, res) => {
     });
   } catch (err) {
     logger.error({ err: err.message }, 'GET /x/status error');
+    return res.status(500).json({ error: 'Server error' });
+  }
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// POST /share-result
+// Publish share result as a real post via connected X account.
+// ─────────────────────────────────────────────────────────────────────────────
+router.post('/share-result', shareResultLimiter, requireXOAuth, async (req, res) => {
+  try {
+    const link = await resolveAuth(req);
+    if (!link) {
+      return res.status(401).json({ error: 'Authentication required' });
+    }
+
+    const primaryId = link.primaryId;
+    const player = await Player.findOne({ wallet: primaryId }).select('+xAccessToken +xRefreshToken');
+    if (!player) {
+      return res.status(404).json({ error: 'Player not found' });
+    }
+
+    if (!player.xAccessToken) {
+      return res.status(400).json({ error: 'x_not_connected' });
+    }
+
+    const scoreForShare = player.bestScore || 0;
+    const referralUrl = buildReferralUrl(player.referralCode || '', req);
+    const postText = buildSharePostText(scoreForShare, referralUrl);
+    const walletAddress = link.wallet || null;
+    const sharePageUrl = walletAddress
+      ? `${getPublicBaseUrl(req)}/api/leaderboard/share/page/${walletAddress}`
+      : null;
+    const tweetText = sharePageUrl ? `${postText}\n${sharePageUrl}` : postText;
+    const shareImageBuffer = await renderScoreSharePng(scoreForShare);
+
+    let tokenToUse = player.xAccessToken;
+    let tweet;
+    try {
+      const mediaId = await xOAuth.uploadMedia(tokenToUse, shareImageBuffer);
+      tweet = await xOAuth.createTweet(tokenToUse, {
+        text: tweetText,
+        media: mediaId ? { media_ids: [mediaId] } : undefined
+      });
+    } catch (err) {
+      if (err?.response?.status !== 401 || !player.xRefreshToken) {
+        throw err;
+      }
+
+      const refreshed = await xOAuth.refreshAccessToken(player.xRefreshToken);
+      tokenToUse = refreshed.access_token || '';
+      player.xAccessToken = tokenToUse || null;
+      if (refreshed.refresh_token) {
+        player.xRefreshToken = refreshed.refresh_token;
+      }
+      await player.save();
+
+      const mediaId = await xOAuth.uploadMedia(tokenToUse, shareImageBuffer);
+      tweet = await xOAuth.createTweet(tokenToUse, {
+        text: tweetText,
+        media: mediaId ? { media_ids: [mediaId] } : undefined
+      });
+    }
+
+    if (!tweet?.id) {
+      return res.status(502).json({ error: 'x_tweet_failed' });
+    }
+
+    const tweetUrl = player.xUsername
+      ? `https://x.com/${player.xUsername}/status/${tweet.id}`
+      : `https://x.com/i/web/status/${tweet.id}`;
+
+    return res.json({
+      posted: true,
+      tweetId: tweet.id,
+      tweetUrl,
+      text: tweet.text || tweetText
+    });
+  } catch (err) {
+    if (err?.code === 'share_png_unavailable') {
+      return res.status(503).json({ error: 'share_png_unavailable' });
+    }
+    logger.error({ err: err.message }, 'POST /x/share-result error');
     return res.status(500).json({ error: 'Server error' });
   }
 });

--- a/tests/share.test.js
+++ b/tests/share.test.js
@@ -84,6 +84,28 @@ test('POST /api/share/start - returns shareId when eligible', async () => {
   }
 });
 
+test('POST /api/share/start - wallet-linked share contains preview URL and tweet URL with page', async () => {
+  const { server, baseUrl } = await startServer();
+  try {
+    process.env.FRONTEND_BASE_URL = 'https://ursasstube.fun';
+    const wallet = '0x1111111111111111111111111111111111111111';
+    const link = { primaryId: 'tg_player3', telegramId: '3', wallet };
+    AccountLink.findOne = async (q) => (q.primaryId === 'tg_player3' ? link : null);
+    Player.findOne = async () => makePlayer({ wallet: 'tg_player3' });
+    ShareEvent.create = async (doc) => ({ ...doc });
+
+    const r = await post(baseUrl, '/api/share/start', {}, { 'X-Primary-Id': 'tg_player3' });
+    assert.equal(r.status, 200, JSON.stringify(r.body));
+    assert.equal(r.body.imageUrl, `${baseUrl}/api/leaderboard/share/image/${wallet}.png`);
+    assert.equal(r.body.previewUrl, `${baseUrl}/api/leaderboard/share/page/${wallet}`);
+    assert.match(r.body.intentUrl, /twitter\.com\/intent\/tweet\?/);
+    assert.match(r.body.intentUrl, /&url=/);
+  } finally {
+    delete process.env.FRONTEND_BASE_URL;
+    server.close();
+  }
+});
+
 test('POST /api/share/start - already_shared_today returns no shareId', async () => {
   const { server, baseUrl } = await startServer();
   try {

--- a/tests/xOAuth.test.js
+++ b/tests/xOAuth.test.js
@@ -468,3 +468,113 @@ test('GET /api/x/status - returns connected with username after linking', async 
     server.close();
   }
 });
+
+test('POST /api/x/share-result - publishes post via connected X account', async () => {
+  setXOAuthEnv();
+  const { server, baseUrl } = await startServer();
+  const origCreateTweet = xOAuthModule.createTweet;
+  const origUploadMedia = xOAuthModule.uploadMedia;
+  try {
+    const link = {
+      primaryId: 'tg_x10',
+      telegramId: '10',
+      wallet: '0x1111111111111111111111111111111111111111'
+    };
+    AccountLink.findOne = async () => link;
+
+    const player = makePlayer({
+      wallet: 'tg_x10',
+      bestScore: 777,
+      xUserId: 'x_user_10',
+      xUsername: 'x_user_name',
+      xAccessToken: 'token_1',
+      xRefreshToken: 'refresh_1',
+      referralCode: 'ABCD1234'
+    });
+    Player.findOne = () => chainableQuery({ ...player, save: async function() { return this; } });
+
+    let sentText = '';
+    let uploadedBufferSize = 0;
+    xOAuthModule.uploadMedia = async (_token, mediaBuffer) => {
+      uploadedBufferSize = Buffer.isBuffer(mediaBuffer) ? mediaBuffer.length : 0;
+      return 'media_777';
+    };
+    xOAuthModule.createTweet = async (_token, payload) => {
+      sentText = payload.text;
+      assert.deepEqual(payload.media, { media_ids: ['media_777'] });
+      return { id: '191919', text: payload.text };
+    };
+
+    const r = await post(baseUrl, '/api/x/share-result', {}, { 'X-Primary-Id': 'tg_x10' });
+    assert.equal(r.status, 200, JSON.stringify(r.body));
+    assert.equal(r.body.posted, true);
+    assert.equal(r.body.tweetId, '191919');
+    assert.equal(r.body.tweetUrl, 'https://x.com/x_user_name/status/191919');
+    assert.ok(uploadedBufferSize > 0, 'should upload prepared PNG buffer');
+    assert.match(sentText, /I scored 777 in Ursass Tube/);
+    assert.match(sentText, /#UrsassTube/);
+    assert.match(sentText, /\/api\/leaderboard\/share\/page\/0x1111111111111111111111111111111111111111/);
+  } finally {
+    xOAuthModule.createTweet = origCreateTweet;
+    xOAuthModule.uploadMedia = origUploadMedia;
+    clearXOAuthEnv();
+    server.close();
+  }
+});
+
+test('POST /api/x/share-result - refreshes access token on 401 and retries', async () => {
+  setXOAuthEnv();
+  const { server, baseUrl } = await startServer();
+  const origCreateTweet = xOAuthModule.createTweet;
+  const origUploadMedia = xOAuthModule.uploadMedia;
+  const origRefresh = xOAuthModule.refreshAccessToken;
+  try {
+    const link = { primaryId: 'tg_x11', telegramId: '11', wallet: null };
+    AccountLink.findOne = async () => link;
+
+    const player = makePlayer({
+      wallet: 'tg_x11',
+      bestScore: 321,
+      xUserId: 'x_user_11',
+      xUsername: 'retry_user',
+      xAccessToken: 'expired_token',
+      xRefreshToken: 'refresh_token_11'
+    });
+
+    let saved = false;
+    Player.findOne = () => chainableQuery({
+      ...player,
+      save: async function() { saved = true; return this; }
+    });
+
+    let attempts = 0;
+    xOAuthModule.uploadMedia = async () => 'media_retry';
+    xOAuthModule.createTweet = async (_token, payload) => {
+      attempts += 1;
+      if (attempts === 1) {
+        const err = new Error('Unauthorized');
+        err.response = { status: 401 };
+        throw err;
+      }
+      assert.deepEqual(payload.media, { media_ids: ['media_retry'] });
+      return { id: '202020', text: payload.text };
+    };
+    xOAuthModule.refreshAccessToken = async () => ({
+      access_token: 'fresh_access',
+      refresh_token: 'fresh_refresh'
+    });
+
+    const r = await post(baseUrl, '/api/x/share-result', {}, { 'X-Primary-Id': 'tg_x11' });
+    assert.equal(r.status, 200, JSON.stringify(r.body));
+    assert.equal(r.body.posted, true);
+    assert.equal(r.body.tweetId, '202020');
+    assert.equal(attempts, 2, 'should retry createTweet once after refresh');
+    assert.equal(saved, true, 'should persist refreshed token');
+  } finally {
+    xOAuthModule.createTweet = origCreateTweet;
+    xOAuthModule.uploadMedia = origUploadMedia;
+    xOAuthModule.refreshAccessToken = origRefresh;
+    clearXOAuthEnv();
+    server.close();
+  }
+});

--- a/utils/shareCard.js
+++ b/utils/shareCard.js
@@ -1,0 +1,116 @@
+const path = require('path');
+let sharp;
+try { sharp = require('sharp'); } catch (_) { sharp = null; }
+
+function escapeXml(value) {
+  return String(value ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+const SCORE_TEMPLATE_PATH = path.join(__dirname, '..', 'img', 'score_result.png');
+
+const SCORE_LAYOUT = {
+  canvas: { width: 2048, height: 2048 },
+  box: { x: 80, y: 610, width: 1050, height: 390 },
+  fontFamily: 'Anton, Impact, Arial Black, sans-serif',
+  fontWeight: 900,
+  fontSizeDefault: 330,
+  fontSizeMin: 200,
+  fontSizeMax: 390,
+  skewX: -6,
+  fill: '#FFFFFF',
+  strokeColor: '#E7E2FF',
+  strokeWidth: 2,
+  shadowColor: '#6A4CFF',
+  shadowBlur: 28,
+  shadowOffsetX: 0,
+  shadowOffsetY: 8,
+  maxWidth: 1030
+};
+
+function clamp(value, min, max) {
+  return Math.max(min, Math.min(max, value));
+}
+
+function estimateTextWidth(text, fontSize) {
+  // Visual approximation for condensed heavy fonts (Anton/Impact)
+  return text.length * fontSize * 0.62;
+}
+
+async function renderScoreSharePng(score) {
+  if (!sharp) {
+    const err = new Error('PNG rendering unavailable');
+    err.code = 'share_png_unavailable';
+    throw err;
+  }
+
+  const normalized = Math.max(0, Math.floor(Number(score || 0)));
+  const templateMeta = await sharp(SCORE_TEMPLATE_PATH).metadata();
+  const w = templateMeta.width || 1254;
+  const h = templateMeta.height || 1254;
+
+  const scaleX = w / SCORE_LAYOUT.canvas.width;
+  const scaleY = h / SCORE_LAYOUT.canvas.height;
+  const scoreText = String(normalized);
+
+  const box = {
+    x: Math.round(SCORE_LAYOUT.box.x * scaleX),
+    y: Math.round(SCORE_LAYOUT.box.y * scaleY),
+    width: Math.round(SCORE_LAYOUT.box.width * scaleX),
+    height: Math.round(SCORE_LAYOUT.box.height * scaleY)
+  };
+
+  const maxWidth = Math.round(SCORE_LAYOUT.maxWidth * scaleX);
+  const defaultSize = SCORE_LAYOUT.fontSizeDefault * scaleY;
+  const minSize = SCORE_LAYOUT.fontSizeMin * scaleY;
+  const maxSize = SCORE_LAYOUT.fontSizeMax * scaleY;
+  const estimatedAtDefault = estimateTextWidth(scoreText, defaultSize);
+  const sizeAdjusted = estimatedAtDefault > 0
+    ? defaultSize * (maxWidth / estimatedAtDefault)
+    : defaultSize;
+  const fontSize = clamp(sizeAdjusted, minSize, maxSize);
+
+  const textX = box.x;
+  const textY = box.y + (box.height / 2);
+  const strokeWidth = Math.max(1, Math.round(SCORE_LAYOUT.strokeWidth * ((scaleX + scaleY) / 2)));
+  const shadowBlur = Math.max(2, Math.round(SCORE_LAYOUT.shadowBlur * ((scaleX + scaleY) / 2)));
+  const shadowOffsetX = Math.round(SCORE_LAYOUT.shadowOffsetX * scaleX);
+  const shadowOffsetY = Math.round(SCORE_LAYOUT.shadowOffsetY * scaleY);
+
+  const svgOverlay = Buffer.from(
+    `<svg xmlns="http://www.w3.org/2000/svg" width="${w}" height="${h}" viewBox="0 0 ${w} ${h}">` +
+    `<defs>` +
+    `<filter id="scoreGlow" x="-30%" y="-30%" width="160%" height="160%">` +
+    `<feDropShadow dx="${shadowOffsetX}" dy="${shadowOffsetY}" stdDeviation="${shadowBlur / 2}" flood-color="${SCORE_LAYOUT.shadowColor}" flood-opacity="0.95"/>` +
+    `</filter>` +
+    `</defs>` +
+    `<text x="${textX}" y="${Math.round(textY)}"` +
+    ` font-family="${SCORE_LAYOUT.fontFamily}"` +
+    ` font-size="${Math.round(fontSize)}"` +
+    ` font-weight="${SCORE_LAYOUT.fontWeight}"` +
+    ` fill="${SCORE_LAYOUT.fill}"` +
+    ` stroke="${SCORE_LAYOUT.strokeColor}"` +
+    ` stroke-width="${strokeWidth}"` +
+    ` paint-order="stroke fill"` +
+    ` filter="url(#scoreGlow)"` +
+    ` dominant-baseline="middle"` +
+    ` text-anchor="start"` +
+    ` transform="skewX(${SCORE_LAYOUT.skewX})"` +
+    ` textLength="${maxWidth}" lengthAdjust="spacingAndGlyphs">` +
+    `${escapeXml(scoreText)}</text>` +
+    `</svg>`
+  );
+
+  return sharp(SCORE_TEMPLATE_PATH)
+    .composite([{ input: svgOverlay, blend: 'over' }])
+    .png({ compressionLevel: 8 })
+    .toBuffer();
+}
+
+module.exports = {
+  renderScoreSharePng
+};

--- a/utils/xOAuth.js
+++ b/utils/xOAuth.js
@@ -6,7 +6,7 @@
  *   X_OAUTH_CLIENT_SECRET   – Client Secret (omit or set X_OAUTH_PUBLIC_CLIENT=true for public clients)
  *   X_OAUTH_PUBLIC_CLIENT   – "true" → skip Basic auth on token exchange
  *   X_OAUTH_REDIRECT_URI    – e.g. https://api.ursasstube.fun/api/x/oauth/callback
- *   X_OAUTH_SCOPES          – default "tweet.read users.read offline.access"
+ *   X_OAUTH_SCOPES          – default "tweet.read tweet.write users.read offline.access"
  */
 
 const crypto = require('crypto');
@@ -17,6 +17,8 @@ const X_AUTHORIZE_URL = 'https://x.com/i/oauth2/authorize';
 const X_TOKEN_URL = 'https://api.twitter.com/2/oauth2/token';
 const X_USERS_ME_URL = 'https://api.twitter.com/2/users/me';
 const X_REVOKE_URL = 'https://api.twitter.com/2/oauth2/revoke';
+const X_CREATE_TWEET_URL = 'https://api.twitter.com/2/tweets';
+const X_MEDIA_UPLOAD_URL = 'https://upload.twitter.com/1.1/media/upload.json';
 
 const HTTP_TIMEOUT_MS = 10_000;
 
@@ -37,7 +39,7 @@ function getRedirectUri() {
 }
 
 function getScopes() {
-  return process.env.X_OAUTH_SCOPES || 'tweet.read users.read offline.access';
+  return process.env.X_OAUTH_SCOPES || 'tweet.read tweet.write users.read offline.access';
 }
 
 /**
@@ -172,6 +174,44 @@ async function revokeToken(token) {
 }
 
 /**
+ * Upload media and return media_id_string.
+ * @param {string} accessToken
+ * @param {Buffer} mediaBuffer
+ * @returns {Promise<string>}
+ */
+async function uploadMedia(accessToken, mediaBuffer) {
+  const base64 = Buffer.from(mediaBuffer).toString('base64');
+  const body = new URLSearchParams({ media_data: base64 });
+
+  const response = await axios.post(X_MEDIA_UPLOAD_URL, body.toString(), {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      'Content-Type': 'application/x-www-form-urlencoded'
+    },
+    timeout: 30_000
+  });
+
+  return response.data?.media_id_string || '';
+}
+
+/**
+ * Create a Tweet as the authenticated user.
+ * @param {string} accessToken
+ * @param {{ text: string, media?: { media_ids: string[] } }} payload
+ * @returns {Promise<{ id: string, text: string }>}
+ */
+async function createTweet(accessToken, payload) {
+  const response = await axios.post(X_CREATE_TWEET_URL, payload, {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      'Content-Type': 'application/json'
+    },
+    timeout: HTTP_TIMEOUT_MS
+  });
+  return response.data?.data || {};
+}
+
+/**
  * Returns true if X OAuth is configured (client ID and redirect URI are set).
  */
 function isXOAuthConfigured() {
@@ -184,6 +224,8 @@ module.exports = {
   exchangeCodeForToken,
   refreshAccessToken,
   fetchXUser,
+  uploadMedia,
+  createTweet,
   revokeToken,
   isXOAuthConfigured
 };


### PR DESCRIPTION
### Motivation

- Provide a unified, higher-quality PNG share image generator and reuse it across routes to simplify rendering and enable posting to X/Twitter. 
- Allow wallet-linked shares to expose a preview page URL and include it in the tweet intent URL. 
- Enable server-side publishing of share posts via a connected X account (including token refresh) to improve sharing UX.

### Description

- Added `utils/shareCard.js` which centralizes PNG rendering using `sharp` and exposes `renderScoreSharePng(score)`, throwing `err.code === 'share_png_unavailable'` when `sharp` is not available. 
- Replaced inline PNG composition in `routes/leaderboard.js` with `renderScoreSharePng` and mapped the PNG-unavailable error to a `503` response. 
- Updated `routes/share.js` to include `previewUrl` in responses and append the share page URL to the Twitter intent `url` parameter for wallet-linked shares. 
- Extended `routes/x.js` to add helpers (`getPublicBaseUrl`, `buildSharePostText`), a rate limiter for share publishing, and a new `POST /api/x/share-result` endpoint that uploads the generated PNG via the X API and creates a tweet, including logic to refresh the access token on `401` and persist refreshed tokens. 
- Enhanced `utils/xOAuth.js` to include `tweet.write` in the default scopes and added `uploadMedia` and `createTweet` helpers to support media upload and tweet creation. 
- Updated tests: added coverage for wallet-linked share responses in `tests/share.test.js` and end-to-end tests for `POST /api/x/share-result` including normal post and token-refresh retry in `tests/xOAuth.test.js`.

### Testing

- Ran the test suite covering share flows and X OAuth: `tests/share.test.js` succeeded for the new wallet-linked preview and intent URL assertions. 
- Ran the X posting tests `tests/xOAuth.test.js` and verified that `POST /api/x/share-result` posts media and handles token refresh, both tests passed. 
- Existing share start/confirm tests were executed and continued to pass after the refactor.'}

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f111dc17888320965510b40215ac69)