### PR TITLE
Remove non-PostHog analytics endpoints and metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,8 +103,6 @@ Versioned aliases are also available under `/api/v1/*` (backward-compatible with
 | `POST` | `/api/account/link/request-code` | Generate a 6-character code to link Telegram to a wallet |
 | `GET` | `/api/account/info` | Get account info |
 | `GET` | `/api/game/config?mode=unauth` | Get runtime config for non-persistent game modes |
-| `POST` | `/api/analytics/events` | Ingest analytics events batch (`{ sentAt, events: [...] }`) |
-| `POST` | `/api/analytics/event` | Ingest a single analytics event (`{ sentAt, event: {...} }`) |
 
 
 ## Frontend Integration Note
@@ -113,7 +111,6 @@ Versioned aliases are also available under `/api/v1/*` (backward-compatible with
 - `https://ursasstube.fun`, `https://www.ursasstube.fun`, and `https://play.ursasstube.fun` are allowed by CORS.
 - `https://api.ursasstube.fun` is also whitelisted (useful for same-site tooling / dashboards that call the API from that origin).
 - API requests must target the deployed backend host (for example, Railway), not the frontend host itself.
-- If you send `POST https://bageus-github-io.vercel.app/api/analytics/events`, Vercel frontend hosting may return `404 Not Found` because that route is not served there.
 
 ## Auth Headers
 

--- a/app.js
+++ b/app.js
@@ -9,7 +9,6 @@ const storeRoutes = require('./routes/store');
 const accountRoutes = require('./routes/account');
 const gameRoutes = require('./routes/game');
 const donationsRoutes = require('./routes/donations');
-const analyticsRoutes = require('./routes/analytics');
 const referralRoutes = require('./routes/referral');
 const shareRoutes = require('./routes/share');
 const xRoutes = require('./routes/x');
@@ -17,7 +16,7 @@ const logger = require('./utils/logger');
 const Player = require('./models/Player');
 const ShareEvent = require('./models/ShareEvent');
 const { sanitizeReferralCode, buildReferralLandingUrl, isSocialPreviewCrawler } = require('./utils/referral');
-const { metricsMiddleware, markAliasRouteUsage, renderMetricsText } = require('./middleware/requestMetrics');
+const { metricsMiddleware, renderMetricsText } = require('./middleware/requestMetrics');
 const { renderScoreSharePng } = require('./utils/shareCard');
 
 
@@ -43,8 +42,6 @@ function getRouteRegistry() {
     { path: '/account', router: accountRoutes },
     { path: '/game', router: gameRoutes },
     { path: '', router: donationsRoutes },
-    { path: '/analytics', router: analyticsRoutes },
-    { path: '/telemetry', router: analyticsRoutes },
     { path: '/referral', router: referralRoutes },
     { path: '/share', router: shareRoutes },
     { path: '/x', router: xRoutes }
@@ -133,18 +130,6 @@ function createApp() {
 
     if ((process.env.NODE_ENV || '').toLowerCase() === 'production') {
       res.setHeader('Strict-Transport-Security', 'max-age=31536000; includeSubDomains');
-    }
-
-    next();
-  });
-
-  app.use((req, res, next) => {
-    if (req.path.startsWith('/api/telemetry') || req.path.startsWith('/api/v1/telemetry')) {
-      markAliasRouteUsage('telemetry');
-    }
-
-    if (req.path.startsWith('/api/analytics') || req.path.startsWith('/api/v1/analytics')) {
-      markAliasRouteUsage('analytics');
     }
 
     next();

--- a/middleware/requestMetrics.js
+++ b/middleware/requestMetrics.js
@@ -2,16 +2,6 @@ const state = {
   requestCount: 0,
   byRoute: {},
   suspiciousEvents: {},
-  analyticsIngest: {
-    accepted: 0,
-    invalid: 0,
-    stored: 0,
-    failed: 0
-  },
-  aliasRouteUsage: {
-    analytics: 0,
-    telemetry: 0
-  },
   durationBuckets: {
     le_50: 0,
     le_100: 0,
@@ -81,20 +71,6 @@ function markSuspicious(type = 'generic') {
 }
 
 
-function markAliasRouteUsage(aliasType) {
-  if (!aliasType || !Object.prototype.hasOwnProperty.call(state.aliasRouteUsage, aliasType)) {
-    return;
-  }
-  state.aliasRouteUsage[aliasType] += 1;
-}
-
-function markAnalyticsIngest({ accepted = 0, invalid = 0, stored = 0, failed = 0 } = {}) {
-  state.analyticsIngest.accepted += Math.max(0, Number(accepted) || 0);
-  state.analyticsIngest.invalid += Math.max(0, Number(invalid) || 0);
-  state.analyticsIngest.stored += Math.max(0, Number(stored) || 0);
-  state.analyticsIngest.failed += Math.max(0, Number(failed) || 0);
-}
-
 async function renderMetricsText() {
   const lines = [];
   lines.push('# TYPE app_requests_total counter');
@@ -116,16 +92,6 @@ async function renderMetricsText() {
     lines.push(`app_request_duration_buckets_total{bucket="${bucket}"} ${count}`);
   }
 
-  lines.push('# TYPE app_analytics_ingest_total counter');
-  for (const [type, count] of Object.entries(state.analyticsIngest)) {
-    lines.push(`app_analytics_ingest_total{status="${type}"} ${count}`);
-  }
-
-  lines.push('# TYPE app_alias_route_usage_total counter');
-  for (const [aliasType, count] of Object.entries(state.aliasRouteUsage)) {
-    lines.push(`app_alias_route_usage_total{alias="${aliasType}"} ${count}`);
-  }
-
   lines.push('# TYPE app_suspicious_events_total counter');
   for (const [type, count] of Object.entries(state.suspiciousEvents)) {
     const safeType = type.replace(/"/g, '\\"');
@@ -138,7 +104,5 @@ async function renderMetricsText() {
 module.exports = {
   metricsMiddleware,
   markSuspicious,
-  markAnalyticsIngest,
-  markAliasRouteUsage,
   renderMetricsText
 };


### PR DESCRIPTION
### Motivation
- Убрать с бэкенда устаревшую/не-PostHog аналитику и соответствующие метрики и alias-маршруты, чтобы backend не предоставлял независимый ingest/summary surface. 

### Description
- Удалена регистрация маршрутов аналитики из `getRouteRegistry()` в `app.js` (убраны `'/analytics'` и `'/telemetry'`).
- Удалён код учёта alias-usage и ingest-метрик из `middleware/requestMetrics.js` вместе с полями `analyticsIngest` и `aliasRouteUsage`, а также экспортами `markAnalyticsIngest` и `markAliasRouteUsage` и соответствующими строками в `renderMetricsText()`.
- Обновлён `README.md`, удалены строки документации по `POST /api/analytics/events` и `POST /api/analytics/event` чтобы таблица API соответствовала реальному состоянию кода.

### Testing
- Запущена автоматическая проверка синтаксиса с помощью `npm run check:syntax`, которая завершилась успешно (`Syntax check passed` for project files).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb5b819cec832694731e356dab5a48)