### PR TITLE
Generate SVG score overlay and composite for 1600x800 banner

### DIFF
--- a/src/generateScoreBanner.ts
+++ b/src/generateScoreBanner.ts
@@ -2,7 +2,16 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import sharp from 'sharp';
 
-const MAX_SCORE = 999999;
+const MAX_SCORE = 999_999;
+
+// Text box calibrated for img/score_result1600х800.png template.
+const SCORE_BOX = {
+  x: 108,
+  y: 242,
+  width: 812,
+  height: 164,
+  rotationDeg: -12
+};
 
 function escapeXml(value: string): string {
   return value
@@ -15,50 +24,93 @@ function escapeXml(value: string): string {
 
 function normalizeScore(score: number | string): string {
   const raw = String(score).trim();
-  if (!/^\d+$/.test(raw)) throw new Error('score must be an integer between 0 and 999999');
+  if (!/^\d{1,6}$/.test(raw)) {
+    throw new Error('score must be an integer from 0 to 999999');
+  }
+
   const parsed = Number(raw);
-  if (!Number.isInteger(parsed) || parsed < 0 || parsed > MAX_SCORE) throw new Error('score must be an integer between 0 and 999999');
+  if (!Number.isInteger(parsed) || parsed < 0 || parsed > MAX_SCORE) {
+    throw new Error('score must be an integer from 0 to 999999');
+  }
+
   return String(parsed);
 }
 
-export function buildScoreSvg(score: number | string, options: { width: number; height: number } = { width: 1024, height: 1024 }): string {
-  const scoreText = normalizeScore(score);
-  const { width, height } = options;
-  const block = {
-    x: width * (70 / 1024),
-    y: height * (310 / 1024),
-    width: width * (520 / 1024),
-    height: height * (210 / 1024),
-    radius: Math.min(width, height) * (24 / 1024)
+function getFontSize(length: number): number {
+  if (length <= 2) return 168;
+  if (length <= 4) return 156;
+  if (length === 5) return 146;
+  return 134;
+}
+
+function buildScoreSvg(score: string, width: number, height: number): string {
+  const scaleX = width / 1600;
+  const scaleY = height / 800;
+
+  const box = {
+    x: SCORE_BOX.x * scaleX,
+    y: SCORE_BOX.y * scaleY,
+    width: SCORE_BOX.width * scaleX,
+    height: SCORE_BOX.height * scaleY,
+    rotationDeg: SCORE_BOX.rotationDeg
   };
-  const scale = Math.min(width, height) / 1024;
-  const fontSize = scoreText.length <= 4 ? 128 * scale : 108 * scale;
-  const textX = block.x + block.width / 2;
-  const textY = block.y + block.height / 2;
+
+  const textX = box.x + box.width / 2;
+  const textY = box.y + box.height / 2;
+  const fontSize = getFontSize(score.length) * Math.min(scaleX, scaleY);
 
   return `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}">
   <defs>
-    <linearGradient id="scoreTextGradient" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" stop-color="#a855f7"/><stop offset="100%" stop-color="#22d3ee"/></linearGradient>
-    <linearGradient id="boxFill" x1="0%" y1="0%" x2="100%" y2="100%"><stop offset="0%" stop-color="#111327"/><stop offset="100%" stop-color="#1f233d"/></linearGradient>
-    <filter id="boxGlow" x="-40%" y="-60%" width="180%" height="220%"><feDropShadow dx="0" dy="8" stdDeviation="10" flood-color="#05060f" flood-opacity="0.8"/><feDropShadow dx="0" dy="0" stdDeviation="7" flood-color="#22d3ee" flood-opacity="0.5"/></filter>
-    <filter id="textGlow" x="-40%" y="-40%" width="180%" height="180%"><feDropShadow dx="0" dy="0" stdDeviation="3.5" flood-color="#22d3ee" flood-opacity="0.7"/></filter>
+    <linearGradient id="scoreGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#a855f7"/>
+      <stop offset="100%" stop-color="#22d3ee"/>
+    </linearGradient>
+    <filter id="scoreGlow" x="-40%" y="-40%" width="180%" height="180%">
+      <feDropShadow dx="0" dy="0" stdDeviation="3" flood-color="#22d3ee" flood-opacity="0.75"/>
+      <feDropShadow dx="0" dy="2" stdDeviation="1.5" flood-color="#000" flood-opacity="0.55"/>
+    </filter>
   </defs>
-  <g transform="rotate(-12 ${textX} ${textY})">
-    <rect x="${block.x}" y="${block.y}" width="${block.width}" height="${block.height}" rx="${block.radius}" fill="url(#boxFill)" stroke="#67e8f9" stroke-width="5" filter="url(#boxGlow)"/>
-    <text x="${textX}" y="${textY}" fill="url(#scoreTextGradient)" font-family="Anton, Impact, Arial Black, sans-serif" font-size="${fontSize}" font-weight="900" text-anchor="middle" dominant-baseline="middle" letter-spacing="2" lengthAdjust="spacingAndGlyphs" textLength="${block.width * 0.84}" filter="url(#textGlow)">${escapeXml(scoreText)}</text>
+  <g transform="rotate(${box.rotationDeg} ${textX} ${textY})">
+    <text
+      x="${textX}"
+      y="${textY}"
+      fill="url(#scoreGradient)"
+      font-family="Anton, Impact, Arial Black, sans-serif"
+      font-size="${fontSize}"
+      font-weight="900"
+      text-anchor="middle"
+      dominant-baseline="middle"
+      letter-spacing="2"
+      lengthAdjust="spacingAndGlyphs"
+      textLength="${box.width * 0.9}"
+      filter="url(#scoreGlow)"
+    >${escapeXml(score)}</text>
   </g>
 </svg>`;
 }
 
-export async function generateScoreBanner(params: { baseImagePath: string; score: number | string; outputPath?: string; }): Promise<Buffer> {
+export async function generateScoreBanner(params: {
+  baseImagePath: string;
+  score: number | string;
+  outputPath?: string;
+}): Promise<Buffer> {
   const scoreText = normalizeScore(params.score);
   const metadata = await sharp(params.baseImagePath).metadata();
-  const svg = buildScoreSvg(scoreText, { width: metadata.width ?? 1024, height: metadata.height ?? 1024 });
-  const svgBuffer = Buffer.from(svg);
-  const resultBuffer = await sharp(params.baseImagePath).composite([{ input: svgBuffer, left: 0, top: 0 }]).png().toBuffer();
+  const width = metadata.width ?? 1600;
+  const height = metadata.height ?? 800;
+
+  const svg = buildScoreSvg(scoreText, width, height);
+  const overlayBuffer = Buffer.from(svg);
+
+  const resultBuffer = await sharp(params.baseImagePath)
+    .composite([{ input: overlayBuffer, left: 0, top: 0 }])
+    .png()
+    .toBuffer();
+
   if (params.outputPath) {
     await fs.mkdir(path.dirname(params.outputPath), { recursive: true });
     await fs.writeFile(params.outputPath, resultBuffer);
   }
+
   return resultBuffer;
 }


### PR DESCRIPTION
### Motivation
- Overlay a numeric score onto the new 1600x800 PNG template and produce a final PNG `Buffer` with the score precisely placed inside a predefined textbox.

### Description
- Implemented `generateScoreBanner` in `src/generateScoreBanner.ts` which builds an SVG score overlay and composites it over the base PNG using `sharp`, returning a `Buffer` and optionally writing to `outputPath`.
- Calibrated a `SCORE_BOX` for `img/score_result1600х800.png` and applied scaling so the same logic works for non-default dimensions (`1600x800` is the reference size).
- Added `normalizeScore` validation to enforce 1–6 digit integer scores (`0..999999`) and implemented adaptive font sizing via `getFontSize` to keep the text within the box.
- Tuned SVG styling (gradient, glow, rotation, `textLength`, center alignment) to ensure consistent rendering of 1–6 digit scores.

### Testing
- Ran `npm run check:syntax` and the syntax check completed successfully.
- No additional automated tests were added in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb56c75cf483268ebf409d18e03195)