### PR TITLE
Validate donation env vars and guard txRequest building

### DIFF
--- a/utils/donationService.js
+++ b/utils/donationService.js
@@ -637,7 +637,24 @@ function serializeDonationPayment(payment, options = {}) {
     paidAt: payment.paidAt || null,
     creditedAt: payment.creditedAt || null,
     rewardGrantedAt: payment.rewardGrantedAt || null,
-    txRequest: !isStars && includeTxRequest ? buildDonationTxRequest(payment) : null
+    txRequest: (() => {
+      if (isStars || !includeTxRequest) {
+        return null;
+      }
+
+      try {
+        return buildDonationTxRequest(payment);
+      } catch (error) {
+        logger.error({
+          err: error,
+          paymentId: payment.paymentId,
+          productKey: payment.productKey,
+          expectedAmount: payment.expectedAmount,
+          expectedDecimals: payment.expectedDecimals
+        }, 'Failed to build donation txRequest');
+        return null;
+      }
+    })()
   };
 }
 

--- a/utils/donationsConfig.js
+++ b/utils/donationsConfig.js
@@ -1,11 +1,35 @@
 const DEFAULT_NETWORK = process.env.DONATIONS_NETWORK || 'Base';
 const DEFAULT_TOKEN_SYMBOL = process.env.DONATIONS_TOKEN_SYMBOL || 'USDT';
-const DEFAULT_TOKEN_DECIMALS = Number(process.env.DONATIONS_TOKEN_DECIMALS || 18);
+function resolvePositiveInt(rawValue, fallbackValue, { min = 0, max = Number.MAX_SAFE_INTEGER } = {}) {
+  const parsed = Number(rawValue);
+  if (!Number.isFinite(parsed)) return fallbackValue;
+  const normalized = Math.floor(parsed);
+  if (normalized < min || normalized > max) return fallbackValue;
+  return normalized;
+}
+
+const DEFAULT_TOKEN_DECIMALS = resolvePositiveInt(process.env.DONATIONS_TOKEN_DECIMALS ?? 18, 18, { min: 0, max: 36 });
 const DEFAULT_TOKEN_CONTRACT = (process.env.DONATIONS_TOKEN_CONTRACT || '0xfde4c96c8593536e31f229ea8f37b2ada2699bb2').toLowerCase();
 const DEFAULT_MERCHANT_WALLET = (process.env.DONATIONS_MERCHANT_WALLET || '0xbae8504df4e9816934e13390b4e83d408b7db5d8').toLowerCase();
 const PRICE_MODE = String(process.env.DONATIONS_PRICE_MODE || 'test').toLowerCase() === 'prod' ? 'prod' : 'test';
-const TTL_MINUTES = Number(process.env.DONATIONS_TTL_MINUTES || 30);
-const REQUIRED_CONFIRMATIONS = Number(process.env.DONATIONS_REQUIRED_CONFIRMATIONS || 1);
+const TTL_MINUTES = resolvePositiveInt(process.env.DONATIONS_TTL_MINUTES ?? 30, 30, { min: 1, max: 24 * 60 });
+const REQUIRED_CONFIRMATIONS = resolvePositiveInt(process.env.DONATIONS_REQUIRED_CONFIRMATIONS ?? 1, 1, { min: 1, max: 1024 });
+
+
+function resolveStarsAmount(envName, fallbackValue) {
+  const raw = process.env[envName];
+  if (raw === undefined || raw === null || String(raw).trim() === '') {
+    return fallbackValue;
+  }
+
+  const normalized = String(raw).trim().replace(',', '.');
+  const parsed = Number(normalized);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return fallbackValue;
+  }
+
+  return Math.round(parsed);
+}
 
 function price(testPrice, prodPrice) {
   return PRICE_MODE === 'prod' ? prodPrice : testPrice;
@@ -21,7 +45,7 @@ const DONATIONS_CONFIG = {
     tokenDecimals: DEFAULT_TOKEN_DECIMALS,
     merchantWallet: DEFAULT_MERCHANT_WALLET,
     price: price('2', '200'),
-    starsAmount: Number(process.env.DONATION_STARTER_PACK_STARS || 100),
+    starsAmount: resolveStarsAmount('DONATION_STARTER_PACK_STARS', 100),
     purchaseLimit: 'once',
     ttlMinutes: TTL_MINUTES,
     requiredConfirmations: REQUIRED_CONFIRMATIONS,
@@ -36,7 +60,7 @@ const DONATIONS_CONFIG = {
     tokenDecimals: DEFAULT_TOKEN_DECIMALS,
     merchantWallet: DEFAULT_MERCHANT_WALLET,
     price: price('9', '900'),
-    starsAmount: Number(process.env.DONATION_BASIC_PACK_STARS || 450),
+    starsAmount: resolveStarsAmount('DONATION_BASIC_PACK_STARS', 450),
     purchaseLimit: 'unlimited',
     ttlMinutes: TTL_MINUTES,
     requiredConfirmations: REQUIRED_CONFIRMATIONS,
@@ -51,7 +75,7 @@ const DONATIONS_CONFIG = {
     tokenDecimals: DEFAULT_TOKEN_DECIMALS,
     merchantWallet: DEFAULT_MERCHANT_WALLET,
     price: price('17', '1700'),
-    starsAmount: Number(process.env.DONATION_ADVANCED_PACK_STARS || 850),
+    starsAmount: resolveStarsAmount('DONATION_ADVANCED_PACK_STARS', 850),
     purchaseLimit: 'unlimited',
     ttlMinutes: TTL_MINUTES,
     requiredConfirmations: REQUIRED_CONFIRMATIONS,
@@ -66,7 +90,7 @@ const DONATIONS_CONFIG = {
     tokenDecimals: DEFAULT_TOKEN_DECIMALS,
     merchantWallet: DEFAULT_MERCHANT_WALLET,
     price: price('40', '4000'),
-    starsAmount: Number(process.env.DONATION_SUPER_PACK_STARS || 2000),
+    starsAmount: resolveStarsAmount('DONATION_SUPER_PACK_STARS', 2000),
     purchaseLimit: 'unlimited',
     ttlMinutes: TTL_MINUTES,
     requiredConfirmations: REQUIRED_CONFIRMATIONS,
@@ -81,7 +105,7 @@ const DONATIONS_CONFIG = {
     tokenDecimals: DEFAULT_TOKEN_DECIMALS,
     merchantWallet: DEFAULT_MERCHANT_WALLET,
     price: price('5', '500'),
-    starsAmount: Number(process.env.DONATION_GOLD_PACK_STARS || 250),
+    starsAmount: resolveStarsAmount('DONATION_GOLD_PACK_STARS', 250),
     purchaseLimit: 'unlimited',
     ttlMinutes: TTL_MINUTES,
     requiredConfirmations: REQUIRED_CONFIRMATIONS,
@@ -96,7 +120,7 @@ const DONATIONS_CONFIG = {
     tokenDecimals: DEFAULT_TOKEN_DECIMALS,
     merchantWallet: DEFAULT_MERCHANT_WALLET,
     price: price('3', '300'),
-    starsAmount: Number(process.env.DONATION_SILVER_PACK_STARS || 150),
+    starsAmount: resolveStarsAmount('DONATION_SILVER_PACK_STARS', 150),
     purchaseLimit: 'unlimited',
     ttlMinutes: TTL_MINUTES,
     requiredConfirmations: REQUIRED_CONFIRMATIONS,


### PR DESCRIPTION
### Motivation
- Prevent malformed or out-of-range environment variables from producing invalid donation configuration values.
- Avoid a thrown error during serialization when `buildDonationTxRequest` fails and ensure the rest of the payment object still serializes.

### Description
- Add `resolvePositiveInt` helper and use it to parse `DONATIONS_TOKEN_DECIMALS`, `DONATIONS_TTL_MINUTES`, and `DONATIONS_REQUIRED_CONFIRMATIONS` with safe bounds and defaults.
- Add `resolveStarsAmount` helper and replace raw `Number(...)` parsing for per-product `starsAmount` values to accept common formats and fall back on defaults.
- Wrap the `buildDonationTxRequest(payment)` call in a try/catch inside `serializeDonationPayment` to log errors via `logger.error` and return `null` on failure instead of throwing.
- Keep `price` selection behavior unchanged and expose `DONATIONS_CONFIG`, `DONATIONS_PRICE_MODE`, and `DONATIONS_REQUIRED_CONFIRMATIONS` as before.

### Testing
- Ran project linters via `npm run lint` and static checks, which succeeded.
- Ran the test suite via `npm test` against the modified modules and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f243e5ef148320a5da3f0ac4a1f210)