### PR TITLE
Add safe dry-run script to repair partial referral rewards

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,26 @@ MONGO_URI='mongodb://...' node scripts/migrations/2026-04-26-referral-and-share.
 
 The script is idempotent — safe to run multiple times.
 
+
+### Referral rewards repair script
+
+If some `ReferralReward` rows were marked/applied but one or more credits/history rows were not written, run:
+
+```bash
+MONGO_URL='mongodb://...' node scripts/repair-referral-rewards.js
+```
+
+The script is **dry-run by default** and only prints what would be repaired.
+
+To apply fixes:
+
+```bash
+MONGO_URL='mongodb://...' node scripts/repair-referral-rewards.js --apply
+```
+
+The repair is idempotent and only fills missing pieces (balance/history) without deleting referral records or changing reward amounts.
+
+
 ---
 
 - Use `GET /api/game/config?mode=unauth` to fetch the runtime preset for browser users who choose not to authenticate.

--- a/scripts/repair-referral-rewards.js
+++ b/scripts/repair-referral-rewards.js
@@ -1,0 +1,165 @@
+#!/usr/bin/env node
+'use strict';
+
+/**
+ * Repair/backfill script for referral rewards.
+ *
+ * By default this script is DRY-RUN and only prints what would be fixed.
+ * Use --apply to persist changes.
+ *
+ * Usage:
+ *   MONGO_URL='mongodb://...' node scripts/repair-referral-rewards.js
+ *   MONGO_URL='mongodb://...' node scripts/repair-referral-rewards.js --apply
+ */
+
+require('dotenv').config();
+const mongoose = require('mongoose');
+
+const ReferralReward = require('../models/ReferralReward');
+const CoinTransaction = require('../models/CoinTransaction');
+const { addGold } = require('../utils/goldWallet');
+const { recordCoinReward } = require('../utils/coinHistory');
+
+const MONGO_URL = process.env.MONGO_URL || process.env.MONGODB_URI;
+const APPLY = process.argv.includes('--apply');
+
+const EXPECTED_REFERRED_GOLD = 100;
+const EXPECTED_REFERRER_GOLD = 50;
+
+function normalizeId(value) {
+  return String(value || '').trim().toLowerCase();
+}
+
+async function hasHistory(primaryId, type, amount, contextKey) {
+  if (contextKey) {
+    const exact = await CoinTransaction.findOne({ contextKey });
+    if (exact) return true;
+  }
+
+  const fallback = await CoinTransaction.findOne({
+    primaryId,
+    type,
+    gold: amount,
+    silver: 0
+  });
+
+  return !!fallback;
+}
+
+async function run() {
+  if (!MONGO_URL) {
+    console.error('ERROR: MONGO_URL (or MONGODB_URI) is required');
+    process.exit(1);
+  }
+
+  await mongoose.connect(MONGO_URL);
+  console.log(`Connected to MongoDB. Mode: ${APPLY ? 'APPLY' : 'DRY-RUN'}`);
+
+  const stats = {
+    scanned: 0,
+    healthy: 0,
+    repairedBalances: 0,
+    repairedHistory: 0,
+    skippedInvalid: 0,
+    errors: 0
+  };
+
+  const rewards = await ReferralReward.find({}).sort({ createdAt: 1 });
+
+  for (const reward of rewards) {
+    stats.scanned += 1;
+
+    try {
+      const referredPrimaryId = normalizeId(reward.referredPrimaryId);
+      const referrerPrimaryId = normalizeId(reward.referrerPrimaryId);
+      const referralCode = String(reward.referralCode || '').trim().toUpperCase();
+
+      if (!referredPrimaryId || !referrerPrimaryId || !referralCode) {
+        stats.skippedInvalid += 1;
+        console.warn(`[SKIP INVALID] reward=${reward._id} referred=${referredPrimaryId} referrer=${referrerPrimaryId} code=${referralCode}`);
+        continue;
+      }
+
+      const referredBalanceCredited = !!reward.referredBalanceCreditedAt;
+      const referrerBalanceCredited = !!reward.referrerBalanceCreditedAt;
+      const referredCtx = `referral:${reward._id}:referred`;
+      const referrerCtx = `referral:${reward._id}:referrer`;
+
+      const referredHistoryExists = await hasHistory(referredPrimaryId, 'referral', EXPECTED_REFERRED_GOLD, referredCtx);
+      const referrerHistoryExists = await hasHistory(referrerPrimaryId, 'refer', EXPECTED_REFERRER_GOLD, referrerCtx);
+
+      let changedBalance = false;
+      let changedHistory = false;
+
+      if (!referredBalanceCredited) {
+        if (APPLY) {
+          const bal = await addGold(referredPrimaryId, EXPECTED_REFERRED_GOLD, 'referral_repair_referred');
+          if (bal === null) throw new Error('failed_repair_referred_balance');
+          reward.referredBalanceCreditedAt = new Date();
+        }
+        changedBalance = true;
+        console.log(`[REPAIR BALANCE] reward=${reward._id} target=referred +${EXPECTED_REFERRED_GOLD}`);
+      }
+
+      if (!referrerBalanceCredited) {
+        if (APPLY) {
+          const bal = await addGold(referrerPrimaryId, EXPECTED_REFERRER_GOLD, 'referral_repair_referrer');
+          if (bal === null) throw new Error('failed_repair_referrer_balance');
+          reward.referrerBalanceCreditedAt = new Date();
+        }
+        changedBalance = true;
+        console.log(`[REPAIR BALANCE] reward=${reward._id} target=referrer +${EXPECTED_REFERRER_GOLD}`);
+      }
+
+      if (!referredHistoryExists || !reward.referredHistoryRecordedAt) {
+        if (APPLY) {
+          const entry = await recordCoinReward(referredPrimaryId, 'referral', { gold: EXPECTED_REFERRED_GOLD }, { contextKey: referredCtx });
+          if (!entry) throw new Error('failed_repair_referred_history');
+          reward.referredHistoryRecordedAt = reward.referredHistoryRecordedAt || new Date();
+        }
+        changedHistory = true;
+        console.log(`[REPAIR HISTORY] reward=${reward._id} target=referred type=referral gold=${EXPECTED_REFERRED_GOLD}`);
+      }
+
+      if (!referrerHistoryExists || !reward.referrerHistoryRecordedAt) {
+        if (APPLY) {
+          const entry = await recordCoinReward(referrerPrimaryId, 'refer', { gold: EXPECTED_REFERRER_GOLD }, { contextKey: referrerCtx });
+          if (!entry) throw new Error('failed_repair_referrer_history');
+          reward.referrerHistoryRecordedAt = reward.referrerHistoryRecordedAt || new Date();
+        }
+        changedHistory = true;
+        console.log(`[REPAIR HISTORY] reward=${reward._id} target=referrer type=refer gold=${EXPECTED_REFERRER_GOLD}`);
+      }
+
+      if (changedBalance || changedHistory) {
+        if (APPLY) {
+          reward.appliedAt = reward.appliedAt || new Date();
+          await reward.save();
+        }
+        if (changedBalance) stats.repairedBalances += 1;
+        if (changedHistory) stats.repairedHistory += 1;
+      } else {
+        stats.healthy += 1;
+      }
+    } catch (error) {
+      stats.errors += 1;
+      console.error(`[ERROR] reward=${reward._id} message=${error.message}`);
+    }
+  }
+
+  console.log('\n=== Referral reward repair summary ===');
+  console.log(`Total scanned:       ${stats.scanned}`);
+  console.log(`Fully healthy:       ${stats.healthy}`);
+  console.log(`Repaired balances:   ${stats.repairedBalances}`);
+  console.log(`Repaired history:    ${stats.repairedHistory}`);
+  console.log(`Skipped invalid:     ${stats.skippedInvalid}`);
+  console.log(`Errors:              ${stats.errors}`);
+  console.log(`Mode:                ${APPLY ? 'APPLY (changes persisted)' : 'DRY-RUN (no changes persisted)'}`);
+
+  await mongoose.disconnect();
+}
+
+run().catch((err) => {
+  console.error('Fatal error:', err);
+  process.exit(1);
+});


### PR DESCRIPTION
### Motivation

- Some `ReferralReward` records were marked/applied but balances and/or coin history rows were not written, leaving users unpaid or missing history entries. 

### Description

- Add `scripts/repair-referral-rewards.js`, a dry-run-first reconciliation script that scans all `ReferralReward` documents and validates `referredPrimaryId`, `referrerPrimaryId`, and `referralCode` before any repair. 
- Repair only missing pieces: it credits missing balances via `addGold` when the corresponding `*BalanceCreditedAt` is absent and writes missing coin history via `recordCoinReward` using deterministic context keys (`referral:<rewardId>:referred|referrer`) with pre-checks to avoid duplicates. 
- Script is idempotent, does not change reward amounts or delete referral records, prints per-reward actions, and requires `--apply` to persist changes (dry-run by default). 
- Update `README.md` with usage instructions and examples for dry-run and apply modes. 

### Testing

- Performed a syntax check with `node --check scripts/repair-referral-rewards.js`, which succeeded. 
- The script logs a final summary including total scanned, healthy, repaired balances, repaired history, skipped invalid records, errors, and mode (DRY-RUN / APPLY).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdcb4a2af48326afb0adc428cfd27f)