### PR TITLE
Analytics: add payload normalization, PII stripping, partial-batch ingest and summary endpoint

### DIFF
--- a/models/AnalyticsEvent.js
+++ b/models/AnalyticsEvent.js
@@ -1,6 +1,21 @@
 const mongoose = require('mongoose');
 
 const ANALYTICS_EVENT_TYPES = Object.freeze([
+  'app_opened',
+  'onboarding_completed',
+  'run_started',
+  'leaderboard_opened',
+  'wallet_connect_started',
+  'run_finished',
+  'second_run_started',
+  'wallet_connect_success',
+  'wallet_connect_failed',
+  'store_opened',
+  'upgrade_purchased',
+  'donation_started',
+  'donation_success',
+  'donation_failed',
+  'share_result_clicked',
   'game_start',
   'game_end',
   'session_length',

--- a/routes/analytics.js
+++ b/routes/analytics.js
@@ -1,4 +1,5 @@
 const express = require('express');
+const crypto = require('crypto');
 
 const { AnalyticsEvent, ANALYTICS_EVENT_TYPES } = require('../models/AnalyticsEvent');
 const { readLimiter } = require('../middleware/rateLimiter');
@@ -8,6 +9,74 @@ const { markAnalyticsIngest } = require('../middleware/requestMetrics');
 const router = express.Router();
 
 const MAX_BATCH_SIZE = 100;
+const MAX_EVENT_PAYLOAD_BYTES = 16 * 1024;
+const PII_KEYS = new Set(['username', 'first_name', 'last_name', 'displayName', 'phone', 'avatar']);
+const SUPPORTED_SUMMARY_EVENTS = new Set([
+  'app_opened',
+  'run_started',
+  'run_finished',
+  'second_run_started',
+  'wallet_connect_success',
+  'donation_success'
+]);
+
+function safeDivide(numerator, denominator) {
+  if (!denominator) {
+    return 0;
+  }
+  return numerator / denominator;
+}
+
+function parseRangeValue(raw) {
+  if (raw === undefined || raw === null || raw === '') {
+    return null;
+  }
+
+  if (typeof raw === 'number' || /^\d+$/.test(String(raw))) {
+    const ts = Number(raw);
+    if (Number.isFinite(ts) && ts >= 0) {
+      return ts;
+    }
+  }
+
+  const parsed = Date.parse(String(raw));
+  if (Number.isFinite(parsed) && parsed >= 0) {
+    return parsed;
+  }
+
+  return null;
+}
+
+function resolveIdentity(event) {
+  const payload = event?.payload && typeof event.payload === 'object' ? event.payload : {};
+  const pick = (...keys) => {
+    for (const key of keys) {
+      const value = payload[key];
+      if (typeof value === 'string' && value.trim()) {
+        return value.trim();
+      }
+      if (typeof value === 'number' && Number.isFinite(value)) {
+        return String(value);
+      }
+    }
+    return null;
+  };
+
+  const directId = pick('userId', 'user_id', 'uid');
+  if (directId) return `user:${directId}`;
+  const anonymousId = pick('anonymousId', 'anonymous_id', 'anonId', 'distinctId', 'distinct_id');
+  if (anonymousId) return `anon:${anonymousId}`;
+  const sessionId = pick('sessionId', 'session_id');
+  if (sessionId) return `session:${sessionId}`;
+  const ipHash = pick('ipHash', 'ip_hash');
+  if (ipHash) return `ip:${ipHash}`;
+  const rawIp = pick('ip', 'clientIp', 'client_ip');
+  if (rawIp) {
+    const hashedIp = crypto.createHash('sha256').update(rawIp).digest('hex');
+    return `ip:${hashedIp}`;
+  }
+  return null;
+}
 
 function normalizePayload(payload) {
   if (!payload || typeof payload !== 'object' || Array.isArray(payload)) {
@@ -19,7 +88,30 @@ function normalizePayload(payload) {
     if (value === undefined || typeof value === 'function') {
       continue;
     }
+    if (PII_KEYS.has(key)) {
+      continue;
+    }
     normalized[key] = value;
+  }
+
+  for (const numericKey of ['score', 'distance', 'duration_sec', 'amount_usd']) {
+    if (normalized[numericKey] !== undefined) {
+      const parsed = Number(normalized[numericKey]);
+      if (Number.isFinite(parsed)) {
+        normalized[numericKey] = parsed;
+      }
+    }
+  }
+  if (normalized.durationSec !== undefined && normalized.duration_sec === undefined) {
+    const parsed = Number(normalized.durationSec);
+    if (Number.isFinite(parsed)) normalized.duration_sec = parsed;
+  }
+  if (normalized.amountUsd !== undefined && normalized.amount_usd === undefined) {
+    const parsed = Number(normalized.amountUsd);
+    if (Number.isFinite(parsed)) normalized.amount_usd = parsed;
+  }
+  if (normalized.currency !== undefined && normalized.currency !== null) {
+    normalized.currency = String(normalized.currency).toUpperCase();
   }
 
   return normalized;
@@ -43,12 +135,15 @@ function validateAndNormalizeEvent(inputEvent) {
     return { error: `Unsupported analytics event type: ${eventType || 'empty'}` };
   }
 
-  const timestamp = parseNonNegativeNumber(inputEvent.timestamp);
+  let timestamp = parseNonNegativeNumber(inputEvent.timestamp);
   if (timestamp === null) {
-    return { error: `Invalid event timestamp for ${eventType}` };
+    timestamp = Date.now();
   }
 
   const payload = normalizePayload(inputEvent.payload);
+  if (Buffer.byteLength(JSON.stringify(payload), 'utf8') > MAX_EVENT_PAYLOAD_BYTES) {
+    return { error: `Payload too large for ${eventType}` };
+  }
 
   return {
     eventType,
@@ -96,15 +191,14 @@ async function ingestEvents(req, res, next, isSingleEventRoute = false) {
     }
 
     const normalizedEvents = [];
+    let rejected = 0;
     for (let index = 0; index < events.length; index += 1) {
       const normalized = validateAndNormalizeEvent(events[index]);
       if (normalized.error) {
         markAnalyticsIngest({ invalid: 1 });
-        const err = new Error(`Invalid event at index ${index}: ${normalized.error}`);
-        err.statusCode = 400;
-        err.code = 'ANALYTICS_INVALID_EVENT';
-        err.expose = true;
-        throw err;
+        rejected += 1;
+        logger.warn({ route: '/api/analytics/events', index, err: normalized.error }, 'Analytics event rejected');
+        continue;
       }
 
       normalizedEvents.push({
@@ -115,14 +209,12 @@ async function ingestEvents(req, res, next, isSingleEventRoute = false) {
 
     markAnalyticsIngest({ accepted: normalizedEvents.length });
 
-    await AnalyticsEvent.insertMany(normalizedEvents, { ordered: false });
-    markAnalyticsIngest({ stored: normalizedEvents.length });
+    if (normalizedEvents.length > 0) {
+      await AnalyticsEvent.insertMany(normalizedEvents, { ordered: false });
+      markAnalyticsIngest({ stored: normalizedEvents.length });
+    }
 
-    res.status(202).json({
-      ok: true,
-      accepted: normalizedEvents.length,
-      dropped: 0
-    });
+    res.status(202).json({ ok: true, accepted: normalizedEvents.length, rejected });
   } catch (error) {
     if (error.code !== 'ANALYTICS_INVALID_EVENT' && error.code !== 'ANALYTICS_INVALID_SENT_AT' && error.code !== 'ANALYTICS_INVALID_EVENTS_BATCH' && error.code !== 'ANALYTICS_BATCH_TOO_LARGE') {
       markAnalyticsIngest({ failed: 1 });
@@ -139,6 +231,117 @@ router.post('/events', readLimiter, async (req, res, next) => {
 
 router.post('/event', readLimiter, async (req, res, next) => {
   await ingestEvents(req, res, next, true);
+});
+
+router.get('/summary', readLimiter, async (req, res, next) => {
+  try {
+    const from = parseRangeValue(req.query.from);
+    const to = parseRangeValue(req.query.to);
+
+    if (from === null || to === null || from > to) {
+      const err = new Error('from and to query params are required and must define a valid range');
+      err.statusCode = 400;
+      err.code = 'ANALYTICS_INVALID_RANGE';
+      err.expose = true;
+      throw err;
+    }
+
+    const match = {
+      timestamp: { $gte: from, $lte: to },
+      eventType: { $in: Array.from(SUPPORTED_SUMMARY_EVENTS) }
+    };
+
+    if (typeof req.query.source === 'string' && req.query.source.trim()) {
+      match['payload.source'] = req.query.source.trim();
+    }
+    if (typeof req.query.env === 'string' && req.query.env.trim()) {
+      match['payload.env'] = req.query.env.trim();
+    }
+
+    const events = await AnalyticsEvent.find(match).select({ eventType: 1, payload: 1 }).lean();
+
+    const unique = {
+      app_opened_users: new Set(),
+      run_started_users: new Set(),
+      run_finished_users: new Set(),
+      second_run_started_users: new Set(),
+      wallet_connect_success_users: new Set(),
+      donation_success_users: new Set()
+    };
+    let total_runs_started = 0;
+    let total_runs_finished = 0;
+    let donation_success_count = 0;
+    let donation_revenue_usd = 0;
+    let totalScore = 0;
+    let scoreCount = 0;
+    let totalDurationSec = 0;
+    let durationCount = 0;
+
+    for (const event of events) {
+      const identity = resolveIdentity(event);
+      const payload = event?.payload && typeof event.payload === 'object' ? event.payload : {};
+
+      if (event.eventType === 'app_opened') {
+        if (identity) unique.app_opened_users.add(identity);
+      }
+      if (event.eventType === 'run_started') {
+        total_runs_started += 1;
+        if (identity) unique.run_started_users.add(identity);
+      }
+      if (event.eventType === 'run_finished') {
+        total_runs_finished += 1;
+        if (identity) unique.run_finished_users.add(identity);
+        const score = Number(payload.score);
+        if (Number.isFinite(score)) {
+          totalScore += score;
+          scoreCount += 1;
+        }
+        const duration = Number(payload.duration_sec ?? payload.durationSec);
+        if (Number.isFinite(duration)) {
+          totalDurationSec += duration;
+          durationCount += 1;
+        }
+      }
+      if (event.eventType === 'second_run_started') {
+        if (identity) unique.second_run_started_users.add(identity);
+      }
+      if (event.eventType === 'wallet_connect_success') {
+        if (identity) unique.wallet_connect_success_users.add(identity);
+      }
+      if (event.eventType === 'donation_success') {
+        donation_success_count += 1;
+        if (identity) unique.donation_success_users.add(identity);
+        const amountUsd = Number(payload.amount_usd ?? payload.amountUsd);
+        if (Number.isFinite(amountUsd)) {
+          donation_revenue_usd += amountUsd;
+        }
+      }
+    }
+
+    const metrics = {
+      app_opened_users: unique.app_opened_users.size,
+      run_started_users: unique.run_started_users.size,
+      run_finished_users: unique.run_finished_users.size,
+      total_runs_started,
+      total_runs_finished,
+      second_run_started_users: unique.second_run_started_users.size,
+      wallet_connect_success_users: unique.wallet_connect_success_users.size,
+      donation_success_users: unique.donation_success_users.size,
+      donation_success_count,
+      donation_revenue_usd,
+      average_score: safeDivide(totalScore, scoreCount),
+      average_duration_sec: safeDivide(totalDurationSec, durationCount),
+      activation_rate: safeDivide(unique.run_started_users.size, unique.app_opened_users.size),
+      completion_rate: safeDivide(total_runs_finished, total_runs_started),
+      second_run_rate: safeDivide(unique.second_run_started_users.size, unique.run_finished_users.size),
+      wallet_conversion_rate: safeDivide(unique.wallet_connect_success_users.size, unique.app_opened_users.size),
+      donation_conversion_rate: safeDivide(unique.donation_success_users.size, unique.wallet_connect_success_users.size)
+    };
+
+    res.json({ ok: true, range: { from, to }, metrics });
+  } catch (error) {
+    next(error);
+  }
 });
 
 module.exports = router;

--- a/tests/api.integration.test.js
+++ b/tests/api.integration.test.js
@@ -1637,8 +1637,8 @@ test('POST /api/analytics/events accepts valid analytics batch', async () => {
     body: JSON.stringify({
       sentAt,
       events: [
-        { name: 'game_start', timestamp: sentAt - 1000, payload: { sessionId: 's1' } },
-        { name: 'currency_spent', timestamp: sentAt - 500, payload: { amount: 50, currency: 'coins' } }
+        { name: 'app_opened', timestamp: sentAt - 1000, payload: { sessionId: 's1', username: 'private_user' } },
+        { name: 'donation_success', timestamp: sentAt - 500, payload: { amount_usd: '12.5', currency: 'usd' } }
       ]
     })
   });
@@ -1648,8 +1648,11 @@ test('POST /api/analytics/events accepts valid analytics batch', async () => {
   assert.equal(body.ok, true);
   assert.equal(body.accepted, 2);
   assert.equal(inserted.length, 2);
-  assert.equal(inserted[0].eventType, 'game_start');
+  assert.equal(inserted[0].eventType, 'app_opened');
   assert.equal(inserted[0].sentAt, sentAt);
+  assert.equal(inserted[0].payload.username, undefined);
+  assert.equal(inserted[1].payload.amount_usd, 12.5);
+  assert.equal(inserted[1].payload.currency, 'USD');
 
   const metricsRes = await fetch(`${baseUrl}/metrics`);
   const metricsText = await metricsRes.text();
@@ -1688,9 +1691,11 @@ test('POST /api/telemetry/events aliases analytics ingestion route', async () =>
   await server.close();
 });
 
-test('POST /api/analytics/events rejects unsupported event type', async () => {
-  AnalyticsEvent.insertMany = async () => {
-    throw new Error('insertMany should not be called for invalid payload');
+test('POST /api/analytics/events partially accepts valid events and rejects invalid', async () => {
+  const inserted = [];
+  AnalyticsEvent.insertMany = async (docs) => {
+    inserted.push(...docs);
+    return docs;
   };
 
   const { server, baseUrl } = await startServer();
@@ -1700,13 +1705,21 @@ test('POST /api/analytics/events rejects unsupported event type', async () => {
     headers: { 'content-type': 'application/json' },
     body: JSON.stringify({
       sentAt,
-      events: [{ name: 'unknown_event', timestamp: sentAt }]
+      events: [
+        { name: 'unknown_event', timestamp: sentAt },
+        { name: 'run_started', payload: { sessionId: 's2' } }
+      ]
     })
   });
 
-  assert.equal(res.status, 400);
+  assert.equal(res.status, 202);
   const body = await res.json();
-  assert.equal(body.code, 'ANALYTICS_INVALID_EVENT');
+  assert.equal(body.ok, true);
+  assert.equal(body.accepted, 1);
+  assert.equal(body.rejected, 1);
+  assert.equal(inserted.length, 1);
+  assert.equal(inserted[0].eventType, 'run_started');
+  assert.equal(typeof inserted[0].timestamp, 'number');
 
   const metricsRes = await fetch(`${baseUrl}/metrics`);
   const metricsText = await metricsRes.text();
@@ -1744,6 +1757,61 @@ test('POST /api/analytics/event accepts a single analytics event payload', async
   assert.equal(inserted[0].payload.sessionId, 'single-route');
 
   await server.close();
+});
+
+test('GET /api/analytics/summary returns base product metrics', async () => {
+  const originalFind = AnalyticsEvent.find;
+  const from = Date.now() - 3600000;
+  const to = Date.now();
+
+  const docs = [
+    { eventType: 'app_opened', payload: { userId: 'u1', source: 'tg', env: 'prod' } },
+    { eventType: 'app_opened', payload: { anonymousId: 'anon-2', source: 'tg', env: 'prod' } },
+    { eventType: 'run_started', payload: { userId: 'u1', source: 'tg', env: 'prod' } },
+    { eventType: 'run_started', payload: { anonymousId: 'anon-2', source: 'tg', env: 'prod' } },
+    { eventType: 'run_started', payload: { anonymousId: 'anon-2', source: 'tg', env: 'prod' } },
+    { eventType: 'run_started', payload: { ip: '203.0.113.15', source: 'tg', env: 'prod' } },
+    { eventType: 'run_finished', payload: { userId: 'u1', score: 120, duration_sec: 30, source: 'tg', env: 'prod' } },
+    { eventType: 'run_finished', payload: { anonymousId: 'anon-2', score: 80, durationSec: 50, source: 'tg', env: 'prod' } },
+    { eventType: 'second_run_started', payload: { anonymousId: 'anon-2', source: 'tg', env: 'prod' } },
+    { eventType: 'wallet_connect_success', payload: { userId: 'u1', source: 'tg', env: 'prod' } },
+    { eventType: 'donation_success', payload: { userId: 'u1', amount_usd: 3.5, source: 'tg', env: 'prod' } },
+    { eventType: 'donation_success', payload: { userId: 'u1', amountUsd: 4.5, source: 'tg', env: 'prod' } }
+  ];
+
+  AnalyticsEvent.find = () => ({
+    select: () => ({
+      lean: async () => docs
+    })
+  });
+
+  const { server, baseUrl } = await startServer();
+  try {
+    const res = await fetch(`${baseUrl}/api/analytics/summary?from=${from}&to=${to}&source=tg&env=prod`);
+    assert.equal(res.status, 200);
+    const body = await res.json();
+    assert.equal(body.ok, true);
+    assert.equal(body.metrics.app_opened_users, 2);
+    assert.equal(body.metrics.run_started_users, 3);
+    assert.equal(body.metrics.run_finished_users, 2);
+    assert.equal(body.metrics.total_runs_started, 4);
+    assert.equal(body.metrics.total_runs_finished, 2);
+    assert.equal(body.metrics.second_run_started_users, 1);
+    assert.equal(body.metrics.wallet_connect_success_users, 1);
+    assert.equal(body.metrics.donation_success_users, 1);
+    assert.equal(body.metrics.donation_success_count, 2);
+    assert.equal(body.metrics.donation_revenue_usd, 8);
+    assert.equal(body.metrics.average_score, 100);
+    assert.equal(body.metrics.average_duration_sec, 40);
+    assert.equal(body.metrics.activation_rate, 1.5);
+    assert.equal(body.metrics.completion_rate, 0.5);
+    assert.equal(body.metrics.second_run_rate, 0.5);
+    assert.equal(body.metrics.wallet_conversion_rate, 0.5);
+    assert.equal(body.metrics.donation_conversion_rate, 1);
+  } finally {
+    AnalyticsEvent.find = originalFind;
+    await server.close();
+  }
 });
 
 test('GET /api/leaderboard/share/payload/:wallet uses latest score when latest run is personal best', async () => {


### PR DESCRIPTION
### Motivation
- Improve analytics ingestion robustness by normalizing payloads, protecting PII, and tolerating mixed-validity batches instead of failing the whole request. 
- Provide a compact summary API to compute key product metrics over a time range for lightweight reporting.

### Description
- Expanded `ANALYTICS_EVENT_TYPES` and added constants `MAX_EVENT_PAYLOAD_BYTES`, `PII_KEYS`, and `SUPPORTED_SUMMARY_EVENTS` to control payload size, PII filtering, and summary scope. 
- Implemented payload normalization and numeric/currency coercion in `normalizePayload`, added payload size check, and strip PII keys before storing. 
- Changed ingestion flow in `ingestEvents`/`validateAndNormalizeEvent` to default missing timestamps to `Date.now()`, skip invalid events (log and count them) and return `accepted` and `rejected` counts instead of failing the whole batch. 
- Added identity resolution with `resolveIdentity` (including IP hashing) and a new `GET /api/analytics/summary` route that aggregates unique-user counts and conversion/average metrics over a `from`/`to` range and optional `source`/`env` filters.

### Testing
- Updated and ran integration tests covering `POST /api/analytics/events`, `POST /api/telemetry/events`, and `POST /api/analytics/event`, which verify PII stripping, numeric parsing and batch acceptance behavior, and these tests passed. 
- Added and ran `GET /api/analytics/summary` integration test that validates aggregation logic and returned metrics, and it passed. 
- Metrics endpoint checks asserting ingest counters (`accepted`, `stored`, `invalid`) were included and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f22b91aeec83208031f76f8f3f3d0f)