### PR TITLE
Add /referrals alias and harden self-referral protection

### DIFF
--- a/app.js
+++ b/app.js
@@ -44,6 +44,7 @@ function getRouteRegistry() {
     { path: '/game', router: gameRoutes },
     { path: '', router: donationsRoutes },
     { path: '/referral', router: referralRoutes },
+    { path: '/referrals', router: referralRoutes },
     { path: '/share', router: shareRoutes },
     { path: '/x', router: xRoutes }
   ];

--- a/routes/referral.js
+++ b/routes/referral.js
@@ -110,6 +110,11 @@ router.post('/apply', writeLimiter, async (req, res) => {
 
     const referrer = await Player.findOne({ referralCode });
     if (!referrer) return res.status(404).json({ error: 'referral_code_not_found' });
+    const normalizedReferrerWallet = String(referrer.wallet || '').trim().toLowerCase();
+    const normalizedCurrentPrimaryId = String(currentPrimaryId || '').trim().toLowerCase();
+    if (normalizedReferrerWallet && normalizedReferrerWallet === normalizedCurrentPrimaryId) {
+      return res.status(400).json({ error: 'cannot_use_own_referral_code' });
+    }
 
     try {
       await ReferralReward.create({


### PR DESCRIPTION
### Motivation
- Frontend builds may call `/api/referrals/apply` while the backend previously only mounted referral routes under `/api/referral`, causing not-found errors. 
- Strengthen self-referral protection by ensuring users cannot apply a referral code that resolves to their own account even when casing or code state differs.

### Description
- Mounted `referralRoutes` under both `/referral` and `/referrals` in `getRouteRegistry()` (updated `app.js`) to provide a backwards-compatible alias. 
- Preserved the existing own-code guard (`currentPlayer.referralCode === referralCode`) in `POST /apply` (unchanged behavior). 
- Added a second guard after resolving `referrer` that normalizes `referrer.wallet` and `currentPrimaryId` via `String(...).trim().toLowerCase()` and returns `400 { error: 'cannot_use_own_referral_code' }` when they match (updated `routes/referral.js`). 
- Ensured the new check runs before creating `ReferralReward` and before awarding gold, and did not change reward amounts or other referral logic. 

### Testing
- Ran the test suite with `npm test --silent`; the changes compile and the referral flow behaves as expected. 
- The repository test run exposed pre-existing unrelated failures in analytics/share endpoints, while referral-related functionality and the modified routes were exercised and remain isolated from those failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdbd35d3b08326aa48192bebfe2d23)