### PR TITLE
Add internal analytics summary endpoint with core product metrics

### DIFF
--- a/models/AnalyticsEvent.js
+++ b/models/AnalyticsEvent.js
@@ -1,6 +1,12 @@
 const mongoose = require('mongoose');
 
 const ANALYTICS_EVENT_TYPES = Object.freeze([
+  'app_opened',
+  'run_started',
+  'run_finished',
+  'second_run_started',
+  'wallet_connect_success',
+  'donation_success',
   'game_start',
   'game_end',
   'session_length',

--- a/routes/analytics.js
+++ b/routes/analytics.js
@@ -8,6 +8,67 @@ const { markAnalyticsIngest } = require('../middleware/requestMetrics');
 const router = express.Router();
 
 const MAX_BATCH_SIZE = 100;
+const SUPPORTED_SUMMARY_EVENTS = new Set([
+  'app_opened',
+  'run_started',
+  'run_finished',
+  'second_run_started',
+  'wallet_connect_success',
+  'donation_success'
+]);
+
+function safeDivide(numerator, denominator) {
+  if (!denominator) {
+    return 0;
+  }
+  return numerator / denominator;
+}
+
+function parseRangeValue(raw) {
+  if (raw === undefined || raw === null || raw === '') {
+    return null;
+  }
+
+  if (typeof raw === 'number' || /^\d+$/.test(String(raw))) {
+    const ts = Number(raw);
+    if (Number.isFinite(ts) && ts >= 0) {
+      return ts;
+    }
+  }
+
+  const parsed = Date.parse(String(raw));
+  if (Number.isFinite(parsed) && parsed >= 0) {
+    return parsed;
+  }
+
+  return null;
+}
+
+function resolveIdentity(event) {
+  const payload = event?.payload && typeof event.payload === 'object' ? event.payload : {};
+  const pick = (...keys) => {
+    for (const key of keys) {
+      const value = payload[key];
+      if (typeof value === 'string' && value.trim()) {
+        return value.trim();
+      }
+      if (typeof value === 'number' && Number.isFinite(value)) {
+        return String(value);
+      }
+    }
+    return null;
+  };
+
+  const directId = pick('userId', 'user_id', 'uid');
+  if (directId) return `user:${directId}`;
+  const anonymousId = pick('anonymousId', 'anonymous_id', 'anonId', 'distinctId', 'distinct_id');
+  if (anonymousId) return `anon:${anonymousId}`;
+  const sessionId = pick('sessionId', 'session_id');
+  if (sessionId) return `session:${sessionId}`;
+  const ipHash = pick('ipHash', 'ip_hash');
+  if (ipHash) return `ip:${ipHash}`;
+  return null;
+}
 
 function normalizePayload(payload) {
   if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
@@ -139,6 +200,117 @@ router.post('/events', readLimiter, async (req, res, next) => {
 
 router.post('/event', readLimiter, async (req, res, next) => {
   await ingestEvents(req, res, next, true);
+});
+
+router.get('/summary', readLimiter, async (req, res, next) => {
+  try {
+    const from = parseRangeValue(req.query.from);
+    const to = parseRangeValue(req.query.to);
+
+    if (from === null || to === null || from > to) {
+      const err = new Error('from and to query params are required and must define a valid range');
+      err.statusCode = 400;
+      err.code = 'ANALYTICS_INVALID_RANGE';
+      err.expose = true;
+      throw err;
+    }
+
+    const match = {
+      timestamp: { $gte: from, $lte: to },
+      eventType: { $in: Array.from(SUPPORTED_SUMMARY_EVENTS) }
+    };
+
+    if (typeof req.query.source === 'string' && req.query.source.trim()) {
+      match['payload.source'] = req.query.source.trim();
+    }
+    if (typeof req.query.env === 'string' && req.query.env.trim()) {
+      match['payload.env'] = req.query.env.trim();
+    }
+
+    const events = await AnalyticsEvent.find(match).select({ eventType: 1, payload: 1 }).lean();
+
+    const unique = {
+      app_opened_users: new Set(),
+      run_started_users: new Set(),
+      run_finished_users: new Set(),
+      second_run_started_users: new Set(),
+      wallet_connect_success_users: new Set(),
+      donation_success_users: new Set()
+    };
+    let total_runs_started = 0;
+    let total_runs_finished = 0;
+    let donation_success_count = 0;
+    let donation_revenue_usd = 0;
+    let totalScore = 0;
+    let scoreCount = 0;
+    let totalDurationSec = 0;
+    let durationCount = 0;
+
+    for (const event of events) {
+      const identity = resolveIdentity(event);
+      const payload = event?.payload && typeof event.payload === 'object' ? event.payload : {};
+
+      if (event.eventType === 'app_opened') {
+        if (identity) unique.app_opened_users.add(identity);
+      }
+      if (event.eventType === 'run_started') {
+        total_runs_started += 1;
+        if (identity) unique.run_started_users.add(identity);
+      }
+      if (event.eventType === 'run_finished') {
+        total_runs_finished += 1;
+        if (identity) unique.run_finished_users.add(identity);
+        const score = Number(payload.score);
+        if (Number.isFinite(score)) {
+          totalScore += score;
+          scoreCount += 1;
+        }
+        const duration = Number(payload.duration_sec ?? payload.durationSec);
+        if (Number.isFinite(duration)) {
+          totalDurationSec += duration;
+          durationCount += 1;
+        }
+      }
+      if (event.eventType === 'second_run_started') {
+        if (identity) unique.second_run_started_users.add(identity);
+      }
+      if (event.eventType === 'wallet_connect_success') {
+        if (identity) unique.wallet_connect_success_users.add(identity);
+      }
+      if (event.eventType === 'donation_success') {
+        donation_success_count += 1;
+        if (identity) unique.donation_success_users.add(identity);
+        const amountUsd = Number(payload.amount_usd ?? payload.amountUsd);
+        if (Number.isFinite(amountUsd)) {
+          donation_revenue_usd += amountUsd;
+        }
+      }
+    }
+
+    const metrics = {
+      app_opened_users: unique.app_opened_users.size,
+      run_started_users: unique.run_started_users.size,
+      run_finished_users: unique.run_finished_users.size,
+      total_runs_started,
+      total_runs_finished,
+      second_run_started_users: unique.second_run_started_users.size,
+      wallet_connect_success_users: unique.wallet_connect_success_users.size,
+      donation_success_users: unique.donation_success_users.size,
+      donation_success_count,
+      donation_revenue_usd,
+      average_score: safeDivide(totalScore, scoreCount),
+      average_duration_sec: safeDivide(totalDurationSec, durationCount),
+      activation_rate: safeDivide(unique.run_started_users.size, unique.app_opened_users.size),
+      completion_rate: safeDivide(total_runs_finished, total_runs_started),
+      second_run_rate: safeDivide(unique.second_run_started_users.size, unique.run_finished_users.size),
+      wallet_conversion_rate: safeDivide(unique.wallet_connect_success_users.size, unique.app_opened_users.size),
+      donation_conversion_rate: safeDivide(unique.donation_success_users.size, unique.wallet_connect_success_users.size)
+    };
+
+    res.json({ ok: true, range: { from, to }, metrics });
+  } catch (error) {
+    next(error);
+  }
 });
 
 module.exports = router;

--- a/tests/api.integration.test.js
+++ b/tests/api.integration.test.js
@@ -1746,6 +1746,60 @@ test('POST /api/analytics/event accepts a single analytics event payload', async
   await server.close();
 });
 
+test('GET /api/analytics/summary returns base product metrics', async () => {
+  const originalFind = AnalyticsEvent.find;
+  const from = Date.now() - 3600000;
+  const to = Date.now();
+
+  const docs = [
+    { eventType: 'app_opened', payload: { userId: 'u1', source: 'tg', env: 'prod' } },
+    { eventType: 'app_opened', payload: { anonymousId: 'anon-2', source: 'tg', env: 'prod' } },
+    { eventType: 'run_started', payload: { userId: 'u1', source: 'tg', env: 'prod' } },
+    { eventType: 'run_started', payload: { anonymousId: 'anon-2', source: 'tg', env: 'prod' } },
+    { eventType: 'run_started', payload: { anonymousId: 'anon-2', source: 'tg', env: 'prod' } },
+    { eventType: 'run_finished', payload: { userId: 'u1', score: 120, duration_sec: 30, source: 'tg', env: 'prod' } },
+    { eventType: 'run_finished', payload: { anonymousId: 'anon-2', score: 80, durationSec: 50, source: 'tg', env: 'prod' } },
+    { eventType: 'second_run_started', payload: { anonymousId: 'anon-2', source: 'tg', env: 'prod' } },
+    { eventType: 'wallet_connect_success', payload: { userId: 'u1', source: 'tg', env: 'prod' } },
+    { eventType: 'donation_success', payload: { userId: 'u1', amount_usd: 3.5, source: 'tg', env: 'prod' } },
+    { eventType: 'donation_success', payload: { userId: 'u1', amountUsd: 4.5, source: 'tg', env: 'prod' } }
+  ];
+
+  AnalyticsEvent.find = () => ({
+    select: () => ({
+      lean: async () => docs
+    })
+  });
+
+  const { server, baseUrl } = await startServer();
+  try {
+    const res = await fetch(`${baseUrl}/api/analytics/summary?from=${from}&to=${to}&source=tg&env=prod`);
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.ok, true);
+    assert.equal(body.metrics.app_opened_users, 2);
+    assert.equal(body.metrics.run_started_users, 2);
+    assert.equal(body.metrics.run_finished_users, 2);
+    assert.equal(body.metrics.total_runs_started, 3);
+    assert.equal(body.metrics.total_runs_finished, 2);
+    assert.equal(body.metrics.second_run_started_users, 1);
+    assert.equal(body.metrics.wallet_connect_success_users, 1);
+    assert.equal(body.metrics.donation_success_users, 1);
+    assert.equal(body.metrics.donation_success_count, 2);
+    assert.equal(body.metrics.donation_revenue_usd, 8);
+    assert.equal(body.metrics.average_score, 100);
+    assert.equal(body.metrics.average_duration_sec, 40);
+    assert.equal(body.metrics.activation_rate, 1);
+    assert.ok(Math.abs(body.metrics.completion_rate - (2 / 3)) < 0.000001);
+    assert.equal(body.metrics.second_run_rate, 0.5);
+    assert.equal(body.metrics.wallet_conversion_rate, 0.5);
+    assert.equal(body.metrics.donation_conversion_rate, 1);
+  } finally {
+    AnalyticsEvent.find = originalFind;
+    await server.close();
+  }
+});
+
 test('GET /api/leaderboard/share/payload/:wallet uses latest score when latest run is personal best', async () => {
   const wallet = '0x1111111111111111111111111111111111111111';
 


### PR DESCRIPTION
### Motivation
- Provide a small, fast backend endpoint for Product Owner and Telegram Apps Center readiness checks that complements PostHog visualizations. 
- Allow quick verification of product events stored in `analytics_events` without introducing a BI stack. 
- Use existing analytics ingestion but expose aggregated unique/user and run/donation metrics over a time range.

### Description
- Add `GET /api/analytics/summary` with required `from` and `to` query params and optional `source` and `env` filters, including range validation and parsing. 
- Compute metrics per the spec (unique users, totals, donation revenue, averages, and conversion rates) with a `safeDivide` helper returning `0` when denominator is `0`. 
- Implement identity resolution fallback for uniqueness using `userId` → `anonymous/distinctId` → `sessionId` → `ipHash` without storing raw IPs. 
- Extend `ANALYTICS_EVENT_TYPES` to accept product events (`app_opened`, `run_started`, `run_finished`, `second_run_started`, `wallet_connect_success`, `donation_success`) and add an integration test validating the response contract and metric calculations; changes are in `routes/analytics.js`, `models/AnalyticsEvent.js` and `tests/api.integration.test.js`.

### Testing
- Ran `npm run check:syntax` and it passed successfully. 
- Ran `NODE_ENV=test node --test tests/api.integration.test.js` and the test suite passed (`52` tests, `0` failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f22b91aeec83208031f76f8f3f3d0f)