### PR TITLE
Fix referral apply rewards persistence and repair idempotency

### DIFF
--- a/models/CoinTransaction.js
+++ b/models/CoinTransaction.js
@@ -5,12 +5,14 @@ const COIN_TRANSACTION_TYPES = ['share', 'ride', 'buy', 'referral', 'refer', 'ta
 const coinTransactionSchema = new mongoose.Schema({
   primaryId: { type: String, required: true, index: true, trim: true, lowercase: true },
   type: { type: String, required: true, enum: COIN_TRANSACTION_TYPES },
+  contextKey: { type: String, default: null, index: true },
   gold: { type: Number, required: true, min: 0, default: 0 },
   silver: { type: Number, required: true, min: 0, default: 0 },
   createdAt: { type: Date, default: Date.now, index: true }
 }, { versionKey: false });
 
 coinTransactionSchema.index({ primaryId: 1, createdAt: -1 });
+coinTransactionSchema.index({ contextKey: 1 }, { unique: true, sparse: true });
 
 coinTransactionSchema.pre('validate', function(next) {
   if ((this.gold || 0) <= 0 && (this.silver || 0) <= 0) {

--- a/models/ReferralReward.js
+++ b/models/ReferralReward.js
@@ -6,6 +6,11 @@ const referralRewardSchema = new mongoose.Schema({
   referralCode: { type: String, required: true, index: true },
   referredGoldAwarded: { type: Number, default: 100 },
   referrerGoldAwarded: { type: Number, default: 50 },
+  referredBalanceCreditedAt: { type: Date, default: null },
+  referrerBalanceCreditedAt: { type: Date, default: null },
+  referredHistoryRecordedAt: { type: Date, default: null },
+  referrerHistoryRecordedAt: { type: Date, default: null },
+  appliedAt: { type: Date, default: null },
   createdAt: { type: Date, default: Date.now }
 });
 

--- a/routes/referral.js
+++ b/routes/referral.js
@@ -96,7 +96,7 @@ router.post('/apply', writeLimiter, async (req, res) => {
     const link = await resolveAuth(req);
     if (!link) return res.status(401).json({ error: 'authentication_required' });
 
-    const currentPrimaryId = link.primaryId;
+    const currentPrimaryId = String(link.primaryId || '').trim().toLowerCase();
     const referralCode = String(req.body?.referralCode || '').trim().toUpperCase();
     if (!/^[A-Z0-9_-]{1,64}$/.test(referralCode)) {
       return res.status(400).json({ error: 'invalid_referral_code' });
@@ -110,31 +110,73 @@ router.post('/apply', writeLimiter, async (req, res) => {
 
     const referrer = await Player.findOne({ referralCode });
     if (!referrer) return res.status(404).json({ error: 'referral_code_not_found' });
-    const normalizedReferrerWallet = String(referrer.wallet || '').trim().toLowerCase();
-    const normalizedCurrentPrimaryId = String(currentPrimaryId || '').trim().toLowerCase();
-    if (normalizedReferrerWallet && normalizedReferrerWallet === normalizedCurrentPrimaryId) {
+    const referrerPrimaryId = String(referrer.wallet || '').trim().toLowerCase();
+
+    if (referrerPrimaryId && referrerPrimaryId === currentPrimaryId) {
       return res.status(400).json({ error: 'cannot_use_own_referral_code' });
     }
 
-    try {
-      await ReferralReward.create({
+    let reward = await ReferralReward.findOne({ referredPrimaryId: currentPrimaryId });
+    let repairedPartial = false;
+    if (!reward) {
+      reward = await ReferralReward.create({
         referredPrimaryId: currentPrimaryId,
-        referrerPrimaryId: referrer.wallet,
+        referrerPrimaryId,
         referralCode,
         referredGoldAwarded: 100,
         referrerGoldAwarded: 50
       });
-    } catch (e) {
-      if (e?.code === 11000) return res.status(409).json({ error: 'referral_already_applied', alreadyApplied: true });
-      throw e;
+    } else {
+      repairedPartial = true;
+      if (reward.referralCode !== referralCode) {
+        return res.status(409).json({ error: 'referral_already_applied', alreadyApplied: true });
+      }
+    }
+
+    const op = {
+      referredBalance: !!reward.referredBalanceCreditedAt,
+      referrerBalance: !!reward.referrerBalanceCreditedAt,
+      referredHistory: !!reward.referredHistoryRecordedAt,
+      referrerHistory: !!reward.referrerHistoryRecordedAt,
+      referredBy: false
+    };
+
+    if (!reward.referredBalanceCreditedAt) {
+      const bal = await addGold(currentPrimaryId, 100, 'referral_apply_referred');
+      if (bal === null) throw new Error('failed_referred_balance_credit');
+      reward.referredBalanceCreditedAt = new Date();
+      op.referredBalance = true;
+    }
+
+    if (!reward.referrerBalanceCreditedAt) {
+      const bal = await addGold(referrerPrimaryId, 50, 'referral_apply_referrer');
+      if (bal === null) throw new Error('failed_referrer_balance_credit');
+      reward.referrerBalanceCreditedAt = new Date();
+      op.referrerBalance = true;
+    }
+
+    if (!reward.referredHistoryRecordedAt) {
+      const entry = await recordCoinReward(currentPrimaryId, 'referral', { gold: 100 }, { contextKey: `referral:${reward._id}:referred` });
+      if (!entry) throw new Error('failed_referred_history');
+      reward.referredHistoryRecordedAt = new Date();
+      op.referredHistory = true;
+    }
+
+    if (!reward.referrerHistoryRecordedAt) {
+      const entry = await recordCoinReward(referrerPrimaryId, 'refer', { gold: 50 }, { contextKey: `referral:${reward._id}:referrer` });
+      if (!entry) throw new Error('failed_referrer_history');
+      reward.referrerHistoryRecordedAt = new Date();
+      op.referrerHistory = true;
     }
 
     await Player.updateOne({ wallet: currentPrimaryId }, { $set: { referredBy: referralCode } });
-    await addGold(currentPrimaryId, 100, 'referral_apply_referred');
-    await addGold(referrer.wallet, 50, 'referral_apply_referrer');
-    await recordCoinReward(currentPrimaryId, 'referral_apply', { gold: 100 });
-    await recordCoinReward(referrer.wallet, 'refer_apply', { gold: 50 });
+    op.referredBy = true;
+
+    reward.appliedAt = new Date();
+    await reward.save();
+
     const refreshed = await Player.findOne({ wallet: currentPrimaryId });
+    logger.info({ currentPrimaryId, referrerPrimaryId, referralCode, repairedPartial, ...op }, 'Referral apply completed');
 
     return res.json({
       applied: true,

--- a/tests/referral.test.js
+++ b/tests/referral.test.js
@@ -134,7 +134,12 @@ test('POST /api/referral/track - self-referral blocked (400)', async () => {
       save: async function() {}
     };
     Player.findOne = async () => currentPlayer;
-    Player.findOneAndUpdate = async () => null;
+    Player.findOneAndUpdate = async (q, update) => {
+      const p = players[q.wallet];
+      if (!p) return null;
+      p.gold = (p.gold || 0) + (update.$inc?.gold || 0);
+      return p;
+    };
 
     const r = await post(baseUrl, '/api/referral/track', { ref: 'SELFREF1' }, {
       'X-Primary-Id': 'tg_222'
@@ -165,7 +170,7 @@ test('POST /api/referral/track - unknown ref returns 404', async () => {
       if (q.referralCode) return null; // not found
       return null;
     };
-    Player.findOneAndUpdate = async () => null;
+    Player.findOneAndUpdate = async (q, update) => { const p = players[q.wallet]; if (!p) return null; p.gold = (p.gold || 0) + (update.$inc?.gold || 0); return p; };
 
     const r = await post(baseUrl, '/api/referral/track', { ref: 'UNKNOWN1' }, {
       'X-Primary-Id': 'tg_333'
@@ -200,4 +205,73 @@ test('POST /api/referral/track - second time idempotent (returns already:true)',
   } finally {
     server.close();
   }
+});
+
+const ReferralReward = require('../models/ReferralReward');
+const CoinTransaction = require('../models/CoinTransaction');
+
+test('POST /api/referral/apply - awards both users and writes history', async () => {
+  const { server, baseUrl } = await startServer();
+  try {
+    const players = {
+      tg_apply1: { wallet: 'tg_apply1', referralCode: 'ME111111', gold: 0 },
+      tg_referrer: { wallet: 'tg_referrer', referralCode: 'REF11111', gold: 0 }
+    };
+    const rewards = [];
+    const history = [];
+
+    AccountLink.findOne = async (q) => (q.primaryId === 'tg_apply1' ? { primaryId: 'tg_apply1' } : null);
+    Player.findOne = async (q) => q.wallet ? players[q.wallet] || null : Object.values(players).find(p => p.referralCode === q.referralCode) || null;
+    Player.findOneAndUpdate = async (q, update) => {
+      const p = players[q.wallet];
+      if (!p) return null;
+      p.gold = (p.gold || 0) + (update.$inc?.gold || 0);
+      return p;
+    };
+    Player.updateOne = async (q, update) => { if (players[q.wallet]) players[q.wallet].referredBy = update.$set.referredBy; return { acknowledged: true }; };
+    ReferralReward.findOne = async (q) => rewards.find(r => r.referredPrimaryId === q.referredPrimaryId) || null;
+    ReferralReward.create = async (doc) => { const r = { _id: 'rw1', ...doc, save: async function(){} }; rewards.push(r); return r; };
+    CoinTransaction.findOne = async (q) => history.find(h => h.contextKey === q.contextKey) || null;
+    CoinTransaction.create = async (doc) => { history.push(doc); return doc; };
+
+    const r = await post(baseUrl, '/api/referral/apply', { referralCode: 'REF11111' }, { 'X-Primary-Id': 'tg_apply1' });
+    assert.equal(r.status, 200, JSON.stringify(r.body));
+    assert.equal(players.tg_apply1.gold, 100);
+    assert.equal(players.tg_referrer.gold, 50);
+    assert.equal(history.length, 2);
+  } finally { server.close(); }
+});
+
+test('POST /api/referral/apply - retry after partial reward repairs without double-award', async () => {
+  const { server, baseUrl } = await startServer();
+  try {
+    const players = {
+      tg_apply2: { wallet: 'tg_apply2', referralCode: 'ME222222', gold: 0 },
+      tg_referrer2: { wallet: 'tg_referrer2', referralCode: 'REF22222', gold: 0 }
+    };
+    const reward = { _id: 'rw2', referredPrimaryId: 'tg_apply2', referrerPrimaryId: 'tg_referrer2', referralCode: 'REF22222', referredBalanceCreditedAt: null, referrerBalanceCreditedAt: null, referredHistoryRecordedAt: null, referrerHistoryRecordedAt: null, save: async function(){} };
+    const history = [];
+
+    AccountLink.findOne = async (q) => (q.primaryId === 'tg_apply2' ? { primaryId: 'tg_apply2' } : null);
+    Player.findOne = async (q) => q.wallet ? players[q.wallet] || null : Object.values(players).find(p => p.referralCode === q.referralCode) || null;
+    Player.findOneAndUpdate = async (q, update) => {
+      const p = players[q.wallet];
+      if (!p) return null;
+      p.gold = (p.gold || 0) + (update.$inc?.gold || 0);
+      return p;
+    };
+    Player.updateOne = async () => ({ acknowledged: true });
+    ReferralReward.findOne = async () => reward;
+    ReferralReward.create = async () => { throw new Error('should not create'); };
+    CoinTransaction.findOne = async (q) => history.find(h => h.contextKey === q.contextKey) || null;
+    CoinTransaction.create = async (doc) => { history.push(doc); return doc; };
+
+    const r1 = await post(baseUrl, '/api/referral/apply', { referralCode: 'REF22222' }, { 'X-Primary-Id': 'tg_apply2' });
+    const r2 = await post(baseUrl, '/api/referral/apply', { referralCode: 'REF22222' }, { 'X-Primary-Id': 'tg_apply2' });
+    assert.equal(r1.status, 200);
+    assert.equal(r2.status, 200);
+    assert.equal(players.tg_apply2.gold, 100);
+    assert.equal(players.tg_referrer2.gold, 50);
+    assert.equal(history.length, 2);
+  } finally { server.close(); }
 });

--- a/utils/coinHistory.js
+++ b/utils/coinHistory.js
@@ -21,9 +21,15 @@ async function recordCoinReward(primaryId, type, amounts = {}, opts = {}) {
   }
 
   try {
+    if (opts.contextKey) {
+      const existing = await CoinTransaction.findOne({ contextKey: opts.contextKey });
+      if (existing) return existing;
+    }
+
     const entry = await CoinTransaction.create({
       primaryId: normalizedPrimaryId,
       type,
+      contextKey: opts.contextKey || null,
       gold,
       silver,
       createdAt: opts.createdAt || new Date()


### PR DESCRIPTION
### Motivation
- The `/api/referral/apply` flow returned success before balances and coin history were actually persisted, causing referred/referrer gold and history to be missing.  
- Partially-applied `ReferralReward` rows could block future repairs and prevent users from receiving owed credits.  
- The coin history write used incompatible types and did not protect against duplicate rows during retries.

### Description
- Change `routes/referral.js` `POST /apply` to normalize primary IDs, fetch-or-create `ReferralReward`, and only return success after all balance and history writes complete; added detailed per-step logging.  
- Extend `models/ReferralReward` with progress markers: `referredBalanceCreditedAt`, `referrerBalanceCreditedAt`, `referredHistoryRecordedAt`, `referrerHistoryRecordedAt`, and `appliedAt` to enable safe repair of partial applications.  
- Add `contextKey` to `models/CoinTransaction` with a unique sparse index and update `utils/coinHistory.js` `recordCoinReward()` to accept `opts.contextKey` and return existing transactions when present to ensure idempotent history writes.  
- Use allowed transaction `type` values (`referral` / `refer`) for referral history entries and update logic to avoid duplicate balance awards on retries.  
- Add/adjust tests in `tests/referral.test.js` to assert both balances are credited, both history rows exist, and retries repair partial state without double-awarding.

### Testing
- Ran targeted referral tests with `node --test tests/referral.test.js`, which passed (referral apply and retry scenarios succeed).  
- Executed a broader subset (`npm test -- tests/referral.test.js tests/coinHistory.test.js tests/account-coin-history.test.js`) during the rollout where referral-focused behavior passed but unrelated pre-existing tests in the wider suite surfaced separate failures.  
- New tests verify: referred user +100 gold, referrer +50 gold, both coin-history rows recorded, and retry does not double-award (all referral tests passed in the targeted run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdc7d95b9c8326be666015ab62290d)