### PR TITLE
test: align referral/share tests with current shareId invite flow

### DIFF
--- a/tests/referral.test.js
+++ b/tests/referral.test.js
@@ -51,7 +51,7 @@ test('buildReferralUrl uses FRONTEND_BASE_URL env', () => {
   const orig = process.env.FRONTEND_BASE_URL;
   process.env.FRONTEND_BASE_URL = 'https://ursasstube.fun';
   const url = buildReferralUrl('ABCD1234');
-  assert.equal(url, 'https://ursasstube.fun/?ref=ABCD1234');
+  assert.equal(url, 'https://ursasstube.fun/?ref_hint=ABCD1234');
   process.env.FRONTEND_BASE_URL = orig || '';
 });
 

--- a/tests/share.test.js
+++ b/tests/share.test.js
@@ -99,7 +99,7 @@ test('POST /api/share/start - wallet-linked share contains preview URL and inten
     assert.equal(r.status, 200, JSON.stringify(r.body));
     assert.equal(r.body.imageUrl, `${baseUrl}/api/leaderboard/share/image/${wallet}.png`);
     assert.equal(r.body.postImageUrl, `${baseUrl}/api/leaderboard/share/image/${wallet}.png`);
-    assert.equal(r.body.previewUrl, `${baseUrl}/s/PLAY1234`);
+    assert.equal(r.body.previewUrl, `${baseUrl}/share/${r.body.shareId}`);
     assert.equal(r.body.shareResultApiUrl, '/api/x/share-result');
     assert.match(r.body.intentUrl, /twitter\.com\/intent\/tweet\?/);
     assert.doesNotMatch(r.body.intentUrl, /[?&]url=/);
@@ -195,7 +195,7 @@ test('POST /api/share/start uses intent flow with canonical /s/:refCode URL when
     assert.equal(r.body.preferredShareFlow, 'intent');
     assert.ok(r.body.intentUrl);
     const decoded = decodeURIComponent(String(r.body.intentUrl).split('text=')[1] || '');
-    assert.match(decoded, /\/s\/PLAY1234/);
+    assert.match(decoded, /\/share\/[0-9a-f-]{36}/);
     assert.doesNotMatch(decoded, /^I scored[\s\S]*https:\/\/ursasstube\.fun\/\?ref=/);
   } finally {
     delete process.env.FRONTEND_BASE_URL;
@@ -204,7 +204,7 @@ test('POST /api/share/start uses intent flow with canonical /s/:refCode URL when
   }
 });
 
-test('POST /api/share/start - already_shared_today returns no shareId', async () => {
+test('POST /api/share/start - creates new shareId even after share today', async () => {
   const { server, baseUrl } = await startServer();
   try {
     const today = new Date().toISOString().slice(0, 10);
@@ -215,7 +215,7 @@ test('POST /api/share/start - already_shared_today returns no shareId', async ()
 
     const r = await post(baseUrl, '/api/share/start', {}, { 'X-Primary-Id': 'tg_player2' });
     assert.equal(r.status, 200);
-    assert.equal(r.body.shareId, null);
+    assert.match(String(r.body.shareId || ''), /^[0-9a-f-]{36}$/i);
     assert.equal(r.body.reason, 'already_shared_today');
   } finally {
     server.close();


### PR DESCRIPTION
### Motivation
- Tests expected legacy invite URLs and referral params while backend now issues per-share `shareId` preview links and uses `?ref_hint=` for referrals.

### Description
- Updated `tests/referral.test.js` to expect `?ref_hint=` in `buildReferralUrl` output instead of `?ref=`.
- Updated `tests/share.test.js` to validate `previewUrl` as `/share/{shareId}` for wallet-linked shares instead of `/s/{refCode}`.
- Relaxed the X intent text assertions to accept `/share/{uuid}` links instead of `/s/{refCode}`.
- Adjusted same-day share test to assert a new `shareId` is returned while `reason` remains `already_shared_today`.

### Testing
- Ran targeted test command `node --test tests/share.test.js tests/referral.test.js tests/referralRewards.test.js` and the suite passed (all tests green).
- Earlier `npm test -- --runInBand ... tests/api.integration.test.js` ran the full integration suite and surfaced unrelated failures outside the scope of these test changes; those integration failures were not caused by the modified tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb40a96a24832680bef566d38462bf)