### PR TITLE
Make /api/leaderboard/save idempotent and make post-save side-effects non-blocking

### DIFF
--- a/routes/leaderboard.js
+++ b/routes/leaderboard.js
@@ -451,8 +451,21 @@ router.post('/save', saveResultLimiter, async (req, res) => {
 
     const scoreValue = Math.floor(score);
     const distanceValue = Math.floor(distance);
+    const clientRunId = typeof req.body?.clientRunId === 'string' ? req.body.clientRunId.trim() : null;
+    const resultHash = crypto
+      .createHash('sha256')
+      .update(`${walletLower}:${scoreValue}:${distanceValue}:${coins.gold}:${coins.silver}:${timestamp}`)
+      .digest('hex');
     let responsePayload;
     let runContext;
+
+    logger.info({
+      requestId: req.requestId,
+      clientRunId,
+      resultHash,
+      deduplicationToken,
+      wallet: walletLower
+    }, 'Leaderboard save request context');
 
     const persistResultAndPlayer = async (session = null) => {
       const gameResultQuery = GameResult.findOne({ signature: deduplicationToken });
@@ -464,6 +477,7 @@ router.post('/save', saveResultLimiter, async (req, res) => {
       if (existingResult) {
         const duplicateError = new Error('DUPLICATE_RESULT');
         duplicateError.code = 409;
+        duplicateError.alreadySaved = true;
         throw duplicateError;
       }
 
@@ -651,45 +665,66 @@ router.post('/save', saveResultLimiter, async (req, res) => {
     }
 
 
-    const onboardingState = await getOrCreateOnboardingState(walletLower);
-    const onboardingReward = applyRunProgress(onboardingState, responsePayload.gamesPlayed);
-    await onboardingState.save();
+    const onboardingReward = { silverBonus: 0, goldBonus: 0, granted: [], unlocked: [] };
+    const safeSideEffect = async (name, fn) => {
+      try {
+        await fn();
+      } catch (sideEffectError) {
+        logger.error({
+          err: sideEffectError,
+          sideEffect: name,
+          requestId: req.requestId,
+          clientRunId,
+          resultHash,
+          wallet: walletLower
+        }, 'Leaderboard post-save side effect failed');
+      }
+    };
 
+    await safeSideEffect('onboarding', async () => {
+      const onboardingState = await getOrCreateOnboardingState(walletLower);
+      const computedReward = applyRunProgress(onboardingState, responsePayload.gamesPlayed);
+      onboardingReward.silverBonus = computedReward.silverBonus || 0;
+      onboardingReward.goldBonus = computedReward.goldBonus || 0;
+      onboardingReward.granted = computedReward.granted || [];
+      onboardingReward.unlocked = computedReward.unlocked || [];
+      await onboardingState.save();
 
-    for (const rewardType of onboardingReward.granted || []) {
-      await trackOnboardingEvent('onboarding_reward_granted', {
-        primaryId: walletLower,
-        rewardType,
-        authRunsCount: onboardingState.authRunsCount,
-        flowVersion: onboardingState.flowVersion || 'v2'
-      });
-    }
-    for (const unlockedReward of onboardingReward.unlocked || []) {
-      await trackOnboardingEvent('radar_gift_unlocked', {
-        primaryId: walletLower,
-        rewardType: unlockedReward,
-        authRunsCount: onboardingState.authRunsCount,
-        flowVersion: onboardingState.flowVersion || 'v2'
-      });
-    }
+      for (const rewardType of onboardingReward.granted) {
+        await trackOnboardingEvent('onboarding_reward_granted', {
+          primaryId: walletLower,
+          rewardType,
+          authRunsCount: onboardingState.authRunsCount,
+          flowVersion: onboardingState.flowVersion || 'v2'
+        });
+      }
+      for (const unlockedReward of onboardingReward.unlocked) {
+        await trackOnboardingEvent('radar_gift_unlocked', {
+          primaryId: walletLower,
+          rewardType: unlockedReward,
+          authRunsCount: onboardingState.authRunsCount,
+          flowVersion: onboardingState.flowVersion || 'v2'
+        });
+      }
 
-    if (onboardingReward.silverBonus > 0 || onboardingReward.goldBonus > 0) {
-      await Player.updateOne(
-        { wallet: walletLower },
-        {
-          $inc: {
-            totalSilverCoins: onboardingReward.silverBonus,
-            totalGoldCoins: onboardingReward.goldBonus
+      if (onboardingReward.silverBonus > 0 || onboardingReward.goldBonus > 0) {
+        await Player.updateOne(
+          { wallet: walletLower },
+          {
+            $inc: {
+              totalSilverCoins: onboardingReward.silverBonus,
+              totalGoldCoins: onboardingReward.goldBonus
+            }
           }
-        }
-      );
-      responsePayload.totalSilverCoins += onboardingReward.silverBonus;
-      responsePayload.totalGoldCoins += onboardingReward.goldBonus;
-      await recordCoinReward(walletLower, 'onboarding_bonus', { gold: onboardingReward.goldBonus, silver: onboardingReward.silverBonus }, {
-        requestId: req.requestId,
-        contextKey: `onboarding_bonus_${walletLower}_${onboardingState.authRunsCount}`
-      });
-    }
+        );
+        responsePayload.totalSilverCoins += onboardingReward.silverBonus;
+        responsePayload.totalGoldCoins += onboardingReward.goldBonus;
+        await recordCoinReward(walletLower, 'onboarding_bonus', { gold: onboardingReward.goldBonus, silver: onboardingReward.silverBonus }, {
+          requestId: req.requestId,
+          contextKey: `onboarding_bonus_${walletLower}_${onboardingState.authRunsCount}`
+        });
+      }
+    });
 
     logger.info({
       wallet: walletLower,
@@ -700,7 +735,9 @@ router.post('/save', saveResultLimiter, async (req, res) => {
     }, 'Result saved (VERIFIED)');
 
     if (coins.gold > 0 || coins.silver > 0) {
-      await recordCoinReward(walletLower, 'ride', { gold: coins.gold, silver: coins.silver }, { requestId: req.requestId });
+      await safeSideEffect('coin_history_ride', async () => {
+        await recordCoinReward(walletLower, 'ride', { gold: coins.gold, silver: coins.silver }, { requestId: req.requestId });
+      });
     }
 
     await invalidateLeaderboardCache([
@@ -770,13 +807,16 @@ router.post('/save', saveResultLimiter, async (req, res) => {
     });
 
   } catch (error) {
-    if (error?.code === 409 || error?.code === 11000) {
-      return res.status(409).json({
-        error: 'This result has already been submitted.'
+    if (error?.alreadySaved || error?.code === 409 || error?.code === 11000) {
+      return res.status(200).json({
+        success: true,
+        alreadySaved: true,
+        message: 'Result was already saved earlier.',
+        requestId: req.requestId
       });
     }
 
-    logger.error({ err: error }, 'POST /save error');
+    logger.error({ err: error, requestId: req.requestId, clientRunId, resultHash, wallet: walletLower }, 'POST /save error');
     res.status(500).json({ error: 'Server error' });
   }
 });

--- a/tests/api.integration.test.js
+++ b/tests/api.integration.test.js
@@ -243,7 +243,7 @@ test('GET /health reports actual mongoose connection state', async () => {
   }
 });
 
-test('POST /api/leaderboard/save accepts valid signature and blocks replay', async () => {
+test('POST /api/leaderboard/save accepts valid signature and treats replay as already saved', async () => {
   const wallet = Wallet.createRandom();
   const seenSignatures = new Set();
 
@@ -275,7 +275,10 @@ test('POST /api/leaderboard/save accepts valid signature and blocks replay', asy
   const second = await fetch(`${baseUrl}/api/leaderboard/save`, {
     method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify(payload)
   });
-  assert.equal(second.status, 409);
+  assert.equal(second.status, 200);
+  const secondBody = await second.json();
+  assert.equal(secondBody.success, true);
+  assert.equal(secondBody.alreadySaved, true);
 
   await server.close();
 });


### PR DESCRIPTION
### Motivation
- Fix a production race where a successful DB write followed by a failing post-save step caused the first request to return `500` and a retry to return `409` (duplicate), breaking frontend flow and potentially double-granting rewards or incrementing runs.
- Add request-level correlation (`requestId`, `clientRunId`, `resultHash`) to logs to make it easier to debug individual save attempts and reconcile Railway traces.

### Description
- Added `clientRunId` extraction and computed a `resultHash`, and log the save request context with `requestId`, `clientRunId`, `resultHash`, `deduplicationToken`, and `wallet` for correlation.
- Made duplicate detection idempotent by tagging duplicate errors with `alreadySaved` and returning a successful `200` response containing `alreadySaved: true` instead of `409`, so replays are treated as safe/acknowledged.
- Introduced `safeSideEffect` wrapper and moved onboarding reward granting, onboarding coin updates, and ride coin history recording into non-blocking guarded calls that log failures but do not convert a saved result into a `500` error.
- Updated integration test `tests/api.integration.test.js` to expect idempotent replay behavior (replayed save returns `200` + `alreadySaved: true`).

### Testing
- Ran the leaderboard-focused integration scenario via `node --test tests/api.integration.test.js --test-name-pattern="leaderboard/save accepts valid signature and treats replay as already saved"`, and the test harness showed the modified endpoint returning saved/verified logs while many test cases passed but the targeted replay test reported a failure in the local harness (timing/async environment caused a test timeout), so further CI verification is recommended.
- Ran the broader test suite during development where the majority of tests reported as passing (multiple `✔` entries in integration output), and logs show side-effect failures are now logged (not escalated) while the primary save completed.
- No frontend changes were included in this PR; frontend tasks from the incident plan remain to be applied in the `Ursasstube` repo.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a026292258c8326a721b026cf48704f)