### PR TITLE
Normalize /api/x/share-result error responses, add mappings and tests, add UX prompt doc

### DIFF
--- a/docs/share-result-error-ux-prompt-2026-05-04.md
+++ b/docs/share-result-error-ux-prompt-2026-05-04.md
@@ -1,0 +1,80 @@
+# Share Result: диагностика ошибки и готовый prompt на исправление (2026-05-04)
+
+## Что видно по фактам
+
+- В браузере при клике `Share result` уходит `POST /api/x/share-result` и приходит `500 Internal Server Error`.
+- На backend маршрут `routes/x.js` в случае нераспознанной ошибки от X API возвращает общий `500 { error: "Server error" }`.
+- В том же маршруте есть специальный кейс `x_media_upload_failed` (502), но он срабатывает только когда upload вернул пустой `media_id`; остальные сбои (429/403/5xx/X API errors) уходят в общий 500.
+- На frontend показывается сообщение про ошибку прикрепления картинки, что UX-переизбыточно для пользователя в моменте (пользователь и так видит, что шаринг не завершился).
+
+## Вероятная первопричина
+
+Комбинированная:
+
+1. **Backend**: слишком грубая обработка ошибок в `/api/x/share-result` (всё схлопывается в `Server error`), из-за чего frontend не может различать технические причины.
+2. **Frontend**: агрессивный UX для ошибки attach (показывает «ошибку прикрепления изображения» в явном виде даже когда полезнее мягкий fallback).
+
+## Что исправлять
+
+### Backend
+
+- Нормализовать ошибки X API в стабильные коды:
+  - `x_media_upload_failed`
+  - `x_rate_limited`
+  - `x_auth_expired`
+  - `x_post_failed`
+- В ответ добавлять `retryable: boolean` и `fallback: "text_intent" | null`.
+- Не возвращать общий `Server error`, если ошибка классифицируема.
+- Логи: сохранять `xStatus`, `xErrorCode`, `requestId`, `primaryId(masked)`.
+
+### Frontend
+
+- Для кнопки **Share result**:
+  - Если `posted=true` — успех.
+  - Если `fallback === "text_intent"` — **не показывать пугающий attach-error**; показать нейтральный toast: «Не удалось опубликовать с картинкой, открыть текстовый share?» + CTA.
+  - Для `x_rate_limited` — «Слишком часто, попробуйте через минуту».
+  - Для `x_auth_expired` — «Переподключите X».
+- Сообщение «ошибка прикрепления изображения» убрать из дефолтного UX и оставить только для debug/dev режима.
+
+## Готовый prompt для исполнителя (Cursor/Codex)
+
+```text
+Ты работаешь с двумя репозиториями:
+- backend: URSASS_Backend
+- frontend: Ursasstube
+
+Задача: исправить UX и надежность сценария Share result.
+
+Симптом:
+- При клике Share result иногда приходит POST /api/x/share-result -> 500.
+- На фронте показывается явный текст про ошибку прикрепления изображения, что раздражает пользователя.
+
+Сделай:
+
+1) Backend (URSASS_Backend)
+- В routes/x.js для POST /api/x/share-result добавь классификацию ошибок X API.
+- Возвращай структурированные ошибки:
+  - { error: "x_media_upload_failed", retryable: true, fallback: "text_intent" }
+  - { error: "x_rate_limited", retryable: true, fallback: "text_intent" }
+  - { error: "x_auth_expired", retryable: false, fallback: null }
+  - { error: "x_post_failed", retryable: true, fallback: "text_intent" }
+- Сохрани текущий happy path (tweet c media_ids).
+- Добавь/обнови тесты для новых веток ошибок.
+
+2) Frontend (Ursasstube)
+- В обработчике Share result перестань показывать «ошибка прикрепления изображения» как дефолт.
+- Используй error contract с backend:
+  - fallback=text_intent -> мягкий toast + кнопка «Поделиться текстом».
+  - x_auth_expired -> CTA «Подключить X снова».
+  - x_rate_limited -> нейтральный retry toast.
+- Для 500 без contract показывай общий «Не удалось поделиться, попробуйте позже».
+
+3) UX acceptance criteria
+- Пользователь не видит технический attach-error как основной текст.
+- При проблемах есть понятный следующий шаг (retry, reconnect, share text).
+- Если backend вернул posted=true, никаких fallback окон не открывается.
+
+4) Deliverables
+- PR в backend + PR во frontend.
+- Короткий changelog и таблица: error code -> user message -> action.
+```

--- a/routes/x.js
+++ b/routes/x.js
@@ -34,6 +34,21 @@ function maskedPrimaryId(primaryId) {
     : '***';
 }
 
+
+function classifyShareResultError(err) {
+  const status = Number(err?.response?.status || err?.status || 0);
+  if (status === 401) {
+    return { statusCode: 401, error: 'x_auth_expired', retryable: false, fallback: null };
+  }
+  if (status === 429) {
+    return { statusCode: 429, error: 'x_rate_limited', retryable: true, fallback: 'text_intent' };
+  }
+  if ([400, 403, 404, 413, 415, 422].includes(status)) {
+    return { statusCode: 502, error: 'x_media_upload_failed', retryable: true, fallback: 'text_intent' };
+  }
+  return { statusCode: 502, error: 'x_post_failed', retryable: true, fallback: 'text_intent' };
+}
+
 function getClientIp(req) {
   const xff = req.get('x-forwarded-for');
   if (xff && typeof xff === 'string') {
@@ -393,7 +408,7 @@ router.post('/share-result', shareResultLimiter, requireXOAuth, async (req, res)
       const mediaId = await xOAuth.uploadMedia(tokenToUse, shareImageBuffer);
       if (!mediaId) {
         logger.warn({ primaryId: maskedPrimaryId(primaryId) }, 'X media upload returned empty media id');
-        return res.status(502).json({ error: 'x_media_upload_failed' });
+        return res.status(502).json({ error: 'x_media_upload_failed', retryable: true, fallback: 'text_intent' });
       }
       tweet = await xOAuth.createTweet(tokenToUse, {
         text: tweetText,
@@ -415,7 +430,7 @@ router.post('/share-result', shareResultLimiter, requireXOAuth, async (req, res)
       const mediaId = await xOAuth.uploadMedia(tokenToUse, shareImageBuffer);
       if (!mediaId) {
         logger.warn({ primaryId: maskedPrimaryId(primaryId) }, 'X media upload returned empty media id');
-        return res.status(502).json({ error: 'x_media_upload_failed' });
+        return res.status(502).json({ error: 'x_media_upload_failed', retryable: true, fallback: 'text_intent' });
       }
       tweet = await xOAuth.createTweet(tokenToUse, {
         text: tweetText,
@@ -424,7 +439,7 @@ router.post('/share-result', shareResultLimiter, requireXOAuth, async (req, res)
     }
 
     if (!tweet?.id) {
-      return res.status(502).json({ error: 'x_tweet_failed' });
+      return res.status(502).json({ error: 'x_post_failed', retryable: true, fallback: 'text_intent' });
     }
 
     const tweetUrl = player.xUsername
@@ -442,7 +457,8 @@ router.post('/share-result', shareResultLimiter, requireXOAuth, async (req, res)
       return res.status(503).json({ error: 'share_png_unavailable' });
     }
     logger.error({ err: err.message }, 'POST /x/share-result error');
-    return res.status(500).json({ error: 'Server error' });
+    const mapped = classifyShareResultError(err);
+    return res.status(mapped.statusCode).json({ error: mapped.error, retryable: mapped.retryable, fallback: mapped.fallback });
   }
 });
 

--- a/tests/xOAuth.test.js
+++ b/tests/xOAuth.test.js
@@ -607,8 +607,81 @@ test('POST /api/x/share-result - returns 502 when media upload has no media_id',
     const r = await post(baseUrl, '/api/x/share-result', {}, { 'X-Primary-Id': 'tg_x12' });
     assert.equal(r.status, 502);
     assert.equal(r.body.error, 'x_media_upload_failed');
+    assert.equal(r.body.retryable, true);
+    assert.equal(r.body.fallback, 'text_intent');
   } finally {
     xOAuthModule.createTweet = origCreateTweet;
+    xOAuthModule.uploadMedia = origUploadMedia;
+    clearXOAuthEnv();
+    server.close();
+  }
+});
+
+
+test('POST /api/x/share-result - maps 429 to x_rate_limited contract', async () => {
+  setXOAuthEnv();
+  const { server, baseUrl } = await startServer();
+  const origUploadMedia = xOAuthModule.uploadMedia;
+  try {
+    const link = { primaryId: 'tg_x13', telegramId: '13', wallet: null };
+    AccountLink.findOne = async () => link;
+
+    const player = makePlayer({
+      wallet: 'tg_x13',
+      bestScore: 88,
+      xUserId: 'x_user_13',
+      xAccessToken: 'token_13',
+      xRefreshToken: 'refresh_13'
+    });
+    Player.findOne = () => chainableQuery({ ...player, save: async function() { return this; } });
+
+    xOAuthModule.uploadMedia = async () => {
+      const err = new Error('rate limited');
+      err.response = { status: 429 };
+      throw err;
+    };
+
+    const r = await post(baseUrl, '/api/x/share-result', {}, { 'X-Primary-Id': 'tg_x13' });
+    assert.equal(r.status, 429);
+    assert.equal(r.body.error, 'x_rate_limited');
+    assert.equal(r.body.retryable, true);
+    assert.equal(r.body.fallback, 'text_intent');
+  } finally {
+    xOAuthModule.uploadMedia = origUploadMedia;
+    clearXOAuthEnv();
+    server.close();
+  }
+});
+
+test('POST /api/x/share-result - maps 401 without refresh token to x_auth_expired', async () => {
+  setXOAuthEnv();
+  const { server, baseUrl } = await startServer();
+  const origUploadMedia = xOAuthModule.uploadMedia;
+  try {
+    const link = { primaryId: 'tg_x14', telegramId: '14', wallet: null };
+    AccountLink.findOne = async () => link;
+
+    const player = makePlayer({
+      wallet: 'tg_x14',
+      bestScore: 42,
+      xUserId: 'x_user_14',
+      xAccessToken: 'expired_14',
+      xRefreshToken: ''
+    });
+    Player.findOne = () => chainableQuery({ ...player, save: async function() { return this; } });
+
+    xOAuthModule.uploadMedia = async () => {
+      const err = new Error('unauthorized');
+      err.response = { status: 401 };
+      throw err;
+    };
+
+    const r = await post(baseUrl, '/api/x/share-result', {}, { 'X-Primary-Id': 'tg_x14' });
+    assert.equal(r.status, 401);
+    assert.equal(r.body.error, 'x_auth_expired');
+    assert.equal(r.body.retryable, false);
+    assert.equal(r.body.fallback, null);
+  } finally {
     xOAuthModule.uploadMedia = origUploadMedia;
     clearXOAuthEnv();
     server.close();


### PR DESCRIPTION
### Motivation

- The `/api/x/share-result` route returned a generic `500` for many X API failures, preventing the frontend from distinguishing actionable cases.
- Media upload and post failures should surface structured error contracts (`error`, `retryable`, `fallback`) so the UI can present softer UX and recovery actions.

### Description

- Added `classifyShareResultError` to `routes/x.js` and mapped X API statuses to structured responses such as `x_auth_expired`, `x_rate_limited`, `x_media_upload_failed`, and `x_post_failed` with `retryable` and `fallback` fields.
- Replaced ad-hoc `502`/`500` responses and a generic `Server error` with the new mapped responses and updated early returns to include `retryable` and `fallback` where appropriate.
- Updated the media/post failure path to return `x_media_upload_failed` / `x_post_failed` and included `retryable: true` and `fallback: 'text_intent'` for fallback behavior.
- Added/updated tests in `tests/xOAuth.test.js` to assert the new contract and mappings, and added a documentation note at `docs/share-result-error-ux-prompt-2026-05-04.md` describing the UX guidance and developer prompt.

### Testing

- Ran the automated test suite via `npm test` which includes the updated `tests/xOAuth.test.js` checks.  
- Existing test for empty media id was extended to assert `retryable` and `fallback` and passed.  
- New tests for mapping a `429` to `x_rate_limited` and a `401` without refresh token to `x_auth_expired` were added and passed.  
- All automated tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8b227a26c8326b1d252b8538a6129)