### PR TITLE
Classify X API errors for /api/x/share-result, return structured error contract, and use static share image

### DIFF
--- a/docs/share-result-error-ux-prompt-2026-05-04.md
+++ b/docs/share-result-error-ux-prompt-2026-05-04.md
@@ -1,0 +1,80 @@
+# Share Result: диагностика ошибки и готовый prompt на исправление (2026-05-04)
+
+## Что видно по фактам
+
+- В браузере при клике `Share result` уходит `POST /api/x/share-result` и приходит `500 Internal Server Error`.
+- На backend маршрут `routes/x.js` в случае нераспознанной ошибки от X API возвращает общий `500 { error: "Server error" }`.
+- В том же маршруте есть специальный кейс `x_media_upload_failed` (502), но он срабатывает только когда upload вернул пустой `media_id`; остальные сбои (429/403/5xx/X API errors) уходят в общий 500.
+- На frontend показывается сообщение про ошибку прикрепления картинки, что UX-переизбыточно для пользователя в моменте (пользователь и так видит, что шаринг не завершился).
+
+## Вероятная первопричина
+
+Комбинированная:
+
+1. **Backend**: слишком грубая обработка ошибок в `/api/x/share-result` (всё схлопывается в `Server error`), из-за чего frontend не может различать технические причины.
+2. **Frontend**: агрессивный UX для ошибки attach (показывает «ошибку прикрепления изображения» в явном виде даже когда полезнее мягкий fallback).
+
+## Что исправлять
+
+### Backend
+
+- Нормализовать ошибки X API в стабильные коды:
+  - `x_media_upload_failed`
+  - `x_rate_limited`
+  - `x_auth_expired`
+  - `x_post_failed`
+- В ответ добавлять `retryable: boolean` и `fallback: "text_intent" | null`.
+- Не возвращать общий `Server error`, если ошибка классифицируема.
+- Логи: сохранять `xStatus`, `xErrorCode`, `requestId`, `primaryId(masked)`.
+
+### Frontend
+
+- Для кнопки **Share result**:
+  - Если `posted=true` — успех.
+  - Если `fallback === "text_intent"` — **не показывать пугающий attach-error**; показать нейтральный toast: «Не удалось опубликовать с картинкой, открыть текстовый share?» + CTA.
+  - Для `x_rate_limited` — «Слишком часто, попробуйте через минуту».
+  - Для `x_auth_expired` — «Переподключите X».
+- Сообщение «ошибка прикрепления изображения» убрать из дефолтного UX и оставить только для debug/dev режима.
+
+## Готовый prompt для исполнителя (Cursor/Codex)
+
+```text
+Ты работаешь с двумя репозиториями:
+- backend: URSASS_Backend
+- frontend: Ursasstube
+
+Задача: исправить UX и надежность сценария Share result.
+
+Симптом:
+- При клике Share result иногда приходит POST /api/x/share-result -> 500.
+- На фронте показывается явный текст про ошибку прикрепления изображения, что раздражает пользователя.
+
+Сделай:
+
+1) Backend (URSASS_Backend)
+- В routes/x.js для POST /api/x/share-result добавь классификацию ошибок X API.
+- Возвращай структурированные ошибки:
+  - { error: "x_media_upload_failed", retryable: true, fallback: "text_intent" }
+  - { error: "x_rate_limited", retryable: true, fallback: "text_intent" }
+  - { error: "x_auth_expired", retryable: false, fallback: null }
+  - { error: "x_post_failed", retryable: true, fallback: "text_intent" }
+- Сохрани текущий happy path (tweet c media_ids).
+- Добавь/обнови тесты для новых веток ошибок.
+
+2) Frontend (Ursasstube)
+- В обработчике Share result перестань показывать «ошибка прикрепления изображения» как дефолт.
+- Используй error contract с backend:
+  - fallback=text_intent -> мягкий toast + кнопка «Поделиться текстом».
+  - x_auth_expired -> CTA «Подключить X снова».
+  - x_rate_limited -> нейтральный retry toast.
+- Для 500 без contract показывай общий «Не удалось поделиться, попробуйте позже».
+
+3) UX acceptance criteria
+- Пользователь не видит технический attach-error как основной текст.
+- При проблемах есть понятный следующий шаг (retry, reconnect, share text).
+- Если backend вернул posted=true, никаких fallback окон не открывается.
+
+4) Deliverables
+- PR в backend + PR во frontend.
+- Короткий changelog и таблица: error code -> user message -> action.
+```

--- a/routes/x.js
+++ b/routes/x.js
@@ -11,13 +11,14 @@
 const express = require('express');
 const router = express.Router();
 const crypto = require('crypto');
+const fs = require('fs/promises');
+const path = require('path');
 const rateLimit = require('express-rate-limit');
 const OAuthState = require('../models/OAuthState');
 const Player = require('../models/Player');
 const AccountLink = require('../models/AccountLink');
 const xOAuth = require('../utils/xOAuth');
 const { buildReferralUrl } = require('../utils/referral');
-const { renderScoreSharePng } = require('../utils/shareCard');
 const { logSecurityEvent } = require('../utils/security');
 const logger = require('../utils/logger');
 const { findLink } = require('../middleware/requireAuth');
@@ -32,6 +33,25 @@ function maskedPrimaryId(primaryId) {
   return primaryId.length > MIN_ID_LENGTH_FOR_MASKING
     ? `${primaryId.slice(0, 3)}***${primaryId.slice(-3)}`
     : '***';
+}
+
+
+function classifyShareResultError(err) {
+  const status = Number(err?.response?.status || err?.status || 0);
+  if (status === 401) {
+    return { statusCode: 401, error: 'x_auth_expired', retryable: false, fallback: null };
+  }
+  if (status === 429) {
+    return { statusCode: 429, error: 'x_rate_limited', retryable: true, fallback: 'text_intent' };
+  }
+  const dataStr = JSON.stringify(err?.response?.data || {});
+  if (status === 403 && /media\.write|insufficient|scope/i.test(dataStr)) {
+    return { statusCode: 401, error: 'x_auth_expired', retryable: false, fallback: null };
+  }
+  if ([400, 403, 404, 413, 415, 422].includes(status)) {
+    return { statusCode: 502, error: 'x_media_upload_failed', retryable: true, fallback: 'text_intent' };
+  }
+  return { statusCode: 502, error: 'x_post_failed', retryable: true, fallback: 'text_intent' };
 }
 
 function getClientIp(req) {
@@ -97,6 +117,12 @@ function getPublicBaseUrl(req) {
   return `${req.protocol}://${req.get('host')}`;
 }
 
+
+const STATIC_SHARE_IMAGE_PATH = path.join(__dirname, '..', 'img', 'score_result.png');
+
+async function loadStaticShareImagePng() {
+  return fs.readFile(STATIC_SHARE_IMAGE_PATH);
+}
 function buildSharePostText(score, referralUrl) {
   const normalizedScore = Math.max(0, Math.floor(Number(score || 0)));
   const main = SHARE_COPY_TEMPLATE.replace('{score}', normalizedScore);
@@ -385,7 +411,7 @@ router.post('/share-result', shareResultLimiter, requireXOAuth, async (req, res)
       ? `${getPublicBaseUrl(req)}/api/leaderboard/share/page/${walletAddress}`
       : null;
     const tweetText = sharePageUrl ? `${postText}\n${sharePageUrl}` : postText;
-    const shareImageBuffer = await renderScoreSharePng(scoreForShare);
+    const shareImageBuffer = await loadStaticShareImagePng();
 
     let tokenToUse = player.xAccessToken;
     let tweet;
@@ -393,7 +419,7 @@ router.post('/share-result', shareResultLimiter, requireXOAuth, async (req, res)
       const mediaId = await xOAuth.uploadMedia(tokenToUse, shareImageBuffer);
       if (!mediaId) {
         logger.warn({ primaryId: maskedPrimaryId(primaryId) }, 'X media upload returned empty media id');
-        return res.status(502).json({ error: 'x_media_upload_failed' });
+        return res.status(502).json({ error: 'x_media_upload_failed', retryable: true, fallback: 'text_intent' });
       }
       tweet = await xOAuth.createTweet(tokenToUse, {
         text: tweetText,
@@ -415,7 +441,7 @@ router.post('/share-result', shareResultLimiter, requireXOAuth, async (req, res)
       const mediaId = await xOAuth.uploadMedia(tokenToUse, shareImageBuffer);
       if (!mediaId) {
         logger.warn({ primaryId: maskedPrimaryId(primaryId) }, 'X media upload returned empty media id');
-        return res.status(502).json({ error: 'x_media_upload_failed' });
+        return res.status(502).json({ error: 'x_media_upload_failed', retryable: true, fallback: 'text_intent' });
       }
       tweet = await xOAuth.createTweet(tokenToUse, {
         text: tweetText,
@@ -424,7 +450,7 @@ router.post('/share-result', shareResultLimiter, requireXOAuth, async (req, res)
     }
 
     if (!tweet?.id) {
-      return res.status(502).json({ error: 'x_tweet_failed' });
+      return res.status(502).json({ error: 'x_post_failed', retryable: true, fallback: 'text_intent' });
     }
 
     const tweetUrl = player.xUsername
@@ -442,7 +468,8 @@ router.post('/share-result', shareResultLimiter, requireXOAuth, async (req, res)
       return res.status(503).json({ error: 'share_png_unavailable' });
     }
     logger.error({ err: err.message }, 'POST /x/share-result error');
-    return res.status(500).json({ error: 'Server error' });
+    const mapped = classifyShareResultError(err);
+    return res.status(mapped.statusCode).json({ error: mapped.error, retryable: mapped.retryable, fallback: mapped.fallback });
   }
 });
 

--- a/tests/xOAuth.test.js
+++ b/tests/xOAuth.test.js
@@ -607,8 +607,117 @@ test('POST /api/x/share-result - returns 502 when media upload has no media_id',
     const r = await post(baseUrl, '/api/x/share-result', {}, { 'X-Primary-Id': 'tg_x12' });
     assert.equal(r.status, 502);
     assert.equal(r.body.error, 'x_media_upload_failed');
+    assert.equal(r.body.retryable, true);
+    assert.equal(r.body.fallback, 'text_intent');
   } finally {
     xOAuthModule.createTweet = origCreateTweet;
+    xOAuthModule.uploadMedia = origUploadMedia;
+    clearXOAuthEnv();
+    server.close();
+  }
+});
+
+
+test('POST /api/x/share-result - maps 429 to x_rate_limited contract', async () => {
+  setXOAuthEnv();
+  const { server, baseUrl } = await startServer();
+  const origUploadMedia = xOAuthModule.uploadMedia;
+  try {
+    const link = { primaryId: 'tg_x13', telegramId: '13', wallet: null };
+    AccountLink.findOne = async () => link;
+
+    const player = makePlayer({
+      wallet: 'tg_x13',
+      bestScore: 88,
+      xUserId: 'x_user_13',
+      xAccessToken: 'token_13',
+      xRefreshToken: 'refresh_13'
+    });
+    Player.findOne = () => chainableQuery({ ...player, save: async function() { return this; } });
+
+    xOAuthModule.uploadMedia = async () => {
+      const err = new Error('rate limited');
+      err.response = { status: 429 };
+      throw err;
+    };
+
+    const r = await post(baseUrl, '/api/x/share-result', {}, { 'X-Primary-Id': 'tg_x13' });
+    assert.equal(r.status, 429);
+    assert.equal(r.body.error, 'x_rate_limited');
+    assert.equal(r.body.retryable, true);
+    assert.equal(r.body.fallback, 'text_intent');
+  } finally {
+    xOAuthModule.uploadMedia = origUploadMedia;
+    clearXOAuthEnv();
+    server.close();
+  }
+});
+
+test('POST /api/x/share-result - maps 401 without refresh token to x_auth_expired', async () => {
+  setXOAuthEnv();
+  const { server, baseUrl } = await startServer();
+  const origUploadMedia = xOAuthModule.uploadMedia;
+  try {
+    const link = { primaryId: 'tg_x14', telegramId: '14', wallet: null };
+    AccountLink.findOne = async () => link;
+
+    const player = makePlayer({
+      wallet: 'tg_x14',
+      bestScore: 42,
+      xUserId: 'x_user_14',
+      xAccessToken: 'expired_14',
+      xRefreshToken: ''
+    });
+    Player.findOne = () => chainableQuery({ ...player, save: async function() { return this; } });
+
+    xOAuthModule.uploadMedia = async () => {
+      const err = new Error('unauthorized');
+      err.response = { status: 401 };
+      throw err;
+    };
+
+    const r = await post(baseUrl, '/api/x/share-result', {}, { 'X-Primary-Id': 'tg_x14' });
+    assert.equal(r.status, 401);
+    assert.equal(r.body.error, 'x_auth_expired');
+    assert.equal(r.body.retryable, false);
+    assert.equal(r.body.fallback, null);
+  } finally {
+    xOAuthModule.uploadMedia = origUploadMedia;
+    clearXOAuthEnv();
+    server.close();
+  }
+});
+
+
+test('POST /api/x/share-result - maps 403 insufficient scope to x_auth_expired', async () => {
+  setXOAuthEnv();
+  const { server, baseUrl } = await startServer();
+  const origUploadMedia = xOAuthModule.uploadMedia;
+  try {
+    const link = { primaryId: 'tg_x15', telegramId: '15', wallet: null };
+    AccountLink.findOne = async () => link;
+
+    const player = makePlayer({
+      wallet: 'tg_x15',
+      bestScore: 7,
+      xUserId: 'x_user_15',
+      xAccessToken: 'token_15',
+      xRefreshToken: 'refresh_15'
+    });
+    Player.findOne = () => chainableQuery({ ...player, save: async function() { return this; } });
+
+    xOAuthModule.uploadMedia = async () => {
+      const err = new Error('forbidden');
+      err.response = { status: 403, data: { detail: 'missing media.write scope' } };
+      throw err;
+    };
+
+    const r = await post(baseUrl, '/api/x/share-result', {}, { 'X-Primary-Id': 'tg_x15' });
+    assert.equal(r.status, 401);
+    assert.equal(r.body.error, 'x_auth_expired');
+    assert.equal(r.body.retryable, false);
+    assert.equal(r.body.fallback, null);
+  } finally {
     xOAuthModule.uploadMedia = origUploadMedia;
     clearXOAuthEnv();
     server.close();

--- a/utils/xOAuth.js
+++ b/utils/xOAuth.js
@@ -39,7 +39,7 @@ function getRedirectUri() {
 }
 
 function getScopes() {
-  return process.env.X_OAUTH_SCOPES || 'tweet.read tweet.write users.read offline.access';
+  return process.env.X_OAUTH_SCOPES || 'tweet.read tweet.write users.read offline.access media.write';
 }
 
 /**


### PR DESCRIPTION
### Motivation

- Improve the Share result flow so frontend can differentiate X API failures and present user-friendly fallbacks instead of a generic 500 and an aggressive attach-error UI. 
- Provide actionable error metadata (`retryable`, `fallback`) to enable soft fallbacks (text-only sharing), retry hints, and reconnect CTAs.

### Description

- Added `classifyShareResultError` to map X API responses to stable error contracts (`x_media_upload_failed`, `x_rate_limited`, `x_auth_expired`, `x_post_failed`) and return `error`, `retryable`, `fallback` and appropriate HTTP status codes. 
- Replaced dynamic `renderScoreSharePng` with a static image loader `loadStaticShareImagePng` and added `fs`/`path` imports to serve a bundled PNG when sharing. 
- Updated the `/share-result` flow to return structured error objects on media/upload/tweet failures instead of collapsing to `Server error`. 
- Broadened default OAuth scopes to include `media.write` in `utils/xOAuth.js`, added/updated tests in `tests/xOAuth.test.js`, and added a diagnostic prompt doc `docs/share-result-error-ux-prompt-2026-05-04.md`.

### Testing

- Ran the `tests/xOAuth.test.js` suite which includes the updated assertion for empty media id and new tests for 429 rate limit, 401 auth expiration without refresh token, and 403 insufficient scope, and all tests passed. 
- Verified updated share test now asserts `retryable: true` and `fallback: 'text_intent'` for media upload failures and it passed. 
- No automated test failures were observed after the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8b227a26c8326b1d252b8538a6129)