### PR TITLE
Use persisted best score for share banners and add score image generator scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "start:api": "node server.js",
     "start:bot": "node botWorker.js",
     "test": "NODE_ENV=test node --test tests/*.test.js",
-    "preview:share": "node scripts/generate-share-preview.js"
+    "preview:share": "node scripts/generate-share-preview.js",
+    "generate-score": "node scripts/generate-score.js"
   },
   "dependencies": {
     "axios": "^1.15.2",

--- a/routes/leaderboard.js
+++ b/routes/leaderboard.js
@@ -69,9 +69,8 @@ async function resolveShareContextByWallet(wallet) {
   const personalBestScore = Math.max(0, Number(player.bestScore || 0));
   const latestRunScore = latestRun ? Math.max(0, Number(latestRun.score || 0)) : 0;
   const isLatestRunPersonalBest = Boolean(latestRun?.isPersonalBest && latestRunScore > 0);
-  const scoreForShare = isLatestRunPersonalBest
-    ? latestRunScore
-    : Math.max(personalBestScore, latestRunScore);
+  // Share banner must always use persisted player's best score.
+  const scoreForShare = personalBestScore;
 
   return {
     wallet: player.wallet,

--- a/scripts/generate-score-examples.js
+++ b/scripts/generate-score-examples.js
@@ -1,0 +1,12 @@
+#!/usr/bin/env node
+const path = require('path');
+const { execFileSync } = require('child_process');
+
+const base = path.join(process.cwd(), 'img', 'score_result.png');
+const outDir = path.join(process.cwd(), 'tmp', 'score-examples');
+const scores = [1, 9999, 223232, 999999];
+
+for (const score of scores) {
+  const out = path.join(outDir, `score-${score}.png`);
+  execFileSync('node', ['scripts/generate-score.js', '--base', base, '--score', String(score), '--out', out], { stdio: 'inherit' });
+}

--- a/scripts/generate-score.js
+++ b/scripts/generate-score.js
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+const sharp = require('sharp');
+
+function parseArgs(argv) {
+  const args = {};
+  for (let i = 0; i < argv.length; i += 1) {
+    if (!argv[i].startsWith('--')) continue;
+    args[argv[i].slice(2)] = argv[i + 1];
+    i += 1;
+  }
+  return args;
+}
+
+function validateScore(score) {
+  const raw = String(score || '').trim();
+  if (!/^\d+$/.test(raw)) throw new Error('score must be an integer between 0 and 999999');
+  const value = Number(raw);
+  if (!Number.isInteger(value) || value < 0 || value > 999999) throw new Error('score must be an integer between 0 and 999999');
+  return String(value);
+}
+
+function buildScoreSvg(score, width = 1024, height = 1024) {
+  const block = {
+    x: width * (70 / 1024),
+    y: height * (310 / 1024),
+    width: width * (520 / 1024),
+    height: height * (210 / 1024),
+    radius: Math.min(width, height) * (24 / 1024)
+  };
+  const scale = Math.min(width, height) / 1024;
+  const fontSize = score.length <= 4 ? 128 * scale : 108 * scale;
+  const textX = block.x + block.width / 2;
+  const textY = block.y + block.height / 2;
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}"><defs><linearGradient id="scoreTextGradient" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" stop-color="#a855f7"/><stop offset="100%" stop-color="#22d3ee"/></linearGradient><linearGradient id="boxFill" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" stop-color="#111327"/><stop offset="100%" stop-color="#1f233d"/></linearGradient><filter id="boxGlow" x="-40%" y="-60%" width="180%" height="220%"><feDropShadow dx="0" dy="8" stdDeviation="10" flood-color="#05060f" flood-opacity="0.8"/><feDropShadow dx="0" dy="0" stdDeviation="7" flood-color="#22d3ee" flood-opacity="0.5"/></filter><filter id="textGlow" x="-40%" y="-40%" width="180%" height="180%"><feDropShadow dx="0" dy="0" stdDeviation="3.5" flood-color="#22d3ee" flood-opacity="0.7"/></filter></defs><g transform="rotate(-12 ${textX} ${textY})"><rect x="${block.x}" y="${block.y}" width="${block.width}" height="${block.height}" rx="${block.radius}" fill="url(#boxFill)" stroke="#67e8f9" stroke-width="5" filter="url(#boxGlow)"/><text x="${textX}" y="${textY}" fill="url(#scoreTextGradient)" font-family="Anton, Impact, Arial Black, sans-serif" font-size="${fontSize}" font-weight="900" text-anchor="middle" dominant-baseline="middle" letter-spacing="2" lengthAdjust="spacingAndGlyphs" textLength="${block.width * 0.84}" filter="url(#textGlow)">${score}</text></g></svg>`;
+}
+
+async function generate(baseImagePath, score, outputPath) {
+  const metadata = await sharp(baseImagePath).metadata();
+  const svgBuffer = Buffer.from(buildScoreSvg(score, metadata.width || 1024, metadata.height || 1024));
+  const out = await sharp(baseImagePath).composite([{ input: svgBuffer, left: 0, top: 0 }]).png().toBuffer();
+  if (outputPath) {
+    fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+    fs.writeFileSync(outputPath, out);
+  }
+  return out;
+}
+
+(async () => {
+  const args = parseArgs(process.argv.slice(2));
+  const base = args.base || './img/score_result.png';
+  const score = validateScore(args.score);
+  const out = args.out;
+  await generate(base, score, out);
+  process.stdout.write(`${out || '[buffer only]'}\n`);
+})();

--- a/src/generateScoreBanner.ts
+++ b/src/generateScoreBanner.ts
@@ -1,0 +1,64 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import sharp from 'sharp';
+
+const MAX_SCORE = 999999;
+
+function escapeXml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function normalizeScore(score: number | string): string {
+  const raw = String(score).trim();
+  if (!/^\d+$/.test(raw)) throw new Error('score must be an integer between 0 and 999999');
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed) || parsed < 0 || parsed > MAX_SCORE) throw new Error('score must be an integer between 0 and 999999');
+  return String(parsed);
+}
+
+export function buildScoreSvg(score: number | string, options: { width: number; height: number } = { width: 1024, height: 1024 }): string {
+  const scoreText = normalizeScore(score);
+  const { width, height } = options;
+  const block = {
+    x: width * (70 / 1024),
+    y: height * (310 / 1024),
+    width: width * (520 / 1024),
+    height: height * (210 / 1024),
+    radius: Math.min(width, height) * (24 / 1024)
+  };
+  const scale = Math.min(width, height) / 1024;
+  const fontSize = scoreText.length <= 4 ? 128 * scale : 108 * scale;
+  const textX = block.x + block.width / 2;
+  const textY = block.y + block.height / 2;
+
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}">
+  <defs>
+    <linearGradient id="scoreTextGradient" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" stop-color="#a855f7"/><stop offset="100%" stop-color="#22d3ee"/></linearGradient>
+    <linearGradient id="boxFill" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" stop-color="#111327"/><stop offset="100%" stop-color="#1f233d"/></linearGradient>
+    <filter id="boxGlow" x="-40%" y="-60%" width="180%" height="220%"><feDropShadow dx="0" dy="8" stdDeviation="10" flood-color="#05060f" flood-opacity="0.8"/><feDropShadow dx="0" dy="0" stdDeviation="7" flood-color="#22d3ee" flood-opacity="0.5"/></filter>
+    <filter id="textGlow" x="-40%" y="-40%" width="180%" height="180%"><feDropShadow dx="0" dy="0" stdDeviation="3.5" flood-color="#22d3ee" flood-opacity="0.7"/></filter>
+  </defs>
+  <g transform="rotate(-12 ${textX} ${textY})">
+    <rect x="${block.x}" y="${block.y}" width="${block.width}" height="${block.height}" rx="${block.radius}" fill="url(#boxFill)" stroke="#67e8f9" stroke-width="5" filter="url(#boxGlow)"/>
+    <text x="${textX}" y="${textY}" fill="url(#scoreTextGradient)" font-family="Anton, Impact, Arial Black, sans-serif" font-size="${fontSize}" font-weight="900" text-anchor="middle" dominant-baseline="middle" letter-spacing="2" lengthAdjust="spacingAndGlyphs" textLength="${block.width * 0.84}" filter="url(#textGlow)">${escapeXml(scoreText)}</text>
+  </g>
+</svg>`;
+}
+
+export async function generateScoreBanner(params: { baseImagePath: string; score: number | string; outputPath?: string; }): Promise<Buffer> {
+  const scoreText = normalizeScore(params.score);
+  const metadata = await sharp(params.baseImagePath).metadata();
+  const svg = buildScoreSvg(scoreText, { width: metadata.width ?? 1024, height: metadata.height ?? 1024 });
+  const svgBuffer = Buffer.from(svg);
+  const resultBuffer = await sharp(params.baseImagePath).composite([{ input: svgBuffer, left: 0, top: 0 }]).png().toBuffer();
+  if (params.outputPath) {
+    await fs.mkdir(path.dirname(params.outputPath), { recursive: true });
+    await fs.writeFile(params.outputPath, resultBuffer);
+  }
+  return resultBuffer;
+}


### PR DESCRIPTION
### Motivation
- Ensure share banners always display the persisted player best score rather than a possibly higher transient latest run, and provide tooling to generate score banner images for sharing and examples.

### Description
- Change share resolution logic in `routes/leaderboard.js` so `scoreForShare` is always the persisted `player.bestScore` instead of selecting between latest run and best score.
- Add a TypeScript utility `src/generateScoreBanner.ts` that builds SVG score overlays and composes them onto a base image via `sharp` with `buildScoreSvg` and `generateScoreBanner` exports.
- Add CLI Node scripts `scripts/generate-score.js` (image generator) and `scripts/generate-score-examples.js` (batch examples) to create score banner PNGs, and register `generate-score` in `package.json` scripts.

### Testing
- No automated tests were added or executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f7ab66d47c83268aa9d302badc73c7)