### PR TITLE
Improve deterministic onboarding progression for Store flow

### DIFF
--- a/models/OnboardingState.js
+++ b/models/OnboardingState.js
@@ -14,6 +14,7 @@ const onboardingStateSchema = new mongoose.Schema({
   storeIntro: {
     shown: { type: Boolean, default: false },
     skipped: { type: Boolean, default: false },
+    unlocked: { type: Boolean, default: false },
     ridePackBought: { type: Boolean, default: false }
   },
   gifts: {

--- a/routes/onboarding.js
+++ b/routes/onboarding.js
@@ -60,8 +60,11 @@ router.post('/event', async (req, res) => {
     }
   }
   if (event === 'store_opened') state.storeIntro.shown = true;
+  if (event === 'x_connected' || event === 'share_confirmed') state.storeIntro.unlocked = true;
   if (event === 'ride_pack_bought') {
     state.storeIntro.ridePackBought = true;
+  }
+  if (event === 'store_back_clicked') {
     state.mainFlowCompleted = true;
     await trackOnboardingEvent('onboarding_completed', { primaryId, flowVersion: state.flowVersion || 'v2' });
   }
@@ -71,7 +74,8 @@ router.post('/event', async (req, res) => {
   }
   updateStep(state);
   await state.save();
-  return res.json({ success: true, state });
+  const upgrades = await PlayerUpgrades.findOne({ wallet: primaryId });
+  return res.json({ success: true, state: buildStateResponse(state, upgrades) });
 });
 
 router.post('/claim', async (req, res) => {

--- a/services/onboardingService.js
+++ b/services/onboardingService.js
@@ -31,8 +31,16 @@ async function getOrCreateOnboardingState(primaryId) {
 function updateStep(state) {
   if (state.mainFlowCompleted) {
     state.currentStep = 'completed';
-  } else if (state.authRunsCount >= 3 && !state.storeIntro.ridePackBought) {
-    state.currentStep = 'store_intro';
+  } else if (state.authRunsCount >= 3) {
+    if (state.storeIntro.ridePackBought) {
+      state.currentStep = 'store_back';
+    } else if (state.storeIntro.shown) {
+      state.currentStep = 'store_ride_pack';
+    } else if (state.storeIntro.unlocked) {
+      state.currentStep = 'store_intro';
+    } else {
+      state.currentStep = 'auth_run_3_done';
+    }
   } else if (state.authRunsCount >= 2) {
     state.currentStep = 'auth_run_2_done';
   } else if (state.authRunsCount >= 1) {


### PR DESCRIPTION
### Motivation
- Ensure frontend receives a deterministic Store onboarding flow after authenticated runs instead of jumping between generic auth steps and `completed`.
- Gate the Store flow behind a third authenticated run (`auth_run_3_done`) and explicit user actions (connect/share/store open) so the UI can reliably transition through `store_intro` → `store_ride_pack` → `store_back` → `completed`.
- Preserve existing reward/grant semantics and avoid counting guest runs toward progression.
- Return a consistent onboarding state shape from the API so the frontend does not need to normalize different responses.

### Description
- Updated `updateStep` in `services/onboardingService.js` to produce the sequence: `auth_run_1_done` → `auth_run_2_done` → `auth_run_3_done` (gate) → `store_intro` → `store_ride_pack` → `store_back` → `completed`, with `mainFlowCompleted` taking priority and `storeIntro.unlocked/shown/ridePackBought` deciding the Store sub-flow.
- Added `storeIntro.unlocked` to `models/OnboardingState.js` to represent readiness to show the intro after the 3rd authenticated run.
- Extended `POST /api/onboarding/event` in `routes/onboarding.js` to: mark `storeIntro.unlocked` on `x_connected`/`share_confirmed`, set `storeIntro.shown` on `store_opened`, set `storeIntro.ridePackBought` on `ride_pack_bought` (without auto-completing), and mark `mainFlowCompleted` on `store_back_clicked` while tracking completion analytics.
- Made the `/api/onboarding/event` response return the normalized state payload (same structure as `GET /api/onboarding/state`) and kept reward grant/claim logic idempotent while `run_finished` progression still requires `shouldCountAuthenticatedRun` so guest runs are not counted.

### Testing
- Ran `npm run check:syntax` and it completed successfully (syntax check passed for project files).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01089242108326be568cb235641580)