### PR TITLE
Second-race onboarding: add unit tests and include onboarding statuses in /api/onboarding/state logs

### DIFF
--- a/routes/onboarding.js
+++ b/routes/onboarding.js
@@ -89,6 +89,7 @@ router.get('/state', readLimiter, async (req, res) => {
     screen,
     raceCount: gameplayHistory.raceCount,
     xConnected: gameplayHistory.xConnected,
+    onboardingStatuses: response.onboarding,
     activeOnboardingKey: response.activeOnboarding?.key || null,
     reason
   }, 'Onboarding state resolved');

--- a/tests/onboarding.service.test.js
+++ b/tests/onboarding.service.test.js
@@ -36,3 +36,43 @@ test('resolveActiveOnboarding returns first_race on menu for zero runs', () => {
   const active = resolveActiveOnboarding({ state, raceCount: 0, xConnected: false, screen: 'menu' });
   assert.equal(active?.key, 'first_race');
 });
+
+test('resolveActiveOnboarding returns second_race_game_over for one run on game-over screen', () => {
+  const state = baseState();
+  const active = resolveActiveOnboarding({ state, raceCount: 1, xConnected: false, screen: 'game-over' });
+  assert.deepEqual(active, {
+    key: 'second_race_game_over',
+    screen: 'game-over',
+    target: 'play_again',
+    hook: 'Play again and get +100 silver'
+  });
+});
+
+test('resolveActiveOnboarding returns second_race_menu for one run on menu screen', () => {
+  const state = baseState();
+  const active = resolveActiveOnboarding({ state, raceCount: 1, xConnected: false, screen: 'menu' });
+  assert.deepEqual(active, {
+    key: 'second_race_menu',
+    screen: 'menu',
+    target: 'start_game',
+    hook: 'Play again and get +100 silver'
+  });
+});
+
+test('resolveActiveOnboarding does not return second-race keys when status is skip or complete', () => {
+  const skipped = baseState();
+  skipped.onboarding.set('second_race_menu', {
+    ...skipped.onboarding.get('second_race_menu'),
+    status: 'skip'
+  });
+  const activeMenu = resolveActiveOnboarding({ state: skipped, raceCount: 1, xConnected: false, screen: 'menu' });
+  assert.equal(activeMenu, null);
+
+  const completed = baseState();
+  completed.onboarding.set('second_race_game_over', {
+    ...completed.onboarding.get('second_race_game_over'),
+    status: 'complete'
+  });
+  const activeGameOver = resolveActiveOnboarding({ state: completed, raceCount: 1, xConnected: false, screen: 'game-over' });
+  assert.equal(activeGameOver, null);
+});


### PR DESCRIPTION
### Motivation
- Ensure `GET /api/onboarding/state` behavior for users with exactly one completed run (second-race flow) is covered by tests and locked down by assertions.
- Improve observability for onboarding selection decisions by recording full onboarding statuses alongside identity, screen, race count, selected key and the reason when no active onboarding is chosen.

### Description
- Add `onboardingStatuses: response.onboarding` to the diagnostics payload logged in `routes/onboarding.js` for the `GET /api/onboarding/state` endpoint.
- Add unit tests in `tests/onboarding.service.test.js` asserting that `resolveActiveOnboarding` returns `second_race_game_over` for `raceCount: 1` on the `game-over` screen, returns `second_race_menu` for `raceCount: 1` on the `menu` screen, and does not return those keys when their status is `skip` or `complete`.
- No functional behavior was changed besides adding logging and test coverage.

### Testing
- Ran `node --test tests/onboarding.service.test.js` and all tests in that file passed (6 passed, 0 failed).
- Ran `npm test -- tests/onboarding.service.test.js` which exercised the broader test suite; the new tests ran but the full suite includes unrelated pre-existing failures outside the scope of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a02520aa16483268fdf098e634ff564)