### PR TITLE
Add persistent onboarding system with model, service, routes and run/store integration

### DIFF
--- a/ONBOARDING_BACKEND_IMPLEMENTATION_PLAN.md
+++ b/ONBOARDING_BACKEND_IMPLEMENTATION_PLAN.md
@@ -1,0 +1,435 @@
+# URSASS TUBE — Onboarding Backend Implementation Plan (v2)
+
+## Goal
+
+Implement a persistent onboarding system for:
+- Web guest players
+- Web authenticated players
+- Telegram authenticated players
+
+The onboarding system must:
+- survive page reloads;
+- survive app reopen;
+- work across devices;
+- support persistent rewards and onboarding gifts;
+- support spotlight/tutorial flows on frontend;
+- support future onboarding extensions.
+
+---
+
+## 0) Architecture Audit (Preparation)
+
+1. Validate existing identity resolution for:
+   - wallet-auth players,
+   - telegram-auth players,
+   - guests.
+2. Define a single stable `primaryId` strategy used by onboarding endpoints and services.
+3. Identify current reward settlement points for run completion and store purchase hooks.
+
+---
+
+## 1) New Mongo Model
+
+Create:
+
+`models/OnboardingState.js`
+
+Schema shape:
+
+```js
+{
+  primaryId: String,
+
+  flowVersion: "v2",
+
+  mainFlowCompleted: false,
+  mainFlowSkipped: false,
+
+  currentStep: "auth_start",
+
+  authRunsCount: 0,
+
+  rewards: {
+    silverAfterSecondRunGranted: false,
+    goldAfterThirdRunGranted: false
+  },
+
+  storeIntro: {
+    shown: false,
+    skipped: false,
+    ridePackBought: false
+  },
+
+  gifts: {
+    radarObstacles: {
+      unlocked: false,
+      claimed: false,
+      skipped: false,
+      activeUntil: null
+    },
+
+    radarGold: {
+      unlocked: false,
+      claimed: false,
+      skipped: false,
+      activeUntil: null
+    }
+  },
+
+  createdAt,
+  updatedAt
+}
+```
+
+Implementation notes:
+- add unique index for `primaryId`;
+- use timestamps;
+- include `getOrCreate` helper in service layer;
+- keep schema forward-compatible for future onboarding versions.
+
+---
+
+## 2) New API Endpoints
+
+Add routes:
+
+- `GET  /api/onboarding/state`
+- `POST /api/onboarding/event`
+- `POST /api/onboarding/claim`
+
+Versioned aliases:
+
+- `/api/v1/onboarding/state`
+- `/api/v1/onboarding/event`
+- `/api/v1/onboarding/claim`
+
+---
+
+## 3) GET `/api/onboarding/state`
+
+Purpose: return canonical onboarding state for frontend UI.
+
+Expected response includes:
+- `currentStep`
+- `mainFlowCompleted`
+- `authRunsCount`
+- `rewards`
+- `storeIntro`
+- `gifts`
+- computed `activeBoosts` derived from temporary boosts and expiration checks.
+
+Response example:
+
+```json
+{
+  "currentStep": "auth_run_2_done",
+  "mainFlowCompleted": false,
+
+  "authRunsCount": 2,
+
+  "rewards": {
+    "silverAfterSecondRunGranted": true,
+    "goldAfterThirdRunGranted": false
+  },
+
+  "storeIntro": {
+    "shown": true,
+    "ridePackBought": false
+  },
+
+  "gifts": {
+    "radarObstacles": {
+      "unlocked": true,
+      "claimed": false
+    },
+    "radarGold": {
+      "unlocked": false,
+      "claimed": false
+    }
+  },
+
+  "activeBoosts": {
+    "radarObstaclesUntil": null,
+    "radarGoldUntil": null
+  }
+}
+```
+
+---
+
+## 4) POST `/api/onboarding/event`
+
+Purpose: universal onboarding event ingestion endpoint.
+
+Request example:
+
+```json
+{
+  "event": "wallet_connected",
+  "meta": {}
+}
+```
+
+Supported events:
+
+- `wallet_connected`
+- `run_finished`
+- `x_connected`
+- `share_confirmed`
+- `store_opened`
+- `ride_pack_bought`
+- `store_back_clicked`
+- `skip_step`
+
+Implementation requirements:
+- strict event whitelist validation;
+- idempotent state transitions where possible;
+- internal server-side step progression only.
+
+---
+
+## 5) POST `/api/onboarding/claim`
+
+Purpose: claim persistent onboarding gifts.
+
+Request example:
+
+```json
+{
+  "reward": "radar_obstacles_24h"
+}
+```
+
+Supported rewards:
+
+- `radar_obstacles_24h`
+- `radar_gold_24h`
+
+Requirements:
+- idempotent;
+- cannot claim twice;
+- persists forever until claimed;
+- survives reloads/reconnects/reopen.
+
+---
+
+## 6) Authenticated Run Tracking
+
+Increment `authRunsCount` only for:
+- authenticated wallet players;
+- authenticated Telegram players.
+
+Guest runs must not affect onboarding progression.
+
+---
+
+## 7) Onboarding Reward Logic
+
+### First authenticated run
+
+No bonus awarded.
+
+Frontend hook text:
+- `Run again. Get +100 silver`
+
+### Second authenticated run
+
+After completion:
+- award `+100 silver`;
+- include in run settlement payload;
+- set `rewards.silverAfterSecondRunGranted = true`.
+
+Settlement payload shape:
+
+```json
+{
+  "collectedSilver": 37,
+  "onboardingSilverBonus": 100,
+  "totalSilverAwarded": 137
+}
+```
+
+### Third authenticated run
+
+After completion:
+- award `+100 gold`;
+- include in run settlement payload;
+- set `rewards.goldAfterThirdRunGranted = true`.
+
+Settlement payload shape:
+
+```json
+{
+  "collectedGold": 4,
+  "onboardingGoldBonus": 100,
+  "totalGoldAwarded": 104
+}
+```
+
+---
+
+## 8) Store Intro Flow
+
+- Reuse existing store product: **3 rides pack**.
+- Do not create any new store product.
+- Integrate with existing `POST /api/store/buy` flow.
+
+On successful target pack purchase:
+- set `storeIntro.ridePackBought = true`;
+- set `mainFlowCompleted = true`.
+
+---
+
+## 9) Radar Gift Unlocks
+
+### After 6 authenticated runs
+
+Unlock:
+
+```js
+gifts.radarObstacles.unlocked = true
+```
+
+### After 15 authenticated runs
+
+Unlock:
+
+```js
+gifts.radarGold.unlocked = true
+```
+
+Rules:
+- unlocked gifts remain claimable forever until claimed.
+
+---
+
+## 10) Temporary Radar Boosts Model Update
+
+Modify:
+
+`models/PlayerUpgrades.js`
+
+Add:
+
+```js
+temporaryBoosts: {
+  radarObstaclesUntil: Date,
+  radarGoldUntil: Date
+}
+```
+
+Do not modify permanent upgrades behavior.
+
+---
+
+## 11) Radar Claim Logic
+
+When claiming `radar_obstacles_24h`:
+
+```js
+temporaryBoosts.radarObstaclesUntil = now + 24 hours
+```
+
+When claiming `radar_gold_24h`:
+
+```js
+temporaryBoosts.radarGoldUntil = now + 24 hours
+```
+
+And mark onboarding gift as claimed.
+
+---
+
+## 12) Runtime Effect Calculation
+
+Update effect builder rules:
+
+Radar is active if:
+- permanent upgrade exists, **OR**
+- temporary boost exists and is not expired.
+
+Apply to:
+- `radar_obstacles`
+- `radar_gold`
+
+---
+
+## 13) Persistence Rules
+
+Server-side onboarding state is source of truth.
+
+Must persist across:
+- reload;
+- reconnect;
+- Telegram reopen;
+- wallet reconnect.
+
+Frontend `localStorage` must never be source of truth for:
+- rewards;
+- onboarding completion;
+- gifts;
+- active boosts.
+
+---
+
+## 14) Edge Cases
+
+1. Reload after 3rd authenticated run:
+   - onboarding continues from store intro stage.
+2. Reload after rides pack purchase:
+   - onboarding already completed.
+3. Gift skipped:
+   - remains claimable forever until claimed.
+4. Manual store entry:
+   - if gift unlocked, onboarding gift flow continues automatically.
+
+---
+
+## 15) Analytics Events
+
+Track:
+- `onboarding_step_shown`
+- `onboarding_step_skipped`
+- `onboarding_completed`
+- `onboarding_reward_granted`
+- `onboarding_reward_claimed`
+- `radar_gift_unlocked`
+- `radar_gift_claimed`
+
+Recommended payload:
+- `primaryId`
+- `flowVersion`
+- `currentStep`
+- `event/reward`
+- `authRunsCount`
+- `timestamp`
+
+---
+
+## 16) Implementation Order
+
+1. Add `OnboardingState` model.
+2. Add onboarding service (state transitions + run/gift rules).
+3. Add onboarding routes + v1 aliases.
+4. Integrate run-finish settlement bonuses.
+5. Integrate store-buy completion hook.
+6. Add temporary boosts to `PlayerUpgrades`.
+7. Update runtime effect builder.
+8. Add analytics events.
+9. Add tests (unit + integration + edge cases).
+10. Deploy and run smoke checks for Web + Telegram auth paths.
+
+---
+
+## 17) Acceptance Checklist
+
+- [ ] Onboarding state persists in Mongo and restores after reload/reopen.
+- [ ] Guests do not progress authenticated onboarding runs.
+- [ ] 2nd authenticated run grants +100 silver exactly once.
+- [ ] 3rd authenticated run grants +100 gold exactly once.
+- [ ] Store intro finalizes on existing 3 rides pack purchase.
+- [ ] Gifts unlock at run 6 and run 15 thresholds.
+- [ ] Gift claims are idempotent and non-repeatable.
+- [ ] Temporary radar boosts activate for 24h.
+- [ ] Runtime effects respect permanent OR temporary boost logic.
+- [ ] Analytics events emitted for key onboarding milestones.

--- a/app.js
+++ b/app.js
@@ -12,6 +12,7 @@ const donationsRoutes = require('./routes/donations');
 const referralRoutes = require('./routes/referral');
 const shareRoutes = require('./routes/share');
 const xRoutes = require('./routes/x');
+const onboardingRoutes = require('./routes/onboarding');
 const logger = require('./utils/logger');
 const Player = require('./models/Player');
 const ShareEvent = require('./models/ShareEvent');
@@ -46,7 +47,8 @@ function getRouteRegistry() {
     { path: '/referral', router: referralRoutes },
     { path: '/referrals', router: referralRoutes },
     { path: '/share', router: shareRoutes },
-    { path: '/x', router: xRoutes }
+    { path: '/x', router: xRoutes },
+    { path: '/onboarding', router: onboardingRoutes }
   ];
 }
 

--- a/models/AnalyticsEvent.js
+++ b/models/AnalyticsEvent.js
@@ -3,6 +3,12 @@ const mongoose = require('mongoose');
 const ANALYTICS_EVENT_TYPES = Object.freeze([
   'app_opened',
   'onboarding_completed',
+  'onboarding_step_shown',
+  'onboarding_step_skipped',
+  'onboarding_reward_granted',
+  'onboarding_reward_claimed',
+  'radar_gift_unlocked',
+  'radar_gift_claimed',
   'run_started',
   'leaderboard_opened',
   'wallet_connect_started',

--- a/models/OnboardingState.js
+++ b/models/OnboardingState.js
@@ -1,0 +1,35 @@
+const mongoose = require('mongoose');
+
+const onboardingStateSchema = new mongoose.Schema({
+  primaryId: { type: String, required: true, unique: true, index: true, lowercase: true, trim: true },
+  flowVersion: { type: String, default: 'v2' },
+  mainFlowCompleted: { type: Boolean, default: false },
+  mainFlowSkipped: { type: Boolean, default: false },
+  currentStep: { type: String, default: 'auth_start' },
+  authRunsCount: { type: Number, default: 0, min: 0 },
+  rewards: {
+    silverAfterSecondRunGranted: { type: Boolean, default: false },
+    goldAfterThirdRunGranted: { type: Boolean, default: false }
+  },
+  storeIntro: {
+    shown: { type: Boolean, default: false },
+    skipped: { type: Boolean, default: false },
+    ridePackBought: { type: Boolean, default: false }
+  },
+  gifts: {
+    radarObstacles: {
+      unlocked: { type: Boolean, default: false },
+      claimed: { type: Boolean, default: false },
+      skipped: { type: Boolean, default: false },
+      activeUntil: { type: Date, default: null }
+    },
+    radarGold: {
+      unlocked: { type: Boolean, default: false },
+      claimed: { type: Boolean, default: false },
+      skipped: { type: Boolean, default: false },
+      activeUntil: { type: Date, default: null }
+    }
+  }
+}, { timestamps: true });
+
+module.exports = mongoose.model('OnboardingState', onboardingStateSchema);

--- a/models/PlayerUpgrades.js
+++ b/models/PlayerUpgrades.js
@@ -57,6 +57,12 @@ const playerUpgradesSchema = new mongoose.Schema({
       default: []
     },
 
+
+  temporaryBoosts: {
+    radarObstaclesUntil: { type: Date, default: null },
+    radarGoldUntil: { type: Date, default: null }
+  },
+
   updatedAt: {
     type: Date,
     default: Date.now

--- a/routes/leaderboard.js
+++ b/routes/leaderboard.js
@@ -23,6 +23,7 @@ const { hasAiModeAccess, hasAiModeAccessByTelegramUsername, validateAiSettings }
 const { computePlayerInsights, computeRank, DEFAULTS: leaderboardInsightsConfig } = require('../services/leaderboardInsightsService');
 const { buildGameOverPayload } = require('../services/gameOverAgitationService');
 const { maybeGrantReferralRewards } = require('../utils/referralRewards');
+const { getOrCreateOnboardingState, applyRunProgress } = require('../services/onboardingService');
 const { recordCoinReward } = require('../utils/coinHistory');
 const {
   resolveDisplayNameFromPreferences,
@@ -622,6 +623,25 @@ router.post('/save', saveResultLimiter, async (req, res) => {
       await persistResultAndPlayer();
     }
 
+
+    const onboardingState = await getOrCreateOnboardingState(walletLower);
+    const onboardingReward = applyRunProgress(onboardingState);
+    await onboardingState.save();
+
+    if (onboardingReward.silverBonus > 0 || onboardingReward.goldBonus > 0) {
+      await Player.updateOne(
+        { wallet: walletLower },
+        {
+          $inc: {
+            totalSilverCoins: onboardingReward.silverBonus,
+            totalGoldCoins: onboardingReward.goldBonus
+          }
+        }
+      );
+      responsePayload.totalSilverCoins += onboardingReward.silverBonus;
+      responsePayload.totalGoldCoins += onboardingReward.goldBonus;
+    }
+
     logger.info({
       wallet: walletLower,
       bestScore: responsePayload.bestScore,
@@ -695,6 +715,8 @@ router.post('/save', saveResultLimiter, async (req, res) => {
       totalSilverCoins: responsePayload.totalSilverCoins,
       gamesPlayed: responsePayload.gamesPlayed,
       gameOverPrompt,
+      onboardingSilverBonus: onboardingReward?.silverBonus || 0,
+      onboardingGoldBonus: onboardingReward?.goldBonus || 0,
       ...(gameOverInsights ? { playerInsights: gameOverInsights } : {})
     });
 

--- a/routes/onboarding.js
+++ b/routes/onboarding.js
@@ -1,0 +1,81 @@
+const express = require('express');
+const { readLimiter } = require('../middleware/rateLimiter');
+const PlayerUpgrades = require('../models/PlayerUpgrades');
+const {
+  resolvePrimaryIdFromRequest,
+  getOrCreateOnboardingState,
+  applyRunProgress,
+  updateStep,
+  claimReward
+} = require('../services/onboardingService');
+
+const router = express.Router();
+
+function buildStateResponse(state, upgrades) {
+  return {
+    currentStep: state.currentStep,
+    mainFlowCompleted: state.mainFlowCompleted,
+    authRunsCount: state.authRunsCount,
+    rewards: state.rewards,
+    storeIntro: state.storeIntro,
+    gifts: {
+      radarObstacles: {
+        unlocked: state.gifts.radarObstacles.unlocked,
+        claimed: state.gifts.radarObstacles.claimed
+      },
+      radarGold: {
+        unlocked: state.gifts.radarGold.unlocked,
+        claimed: state.gifts.radarGold.claimed
+      }
+    },
+    activeBoosts: {
+      radarObstaclesUntil: upgrades?.temporaryBoosts?.radarObstaclesUntil || null,
+      radarGoldUntil: upgrades?.temporaryBoosts?.radarGoldUntil || null
+    }
+  };
+}
+
+router.get('/state', readLimiter, async (req, res) => {
+  const primaryId = resolvePrimaryIdFromRequest(req);
+  if (!primaryId) return res.status(400).json({ error: 'primaryId_required' });
+  const state = await getOrCreateOnboardingState(primaryId);
+  const upgrades = await PlayerUpgrades.findOne({ wallet: primaryId });
+  return res.json(buildStateResponse(state, upgrades));
+});
+
+router.post('/event', async (req, res) => {
+  const primaryId = resolvePrimaryIdFromRequest(req);
+  if (!primaryId) return res.status(400).json({ error: 'primaryId_required' });
+  const event = String(req.body?.event || '').trim();
+  const supported = new Set(['wallet_connected', 'run_finished', 'x_connected', 'share_confirmed', 'store_opened', 'ride_pack_bought', 'store_back_clicked', 'skip_step']);
+  if (!supported.has(event)) return res.status(400).json({ error: 'unsupported_event' });
+
+  const state = await getOrCreateOnboardingState(primaryId);
+  if (event === 'run_finished' && req.body?.authType && req.body.authType !== 'guest') {
+    applyRunProgress(state);
+  }
+  if (event === 'store_opened') state.storeIntro.shown = true;
+  if (event === 'ride_pack_bought') {
+    state.storeIntro.ridePackBought = true;
+    state.mainFlowCompleted = true;
+  }
+  if (event === 'skip_step') state.mainFlowSkipped = true;
+  updateStep(state);
+  await state.save();
+  return res.json({ success: true, state });
+});
+
+router.post('/claim', async (req, res) => {
+  try {
+    const primaryId = resolvePrimaryIdFromRequest(req);
+    if (!primaryId) return res.status(400).json({ error: 'primaryId_required' });
+    const reward = String(req.body?.reward || '').trim();
+    const state = await getOrCreateOnboardingState(primaryId);
+    const claim = await claimReward({ state, primaryId, reward });
+    return res.json({ success: true, reward, ...claim });
+  } catch (error) {
+    return res.status(error.statusCode || 500).json({ error: error.message || 'claim_failed' });
+  }
+});
+
+module.exports = router;

--- a/routes/store.js
+++ b/routes/store.js
@@ -12,6 +12,7 @@ const logger = require('../utils/logger');
 const { markSuspicious } = require('../middleware/requestMetrics');
 const { logSecurityEvent, normalizeWallet, parseWalletOrNull, buildInvalidWalletError, validateTimestampWindow } = require('../utils/security');
 const { hasAiModeAccess, hasAiModeAccessByTelegramUsername } = require('../utils/aiModeAccess');
+const { getOrCreateOnboardingState, updateStep } = require('../services/onboardingService');
 
 const UPGRADE_KEY_ALIASES = {
   spin_alert: 'alert',
@@ -644,6 +645,12 @@ router.post('/buy', writeLimiter, async (req, res) => {
       upgrades.paidRidesRemaining += config.amount;
 
       logger.info({ wallet: walletLower, ridesBought: config.amount, price, currency: 'gold', paidRidesRemaining: upgrades.paidRidesRemaining }, 'Rides purchased');
+
+      const onboardingState = await getOrCreateOnboardingState(walletLower);
+      onboardingState.storeIntro.ridePackBought = true;
+      onboardingState.mainFlowCompleted = true;
+      updateStep(onboardingState);
+      await onboardingState.save();
 
     } else {
       return failPurchase(400, 'unknown_upgrade_type', 'Unknown upgrade type');

--- a/services/onboardingService.js
+++ b/services/onboardingService.js
@@ -1,0 +1,95 @@
+const OnboardingState = require('../models/OnboardingState');
+const PlayerUpgrades = require('../models/PlayerUpgrades');
+
+const CLAIMABLE_REWARDS = new Set(['radar_obstacles_24h', 'radar_gold_24h']);
+
+function resolvePrimaryIdFromRequest(req) {
+  return String(req.primaryId || req.get('x-primary-id') || req.get('x-wallet') || req.body?.primaryId || req.query?.primaryId || '')
+    .trim()
+    .toLowerCase();
+}
+
+async function getOrCreateOnboardingState(primaryId) {
+  let state = await OnboardingState.findOne({ primaryId });
+  if (!state) state = await OnboardingState.create({ primaryId });
+  return state;
+}
+
+function updateStep(state) {
+  if (state.mainFlowCompleted) {
+    state.currentStep = 'completed';
+  } else if (state.authRunsCount >= 3 && !state.storeIntro.ridePackBought) {
+    state.currentStep = 'store_intro';
+  } else if (state.authRunsCount >= 2) {
+    state.currentStep = 'auth_run_2_done';
+  } else if (state.authRunsCount >= 1) {
+    state.currentStep = 'auth_run_1_done';
+  } else {
+    state.currentStep = 'auth_start';
+  }
+}
+
+function applyRunProgress(state) {
+  state.authRunsCount += 1;
+  const rewards = { silverBonus: 0, goldBonus: 0, unlocked: [] };
+
+  if (state.authRunsCount >= 2 && !state.rewards.silverAfterSecondRunGranted) {
+    state.rewards.silverAfterSecondRunGranted = true;
+    rewards.silverBonus = 100;
+  }
+  if (state.authRunsCount >= 3 && !state.rewards.goldAfterThirdRunGranted) {
+    state.rewards.goldAfterThirdRunGranted = true;
+    rewards.goldBonus = 100;
+  }
+  if (state.authRunsCount >= 6 && !state.gifts.radarObstacles.unlocked) {
+    state.gifts.radarObstacles.unlocked = true;
+    rewards.unlocked.push('radar_obstacles_24h');
+  }
+  if (state.authRunsCount >= 15 && !state.gifts.radarGold.unlocked) {
+    state.gifts.radarGold.unlocked = true;
+    rewards.unlocked.push('radar_gold_24h');
+  }
+  updateStep(state);
+  return rewards;
+}
+
+async function claimReward({ state, primaryId, reward }) {
+  if (!CLAIMABLE_REWARDS.has(reward)) {
+    const err = new Error('unsupported_reward');
+    err.statusCode = 400;
+    throw err;
+  }
+
+  const upgrades = await PlayerUpgrades.findOneAndUpdate(
+    { wallet: primaryId },
+    { $setOnInsert: { wallet: primaryId } },
+    { upsert: true, new: true }
+  );
+
+  const now = new Date();
+  const until = new Date(now.getTime() + (24 * 60 * 60 * 1000));
+
+  if (reward === 'radar_obstacles_24h') {
+    if (!state.gifts.radarObstacles.unlocked) throw Object.assign(new Error('reward_locked'), { statusCode: 409 });
+    if (state.gifts.radarObstacles.claimed) return { alreadyClaimed: true, until: upgrades.temporaryBoosts?.radarObstaclesUntil || null };
+    state.gifts.radarObstacles.claimed = true;
+    state.gifts.radarObstacles.activeUntil = until;
+    upgrades.temporaryBoosts = upgrades.temporaryBoosts || {};
+    upgrades.temporaryBoosts.radarObstaclesUntil = until;
+  }
+
+  if (reward === 'radar_gold_24h') {
+    if (!state.gifts.radarGold.unlocked) throw Object.assign(new Error('reward_locked'), { statusCode: 409 });
+    if (state.gifts.radarGold.claimed) return { alreadyClaimed: true, until: upgrades.temporaryBoosts?.radarGoldUntil || null };
+    state.gifts.radarGold.claimed = true;
+    state.gifts.radarGold.activeUntil = until;
+    upgrades.temporaryBoosts = upgrades.temporaryBoosts || {};
+    upgrades.temporaryBoosts.radarGoldUntil = until;
+  }
+
+  await upgrades.save();
+  await state.save();
+  return { alreadyClaimed: false, until };
+}
+
+module.exports = { resolvePrimaryIdFromRequest, getOrCreateOnboardingState, applyRunProgress, updateStep, claimReward };

--- a/tests/onboarding.service.test.js
+++ b/tests/onboarding.service.test.js
@@ -1,0 +1,72 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { applyRunProgress, updateStep } = require('../services/onboardingService');
+
+function baseState() {
+  return {
+    mainFlowCompleted: false,
+    storeIntro: { ridePackBought: false },
+    currentStep: 'auth_start',
+    authRunsCount: 0,
+    rewards: {
+      silverAfterSecondRunGranted: false,
+      goldAfterThirdRunGranted: false
+    },
+    gifts: {
+      radarObstacles: { unlocked: false },
+      radarGold: { unlocked: false }
+    }
+  };
+}
+
+test('applyRunProgress grants silver on second auth run exactly once', () => {
+  const state = baseState();
+
+  const r1 = applyRunProgress(state);
+  assert.equal(r1.silverBonus, 0);
+  assert.equal(state.rewards.silverAfterSecondRunGranted, false);
+
+  const r2 = applyRunProgress(state);
+  assert.equal(r2.silverBonus, 100);
+  assert.equal(state.rewards.silverAfterSecondRunGranted, true);
+
+  const r3 = applyRunProgress(state);
+  assert.equal(r3.silverBonus, 0);
+});
+
+test('applyRunProgress grants gold on third auth run exactly once', () => {
+  const state = baseState();
+  applyRunProgress(state);
+  applyRunProgress(state);
+
+  const r3 = applyRunProgress(state);
+  assert.equal(r3.goldBonus, 100);
+  assert.equal(state.rewards.goldAfterThirdRunGranted, true);
+
+  const r4 = applyRunProgress(state);
+  assert.equal(r4.goldBonus, 0);
+});
+
+test('applyRunProgress unlocks radar gifts at 6 and 15 runs', () => {
+  const state = baseState();
+
+  for (let i = 0; i < 6; i += 1) applyRunProgress(state);
+  assert.equal(state.gifts.radarObstacles.unlocked, true);
+  assert.equal(state.gifts.radarGold.unlocked, false);
+
+  for (let i = 6; i < 15; i += 1) applyRunProgress(state);
+  assert.equal(state.gifts.radarGold.unlocked, true);
+});
+
+test('updateStep moves to store_intro after 3rd run and completed after ride pack', () => {
+  const state = baseState();
+  state.authRunsCount = 3;
+  updateStep(state);
+  assert.equal(state.currentStep, 'store_intro');
+
+  state.mainFlowCompleted = true;
+  state.storeIntro.ridePackBought = true;
+  updateStep(state);
+  assert.equal(state.currentStep, 'completed');
+});

--- a/tests/onboarding.temporary-boosts.test.js
+++ b/tests/onboarding.temporary-boosts.test.js
@@ -1,0 +1,38 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { calculateEffects } = require('../utils/upgradesConfig');
+
+test('temporary radar boosts activate effects without permanent upgrades', () => {
+  const now = Date.now();
+  const upgrades = {
+    radar_obstacles: 0,
+    radar_gold: 0,
+    temporaryBoosts: {
+      radarObstaclesUntil: new Date(now + 60_000),
+      radarGoldUntil: new Date(now + 60_000)
+    }
+  };
+
+  const effects = calculateEffects(upgrades);
+  assert.equal(effects.start_with_radar_obstacles, true);
+  assert.equal(effects.start_with_radar_gold, true);
+  assert.equal(effects.start_with_radar, true);
+});
+
+test('expired temporary radar boosts do not activate effects', () => {
+  const now = Date.now();
+  const upgrades = {
+    radar_obstacles: 0,
+    radar_gold: 0,
+    temporaryBoosts: {
+      radarObstaclesUntil: new Date(now - 60_000),
+      radarGoldUntil: new Date(now - 60_000)
+    }
+  };
+
+  const effects = calculateEffects(upgrades);
+  assert.equal(effects.start_with_radar_obstacles, false);
+  assert.equal(effects.start_with_radar_gold, false);
+  assert.equal(effects.start_with_radar, false);
+});

--- a/utils/upgradesConfig.js
+++ b/utils/upgradesConfig.js
@@ -196,6 +196,12 @@ function calculateEffects(upgrades) {
   const legacyRadarLevel = toUpgradeLevel(upgrades.radar);
   const alertLevel = toUpgradeLevel(upgrades.alert);
 
+  const now = Date.now();
+  const radarObstaclesTempUntil = upgrades?.temporaryBoosts?.radarObstaclesUntil ? new Date(upgrades.temporaryBoosts.radarObstaclesUntil).getTime() : 0;
+  const radarGoldTempUntil = upgrades?.temporaryBoosts?.radarGoldUntil ? new Date(upgrades.temporaryBoosts.radarGoldUntil).getTime() : 0;
+  const hasRadarObstaclesTemp = Number.isFinite(radarObstaclesTempUntil) && radarObstaclesTempUntil > now;
+  const hasRadarGoldTemp = Number.isFinite(radarGoldTempUntil) && radarGoldTempUntil > now;
+
   const hasSeparateShieldCapacity = Number.isFinite(shieldCapacityLevel);
   const normalizedShieldLevel = legacyShieldLevel > 0 ? 1 : 0;
   const normalizedShieldCapacityLevel = hasSeparateShieldCapacity
@@ -250,10 +256,10 @@ function calculateEffects(upgrades) {
       ? UPGRADES_CONFIG.shield_capacity.effects[normalizedShieldCapacityLevel - 1]
       : 1,
     start_with_shield: normalizedShieldLevel > 0,
-    start_with_radar_obstacles: radarObstaclesLevel > 0,
-    start_with_radar_gold: normalizedRadarGoldLevel > 0,
+    start_with_radar_obstacles: radarObstaclesLevel > 0 || hasRadarObstaclesTemp,
+    start_with_radar_gold: normalizedRadarGoldLevel > 0 || hasRadarGoldTemp,
     // Backward compatibility for clients that still read `start_with_radar`.
-    start_with_radar: normalizedRadarGoldLevel > 0,
+    start_with_radar: normalizedRadarGoldLevel > 0 || hasRadarGoldTemp,
     alert_level: alertLevel,
     spin_alert_mode: alertLevel > 0
       ? UPGRADES_CONFIG.alert.effects[alertLevel - 1]


### PR DESCRIPTION
### Motivation

- Implement a persistent, server-side onboarding system that survives reloads/reopens and works for web (guest/auth) and Telegram authenticated players.
- Provide deterministic onboarding progression, grant one-time run rewards (+100 silver/gold), unlock claimable radar gifts, and support frontend spotlight/tutorial flows.
- Ensure onboarding ties into existing store flow so buying the 3-rides pack completes the main flow and persists across devices.

### Description

- Add a new Mongo model `models/OnboardingState.js` to store onboarding progress, rewards, gifts and timestamps and expose a unique `primaryId` index.
- Implement `services/onboardingService.js` with `getOrCreateOnboardingState`, `applyRunProgress`, `updateStep`, `claimReward`, and `resolvePrimaryIdFromRequest` to manage transitions, unlocks and claims (including 24h radar boosts).
- Expose new routes mounted at `/onboarding` in `routes/onboarding.js` providing `GET /state`, `POST /event`, and `POST /claim`, and register the router in `app.js`.
- Integrate onboarding into the run save flow in `routes/leaderboard.js` by calling `getOrCreateOnboardingState` and `applyRunProgress`, persisting bonuses to the player's `totalSilverCoins`/`totalGoldCoins` and returning `onboardingSilverBonus`/`onboardingGoldBonus` in the response.
- Hook onboarding into the store purchase flow in `routes/store.js` to mark `storeIntro.ridePackBought` and finalize `mainFlowCompleted` when the 3-rides pack is bought, and then call `updateStep` and persist state.
- Add temporary boost fields to `models/PlayerUpgrades.js` and update `utils/upgradesConfig.js` so temporary radar boosts (`temporaryBoosts.*Until`) activate runtime effects alongside permanent upgrades.
- Add analytics event types to `models/AnalyticsEvent.js` for onboarding and radar gift events.
- Add unit tests `tests/onboarding.service.test.js` and `tests/onboarding.temporary-boosts.test.js` covering run progression, gift unlock thresholds, step transitions and temporary boost effect behavior.

### Testing

- Ran onboarding unit tests: `tests/onboarding.service.test.js` passed and verified silver/gold bonuses, unlock thresholds and `updateStep` transitions.
- Ran temporary boosts tests: `tests/onboarding.temporary-boosts.test.js` passed and verified that `calculateEffects` respects active and expired temporary boosts.
- No integration test failures reported for modified modules during local test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00f5534f608326be755042f711a2ac)