### PR TITLE
Add AI mode access via Telegram username whitelist

### DIFF
--- a/routes/leaderboard.js
+++ b/routes/leaderboard.js
@@ -12,7 +12,7 @@ const { saveResultLimiter, readLimiter } = require('../middleware/rateLimiter');
 const logger = require('../utils/logger');
 const { markSuspicious } = require('../middleware/requestMetrics');
 const { logSecurityEvent, normalizeWallet, validateTimestampWindow } = require('../utils/security');
-const { hasAiModeAccess, validateAiSettings } = require('../utils/aiModeAccess');
+const { hasAiModeAccess, hasAiModeAccessByTelegramUsername, validateAiSettings } = require('../utils/aiModeAccess');
 const { computePlayerInsights, computeRank, DEFAULTS: leaderboardInsightsConfig } = require('../services/leaderboardInsightsService');
 const { buildGameOverPayload } = require('../services/gameOverAgitationService');
 const { maybeGrantReferralRewards } = require('../utils/referralRewards');
@@ -287,8 +287,14 @@ router.post('/save', saveResultLimiter, async (req, res) => {
     }
 
     const aiConfig = aiValidation.sanitized;
-    if (aiConfig?.enabled && !hasAiModeAccess(walletLower)) {
-      return res.status(403).json({ error: 'AI mode is not allowed for this wallet' });
+    let hasAiAccess = hasAiModeAccess(walletLower);
+    if (!hasAiAccess && isTelegramAuth && telegramId) {
+      const tgLink = await AccountLink.findOne({ telegramId: String(telegramId) });
+      hasAiAccess = hasAiModeAccessByTelegramUsername(tgLink?.telegramUsername);
+    }
+
+    if (aiConfig?.enabled && !hasAiAccess) {
+      return res.status(403).json({ error: 'AI mode is not allowed for this wallet or telegram username' });
     }
 
     if (aiConfig?.enabled) {

--- a/routes/store.js
+++ b/routes/store.js
@@ -11,7 +11,7 @@ const SecurityEvent = require('../models/SecurityEvent');
 const logger = require('../utils/logger');
 const { markSuspicious } = require('../middleware/requestMetrics');
 const { logSecurityEvent, normalizeWallet, validateTimestampWindow } = require('../utils/security');
-const { hasAiModeAccess } = require('../utils/aiModeAccess');
+const { hasAiModeAccess, hasAiModeAccessByTelegramUsername } = require('../utils/aiModeAccess');
 
 const UPGRADE_KEY_ALIASES = {
   spin_alert: 'alert',
@@ -320,7 +320,12 @@ router.get('/upgrades/:wallet', readLimiter, async (req, res) => {
     const silver = player ? player.totalSilverCoins : 0;
 
     const effects = calculateEffects(upgrades);
-    effects.ai_mode_access = hasAiModeAccess(wallet);
+    let aiModeAccess = hasAiModeAccess(wallet);
+    if (!aiModeAccess) {
+      const link = await AccountLink.findOne({ wallet });
+      aiModeAccess = hasAiModeAccessByTelegramUsername(link?.telegramUsername);
+    }
+    effects.ai_mode_access = aiModeAccess;
 
     // Build upgrades data
     const upgradesData = {};

--- a/utils/aiModeAccess.js
+++ b/utils/aiModeAccess.js
@@ -32,11 +32,41 @@ const AI_MODE_WALLET_WHITELIST = [
 ];
 // AI_WHITELIST_END
 
+const AI_MODE_TELEGRAM_USERNAME_WHITELIST = [
+  'patrikson_23',
+  'johnfeals',
+  'yahiamop',
+  'lindalidar',
+  'alifamanula',
+  'drulidcry',
+  'rosen_talie',
+  'n0pnamechar',
+  'chumkabesa',
+  'jebamacaleb',
+  'carla1smith7',
+  'jadeantelr',
+  'jasonwoorhies',
+  'usettag',
+  'amandalopessz',
+  'southwdudu',
+  'mrblakjoker',
+  'essabill',
+  'homersimpson98',
+  'rurikivanov',
+  'borisppasternak',
+  'ellibasket'
+];
+
 const AI_MODE_PRIORITIES = new Set(['gold', 'silver', 'bonus', 'score', 'different']);
 
 function hasAiModeAccess(wallet) {
   const normalized = normalizeWallet(wallet);
   return Boolean(normalized) && AI_MODE_WALLET_WHITELIST.includes(normalized);
+}
+
+function hasAiModeAccessByTelegramUsername(username) {
+  const normalized = String(username || '').trim().toLowerCase().replace(/^@/, '');
+  return Boolean(normalized) && AI_MODE_TELEGRAM_USERNAME_WHITELIST.includes(normalized);
 }
 
 function validateAiSettings(aiSettings) {
@@ -82,5 +112,6 @@ function validateAiSettings(aiSettings) {
 
 module.exports = {
   hasAiModeAccess,
+  hasAiModeAccessByTelegramUsername,
   validateAiSettings
 };


### PR DESCRIPTION
### Motivation
- Provide a way to enable AI mode for Telegram-authenticated users who are not in the wallet whitelist by permitting specific Telegram usernames.
- Include the requested list of Telegram usernames so they can immediately use AI mode without wallet whitelisting.

### Description
- Added `AI_MODE_TELEGRAM_USERNAME_WHITELIST` and the helper `hasAiModeAccessByTelegramUsername()` in `utils/aiModeAccess.js` with normalization for optional `@` and case-insensitive matching.
- Updated `POST /api/leaderboard/save` in `routes/leaderboard.js` to allow AI mode when either the wallet is whitelisted or (for `authMode === 'telegram'`) the linked Telegram username is whitelisted.
- Updated `GET /api/store/upgrades/:wallet` in `routes/store.js` to set `effects.ai_mode_access` true when the wallet is whitelisted or when the wallet's linked Telegram username is whitelisted.
- Kept existing wallet whitelist logic intact and added only the Telegram username-based checks.

### Testing
- Ran targeted integration tests via `npm test -- tests/api.integration.test.js --test-name-pattern "ai_mode_access|AI mode"`, and AI-related checks such as store upgrades `ai_mode_access` and leaderboard save AI access passed.
- The full integration test run reported several failing donation-related tests that are unrelated to these changes.  The AI-mode specific tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f292b1fb00832085a5d6500d3cd247)