### PR TITLE
Fix wallet identifier handling for leaderboard top and store upgrades

### DIFF
--- a/routes/leaderboard.js
+++ b/routes/leaderboard.js
@@ -161,11 +161,15 @@ router.get('/top', readLimiter, async (req, res) => {
   try {
     const walletQuery = typeof req.query.wallet === 'string' ? req.query.wallet.trim().toLowerCase() : '';
     let wallet = walletQuery ? parseWalletOrNull(walletQuery) : null;
-    if (walletQuery && !wallet) {
+    const isPrimaryIdQuery = walletQuery.startsWith('tg_');
+    if (walletQuery && !wallet && isPrimaryIdQuery) {
       const link = await AccountLink.findOne({
         $or: [{ primaryId: walletQuery }, { wallet: walletQuery }]
       });
       wallet = link?.primaryId || null;
+    }
+    if (walletQuery && !wallet) {
+      return res.status(400).json(buildInvalidWalletError());
     }
 
     if (!wallet) {

--- a/routes/store.js
+++ b/routes/store.js
@@ -139,6 +139,9 @@ async function getOrCreatePlayerUpgrades(wallet) {
 async function resolvePrimaryIdFromIdentifier(identifier) {
   const normalized = String(identifier || '').trim().toLowerCase();
   if (!normalized) return null;
+  if (parseWalletOrNull(normalized)) {
+    return normalized;
+  }
   const link = await AccountLink.findOne({
     $or: [{ primaryId: normalized }, { wallet: normalized }]
   });


### PR DESCRIPTION
### Motivation
- Recent changes caused contract-level regressions where `/api/leaderboard/top?wallet=...` silently fell back to the public leaderboard for invalid wallet queries and `/api/store/upgrades/:wallet` rejected raw wallet addresses, breaking integration tests and expected client behavior.

### Description
- Make `/api/leaderboard/top` validate the `wallet` query: treat `tg_*` primary-id queries by resolving via `AccountLink`, and return `400` with `buildInvalidWalletError()` if a non-empty query is neither a valid EVM address nor a supported primary id (file: `routes/leaderboard.js`).
- Update `resolvePrimaryIdFromIdentifier` so `/api/store/upgrades/:wallet` accepts and returns a normalized wallet immediately when the identifier is a valid EVM address, avoiding unnecessary AccountLink dependence (file: `routes/store.js`).
- Changes are limited to identifier resolution and validation logic and do not alter business rules beyond restoring prior contract expectations.

### Testing
- Ran targeted integration tests for the affected scenarios with `node --test tests/api.integration.test.js --test-name-pattern "leaderboard/top rejects invalid wallet|store/upgrades/:wallet"` and both tests passed.
- Ran the broader test suite (`npm test` / `node --test tests/*.test.js`) to validate baseline; the leaderboard/store regressions are fixed but there remain unrelated failing tests in analytics/telemetry and share/image flows that are pre-existing and outside the scope of this fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a00f89873b08326b837ca49849885f6)