### PR TITLE
Add backend audit workflow; centralize wallet validation; fix donation payment query handling

### DIFF
--- a/.github/workflows/backend-audit.yml
+++ b/.github/workflows/backend-audit.yml
@@ -1,0 +1,49 @@
+name: backend-audit
+
+on:
+  pull_request:
+  push:
+    branches: [ main, master, develop ]
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Syntax check
+        run: npm run check:syntax
+
+      - name: Run tests
+        run: npm test
+
+      - name: Dependency audit (moderate+)
+        run: npm audit --audit-level=moderate
+
+      - name: Duplicate wallet validation check (guardrail)
+        run: |
+          COUNT=$(rg -n "isValidWalletAddress\(|Invalid wallet format" routes | wc -l)
+          echo "wallet_validation_occurrences=$COUNT"
+          if [ "$COUNT" -gt 12 ]; then
+            echo "Too many duplicated wallet validation checks; consider centralizing." >&2
+            exit 1
+          fi
+
+      - name: Upload audit report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: deep-audit-report
+          path: docs/deep_audit_2026-04-30.md

--- a/docs/deep_audit_2026-04-30.md
+++ b/docs/deep_audit_2026-04-30.md
@@ -1,0 +1,104 @@
+# Deep audit report (backend)
+
+Date: 2026-04-30
+Scope: `/workspace/URSASS_Backend`
+
+## What was checked
+- Test suite health (`npm test`).
+- Architecture scan for duplicated patterns and hot spots.
+- Static dependency check attempt (`npx depcheck --json`) to find unused deps/files.
+- Route-level patterns for repeated wallet validation and repeated share-context fetch logic.
+
+## Findings
+
+### 1) Repeated wallet validation logic (duplication)
+`routes/leaderboard.js` contains an internal regex validator (`isValidWalletAddress`) and many repeated checks with slightly different error payloads. This creates drift risk and inconsistent API behavior.
+
+Examples:
+- Validator declared locally (`isValidWalletAddress`).
+- Repeated checks in `/top`, `/share/*`, `/insights` with inconsistent response shape/message.
+
+**Refactor**:
+- Move wallet validation to a shared utility (`utils/security.js`) and use one helper to parse+validate request wallet.
+- Standardize response contract for invalid wallet errors.
+
+### 2) Repeated share-context resolution path (duplication)
+Endpoints `/share/payload/:wallet`, `/share/image/:wallet.svg`, `/share/image/:wallet.png`, `/share/page/:wallet` all repeat:
+1. parse wallet
+2. validate wallet
+3. load share context
+4. 404 handling
+
+**Refactor**:
+- Add middleware `loadShareContextByWallet` that sets `req.wallet` and `req.shareContext`.
+- Reduce route handlers to output-format concerns only (JSON/SVG/PNG/HTML).
+
+### 3) Inefficient top leaderboard request path (N+1 / extra queries)
+In `GET /top`:
+- Fetches top players.
+- Fetches all account links for top players.
+- For current wallet, fetches player again and account link again.
+- Computes rank via `countDocuments({ bestScore: { $gt: ... } })` each request.
+
+**Optimization options**:
+- Cache global top-10 payload (TTL 15-60s) with invalidation on score updates.
+- Denormalize `displayNameResolved` for leaderboard reads where privacy rules allow.
+- Replace rank count query with precomputed aggregate rank snapshots or cached percentile buckets.
+
+### 4) Test suite instability concentrated in donations integration tests
+Current test run shows multiple failures around `POST /api/store/donations/create-payment` and downstream status checks.
+
+**Likely root cluster**:
+- create-payment returns 500 in tests, cascading into submit/status/history assertions.
+- This means one upstream regression causes many red tests.
+
+**Refactor / quality**:
+- Split integration tests into:
+  - donation contract tests (unit/service-level with strict mocks),
+  - route contract tests,
+  - one e2e happy-path smoke.
+- Add explicit failure code assertions for root error classification (misconfig vs provider rejection vs validation).
+
+### 5) Dependency hygiene gaps (tooling unavailable in current environment)
+`depcheck` installation from npm registry is blocked (403), so automated unused-deps scan was not completed in this environment.
+
+**Mitigation**:
+- Run dependency analysis in CI where registry access is available.
+- Add periodic lockfile audit and dependency report artifact.
+
+## Proposed refactoring backlog (prioritized)
+
+### P0 (1-2 days)
+1. Create shared wallet parsing/validation helper and replace duplicate checks in `routes/leaderboard.js`, `routes/store.js`, `routes/account.js`.
+2. Introduce shared error factory for 400 wallet responses.
+3. Fix donations create-payment regression and unflake tests.
+
+### P1 (2-4 days)
+1. Extract `loadShareContextByWallet` middleware.
+2. Add top leaderboard response cache with TTL and observability counters.
+3. Add strict timeout budgets for Telegram Stars integration tests to reduce 10s+ tail.
+
+### P2 (ongoing)
+1. Precompute leaderboard ranking aggregates.
+2. Add dead-code and unused-export scan with CI tooling (depcheck/knip/eslint rules).
+3. Add API response schema validation tests (contract snapshots).
+
+## CI pipeline proposal (audit-focused)
+
+Recommended stages:
+1. **lint-static**
+   - syntax check
+   - unused-deps scan
+   - duplicate-code threshold scan
+2. **unit**
+   - fast deterministic tests
+3. **integration**
+   - route/service integration with mocked providers
+4. **security**
+   - npm audit (moderate+), secret scan, dependency allowlist check
+5. **performance-smoke**
+   - autocannon on `/health`, `/api/leaderboard/top`, `/api/game/config`
+6. **artifacts**
+   - publish junit + coverage + audit markdown report
+
+A starter GitHub Actions workflow is added in `.github/workflows/backend-audit.yml`.

--- a/routes/leaderboard.js
+++ b/routes/leaderboard.js
@@ -11,7 +11,13 @@ const { verifySignature, createMessageToVerify } = require('../utils/verifySigna
 const { saveResultLimiter, readLimiter } = require('../middleware/rateLimiter');
 const logger = require('../utils/logger');
 const { markSuspicious } = require('../middleware/requestMetrics');
-const { logSecurityEvent, normalizeWallet, validateTimestampWindow } = require('../utils/security');
+const {
+  logSecurityEvent,
+  normalizeWallet,
+  validateTimestampWindow,
+  isValidWalletAddress,
+  parseWalletOrNull
+} = require('../utils/security');
 const { hasAiModeAccess, hasAiModeAccessByTelegramUsername, validateAiSettings } = require('../utils/aiModeAccess');
 const { computePlayerInsights, computeRank, DEFAULTS: leaderboardInsightsConfig } = require('../services/leaderboardInsightsService');
 const { buildGameOverPayload } = require('../services/gameOverAgitationService');
@@ -148,17 +154,13 @@ function buildLeaderboardEntry(player, displayName, position) {
   };
 }
 
-function isValidWalletAddress(wallet) {
-  return /^0x[a-fA-F0-9]{40}$/.test(wallet);
-}
-
 // ✅ GET: Top 10 players
 router.get('/top', readLimiter, async (req, res) => {
   try {
     const walletQuery = typeof req.query.wallet === 'string' ? req.query.wallet.trim() : '';
-    const wallet = walletQuery ? walletQuery.toLowerCase() : null;
+    const wallet = walletQuery ? parseWalletOrNull(walletQuery) : null;
 
-    if (wallet && !isValidWalletAddress(wallet)) {
+    if (walletQuery && !wallet) {
       logger.warn({ wallet: walletQuery, requestId: req.requestId }, 'GET /top rejected: invalid wallet format');
       return res.status(400).json({
         error: 'Invalid wallet format. Expected EVM wallet like 0x... (40 hex chars).',
@@ -730,8 +732,8 @@ router.post('/game-over-preview', readLimiter, async (req, res) => {
 
 router.get('/share/payload/:wallet', readLimiter, async (req, res) => {
   try {
-    const wallet = String(req.params.wallet || '').trim().toLowerCase();
-    if (!isValidWalletAddress(wallet)) {
+    const wallet = parseWalletOrNull(req.params.wallet);
+    if (!wallet) {
       return res.status(400).json({
         error: 'Invalid wallet format. Expected EVM wallet like 0x... (40 hex chars).'
       });
@@ -765,8 +767,8 @@ router.get('/share/payload/:wallet', readLimiter, async (req, res) => {
 
 router.get('/share/image/:wallet.svg', readLimiter, async (req, res) => {
   try {
-    const wallet = String(req.params.wallet || '').trim().toLowerCase();
-    if (!isValidWalletAddress(wallet)) {
+    const wallet = parseWalletOrNull(req.params.wallet);
+    if (!wallet) {
       return res.status(400).json({ error: 'Invalid wallet format.' });
     }
 
@@ -814,8 +816,8 @@ router.get('/share/image/:wallet.svg', readLimiter, async (req, res) => {
 
 router.get('/share/image/:wallet.png', readLimiter, async (req, res) => {
   try {
-    const wallet = String(req.params.wallet || '').trim().toLowerCase();
-    if (!isValidWalletAddress(wallet)) {
+    const wallet = parseWalletOrNull(req.params.wallet);
+    if (!wallet) {
       return res.status(400).json({ error: 'Invalid wallet format.' });
     }
 
@@ -841,8 +843,8 @@ router.get('/share/image/:wallet.png', readLimiter, async (req, res) => {
 
 router.get('/share/page/:wallet', readLimiter, async (req, res) => {
   try {
-    const wallet = String(req.params.wallet || '').trim().toLowerCase();
-    if (!isValidWalletAddress(wallet)) {
+    const wallet = parseWalletOrNull(req.params.wallet);
+    if (!wallet) {
       return res.status(400).send('Invalid wallet');
     }
 
@@ -912,10 +914,8 @@ router.get('/insights', readLimiter, async (req, res) => {
       return res.status(404).json({ error: 'Insights are disabled by feature flag.' });
     }
 
-    const walletQuery = typeof req.query.wallet === 'string' ? req.query.wallet.trim() : '';
-    const wallet = walletQuery ? walletQuery.toLowerCase() : null;
-
-    if (!wallet || !isValidWalletAddress(wallet)) {
+    const wallet = parseWalletOrNull(req.query.wallet);
+    if (!wallet) {
       return res.status(400).json({
         error: 'Invalid wallet format. Expected EVM wallet like 0x... (40 hex chars).'
       });

--- a/utils/donationService.js
+++ b/utils/donationService.js
@@ -198,13 +198,16 @@ async function createDonationPayment(wallet, productKey) {
     throw err;
   }
 
-  const existingOpenPayment = await DonationPayment.findOne({
+  const existingOpenPaymentQuery = DonationPayment.findOne({
     wallet: normalizedWallet,
     productKey: config.key,
     paymentMethod: 'crypto',
     status: { $in: [INTERNAL_STATUS_AWAITING_TX, 'submitted', 'confirmed'] },
     rewardGrantedAt: null
-  }).sort({ createdAt: -1 });
+  });
+  const existingOpenPayment = typeof existingOpenPaymentQuery?.sort === 'function'
+    ? await existingOpenPaymentQuery.sort({ createdAt: -1 })
+    : await existingOpenPaymentQuery;
 
   if (existingOpenPayment) {
     return existingOpenPayment;

--- a/utils/security.js
+++ b/utils/security.js
@@ -10,6 +10,18 @@ function normalizeWallet(wallet) {
   return normalized || null;
 }
 
+function isValidWalletAddress(wallet) {
+  return typeof wallet === 'string' && /^0x[a-fA-F0-9]{40}$/.test(wallet);
+}
+
+function parseWalletOrNull(wallet) {
+  const normalized = normalizeWallet(wallet);
+  if (!normalized) {
+    return null;
+  }
+  return isValidWalletAddress(normalized) ? normalized : null;
+}
+
 function validateTimestampWindow(timestamp, {
   windowMs,
   maxPastAgeMs,
@@ -51,6 +63,8 @@ async function logSecurityEvent({ wallet = null, eventType, route, ipAddress, de
 
 module.exports = {
   normalizeWallet,
+  isValidWalletAddress,
+  parseWalletOrNull,
   validateTimestampWindow,
   logSecurityEvent
 };


### PR DESCRIPTION
### Motivation
- Add a reproducible audit pipeline and artifact for periodic backend health and dependency checks.
- Reduce duplicated wallet parsing/validation logic spread across leaderboard routes to avoid drift and inconsistent error responses.
- Fix a potential async/query bug when finding existing open donation payments that could behave incorrectly when chaining `.sort()` on a query result.

### Description
- Add a new GitHub Actions workflow at `.github/workflows/backend-audit.yml` that runs `npm ci`, `npm run check:syntax`, `npm test`, `npm audit --audit-level=moderate`, a duplicate-wallet-validation guardrail using `rg`, and uploads a `docs/deep_audit_2026-04-30.md` artifact.
- Introduce `isValidWalletAddress` and `parseWalletOrNull` in `utils/security.js` and export them alongside `normalizeWallet` and other helpers to centralize wallet normalization and validation.
- Update `routes/leaderboard.js` to use `parseWalletOrNull` in all wallet-related endpoints (`/top`, `/share/*`, `/insights`, `/share/page/:wallet`, image routes, etc.) and remove the local `isValidWalletAddress` definition to standardize validation and error handling.
- Fix `utils/donationService.js` to avoid calling `.sort()` directly on the immediate query result by separating the `findOne` query into `existingOpenPaymentQuery` and then conditionally calling `.sort({ createdAt: -1 })` before awaiting the result.
- Add a deep audit report `docs/deep_audit_2026-04-30.md` documenting duplication, performance, and testing findings and proposed refactors.

### Testing
- The new audit workflow is configured to run `npm run check:syntax` and `npm test` in CI as part of the audit job (configured in the new workflow), and it uploads the audit report as an artifact when complete.
- A local/CI test run (`npm test`) surfaced instability concentrated in donations integration tests, where `POST /api/store/donations/create-payment` returned 500 and caused multiple downstream failures, which remained failing and are noted in the audit report.
- Syntax checks via `npm run check:syntax` were included as part of the audit job configuration; no further automated test results are available in this rollout beyond the noted unstable donation-related failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f35dcce228832093707e36d70aa6fb)