### PR TITLE
Fix visible profile gold balance to include referral/share reward wallet

### DIFF
--- a/routes/account.js
+++ b/routes/account.js
@@ -359,13 +359,21 @@ router.get('/me/profile', readLimiter, requireAuth, async (req, res) => {
       }
     }
 
+    const totalGoldCoins = player.totalGoldCoins || 0;
+    const totalSilverCoins = player.totalSilverCoins || 0;
+    const rewardGold = player.gold || 0;
+    const visibleGold = totalGoldCoins + rewardGold;
+
     return res.json({
       primaryId,
       rank: rank || null,
       totalRankedPlayers: totalRankedPlayers || 0,
       bestScore: player.bestScore || 0,
-      gold: player.totalGoldCoins || 0,
-      silver: player.totalSilverCoins || 0,
+      gold: visibleGold,
+      silver: totalSilverCoins,
+      rewardGold,
+      totalGoldCoins,
+      totalSilverCoins,
       referralCode,
       referralUrl,
       referralCount,

--- a/tests/profile.test.js
+++ b/tests/profile.test.js
@@ -33,6 +33,8 @@ function makePlayer(overrides = {}) {
     referredBy: null,
     bestScore: 8350,
     gold: 1240,
+    totalGoldCoins: 350,
+    totalSilverCoins: 75,
     shareStreak: 3,
     lastShareDay: null,
     lastShareAt: null,
@@ -92,7 +94,11 @@ test('GET /api/account/me/profile - returns full profile', async () => {
 
     assert.equal(r.body.primaryId, 'tg_profile1');
     assert.equal(r.body.bestScore, 8350);
-    assert.equal(r.body.gold, 1240);
+    assert.equal(r.body.gold, 1590);
+    assert.equal(r.body.rewardGold, 1240);
+    assert.equal(r.body.totalGoldCoins, 350);
+    assert.equal(r.body.totalSilverCoins, 75);
+    assert.equal(r.body.silver, 75);
     assert.equal(r.body.referralCode, 'PROF1234');
     assert.ok(r.body.referralUrl.includes('PROF1234'), `referralUrl should contain code: ${r.body.referralUrl}`);
     assert.equal(r.body.rank, 42, 'rank = 41 + 1 = 42');

--- a/tests/referral.test.js
+++ b/tests/referral.test.js
@@ -18,6 +18,15 @@ async function startServer() {
   });
 }
 
+
+async function get(baseUrl, path, headers = {}) {
+  const res = await fetch(`${baseUrl}${path}`, {
+    headers
+  });
+  const json = await res.json().catch(() => ({}));
+  return { status: res.status, body: json };
+}
+
 async function post(baseUrl, path, body, headers = {}) {
   const res = await fetch(`${baseUrl}${path}`, {
     method: 'POST',
@@ -234,11 +243,20 @@ test('POST /api/referral/apply - awards both users and writes history', async ()
     CoinTransaction.findOne = async (q) => history.find(h => h.contextKey === q.contextKey) || null;
     CoinTransaction.create = async (doc) => { history.push(doc); return doc; };
 
+    Player.countDocuments = async () => 0;
+
     const r = await post(baseUrl, '/api/referral/apply', { referralCode: 'REF11111' }, { 'X-Primary-Id': 'tg_apply1' });
     assert.equal(r.status, 200, JSON.stringify(r.body));
     assert.equal(players.tg_apply1.gold, 100);
     assert.equal(players.tg_referrer.gold, 50);
     assert.equal(history.length, 2);
+    assert.ok(history.some((entry) => entry.type === 'referral' && entry.primaryId === 'tg_apply1' && entry.gold === 100));
+
+    const profile = await get(baseUrl, '/api/account/me/profile', { 'X-Primary-Id': 'tg_apply1' });
+    assert.equal(profile.status, 200, JSON.stringify(profile.body));
+    assert.equal(profile.body.rewardGold, 100);
+    assert.equal(profile.body.totalGoldCoins, 0);
+    assert.equal(profile.body.gold, 100);
   } finally { server.close(); }
 });
 

--- a/tests/share.test.js
+++ b/tests/share.test.js
@@ -20,6 +20,12 @@ async function startServer() {
   });
 }
 
+async function get(baseUrl, path, headers = {}) {
+  const res = await fetch(`${baseUrl}${path}`, { headers });
+  const json = await res.json().catch(() => ({}));
+  return { status: res.status, body: json };
+}
+
 async function post(baseUrl, path, body, headers = {}) {
   const res = await fetch(`${baseUrl}${path}`, {
     method: 'POST',
@@ -303,6 +309,8 @@ test('POST /api/share/confirm - awards 20 gold after 30s', async () => {
       return doc;
     };
 
+    Player.countDocuments = async () => 0;
+
     const r = await post(baseUrl, '/api/share/confirm', { shareId }, { 'X-Primary-Id': 'tg_gold' });
     assert.equal(r.status, 200, JSON.stringify(r.body));
     assert.equal(r.body.awarded, true);
@@ -311,6 +319,12 @@ test('POST /api/share/confirm - awards 20 gold after 30s', async () => {
     assert.equal(historyDoc.type, 'share');
     assert.equal(historyDoc.gold, 20);
     assert.equal(historyDoc.silver, 0);
+
+    const profile = await get(baseUrl, '/api/account/me/profile', { 'X-Primary-Id': 'tg_gold' });
+    assert.equal(profile.status, 200, JSON.stringify(profile.body));
+    assert.equal(profile.body.rewardGold, 20);
+    assert.equal(profile.body.totalGoldCoins, 0);
+    assert.equal(profile.body.gold, 20);
   } finally {
     server.close();
   }


### PR DESCRIPTION
### Motivation
- The profile endpoint exposed `gold` as `totalGoldCoins`, which hid reward-wallet grants (share/referral) and caused UI balance to not update when `Player.gold` increased.
- A canonical visible gold value is required that includes both in-game collected coins and reward wallet coins while preserving leaderboard semantics tied to `totalGoldCoins`.
- The change must remain backward-compatible and make the frontend reliably read the latest visible balance after referral, share, and race save flows.

### Description
- Compute `totalGoldCoins`, `totalSilverCoins`, `rewardGold` and a canonical `visibleGold = totalGoldCoins + rewardGold` in `GET /api/account/me/profile` and return `gold: visibleGold` while also returning `rewardGold`, `totalGoldCoins`, and `totalSilverCoins` for compatibility (changed file: `routes/account.js`).
- Keep `totalGoldCoins` intact so leaderboard and in-game collection stats remain unaffected.
- Update tests to cover the new contract and behavior: `tests/profile.test.js` asserts the combined visible `gold` and the new component fields, `tests/referral.test.js` verifies referral apply increases `Player.gold`, writes coin history, and that the profile reflects the updated visible balance, and `tests/share.test.js` verifies share confirm increases `Player.gold` and profile visibility.

### Testing
- Ran the full test suite with `npm test` and confirmed the updated/targeted tests for profile, referral apply, and share confirm pass locally after the changes.
- The suite run shows unrelated pre-existing failures in other tests in this environment, but the modified tests and the profile/referral/share assertions succeed. 
- Files changed: `routes/account.js`, `tests/profile.test.js`, `tests/referral.test.js`, and `tests/share.test.js`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdd58420e48326af3569ce2383bc3e)