### PR TITLE
Add onboarding_bonus CoinTransaction and make leaderboard save resilient to history errors

### DIFF
--- a/models/CoinTransaction.js
+++ b/models/CoinTransaction.js
@@ -1,11 +1,13 @@
 const mongoose = require('mongoose');
 
-const COIN_TRANSACTION_TYPES = ['share', 'ride', 'buy', 'referral', 'refer', 'task'];
+const COIN_TRANSACTION_TYPES = ['share', 'ride', 'buy', 'referral', 'refer', 'task', 'onboarding_bonus'];
+const ONBOARDING_BONUS_REASONS = ['second_race_bonus', 'third_race_bonus'];
 
 const coinTransactionSchema = new mongoose.Schema({
   primaryId: { type: String, required: true, index: true, trim: true, lowercase: true },
   type: { type: String, required: true, enum: COIN_TRANSACTION_TYPES },
   contextKey: { type: String, default: null, index: true },
+  reason: { type: String, default: null, enum: [...ONBOARDING_BONUS_REASONS, null] },
   gold: { type: Number, required: true, min: 0, default: 0 },
   silver: { type: Number, required: true, min: 0, default: 0 },
   createdAt: { type: Date, default: Date.now, index: true }
@@ -24,3 +26,4 @@ coinTransactionSchema.pre('validate', function(next) {
 
 module.exports = mongoose.models.CoinTransaction || mongoose.model('CoinTransaction', coinTransactionSchema);
 module.exports.COIN_TRANSACTION_TYPES = COIN_TRANSACTION_TYPES;
+module.exports.ONBOARDING_BONUS_REASONS = ONBOARDING_BONUS_REASONS;

--- a/routes/leaderboard.js
+++ b/routes/leaderboard.js
@@ -651,44 +651,56 @@ router.post('/save', saveResultLimiter, async (req, res) => {
     }
 
 
-    const onboardingState = await getOrCreateOnboardingState(walletLower);
-    const onboardingReward = applyRunProgress(onboardingState, responsePayload.gamesPlayed);
-    await onboardingState.save();
+    let onboardingReward = { silverBonus: 0, goldBonus: 0, granted: [], unlocked: [] };
+    try {
+      const onboardingState = await getOrCreateOnboardingState(walletLower);
+      onboardingReward = applyRunProgress(onboardingState, responsePayload.gamesPlayed);
+      await onboardingState.save();
 
+      for (const rewardType of onboardingReward.granted || []) {
+        await trackOnboardingEvent('onboarding_reward_granted', {
+          primaryId: walletLower,
+          rewardType,
+          authRunsCount: onboardingState.authRunsCount,
+          flowVersion: onboardingState.flowVersion || 'v2'
+        });
+      }
+      for (const unlockedReward of onboardingReward.unlocked || []) {
+        await trackOnboardingEvent('radar_gift_unlocked', {
+          primaryId: walletLower,
+          rewardType: unlockedReward,
+          authRunsCount: onboardingState.authRunsCount,
+          flowVersion: onboardingState.flowVersion || 'v2'
+        });
+      }
 
-    for (const rewardType of onboardingReward.granted || []) {
-      await trackOnboardingEvent('onboarding_reward_granted', {
-        primaryId: walletLower,
-        rewardType,
-        authRunsCount: onboardingState.authRunsCount,
-        flowVersion: onboardingState.flowVersion || 'v2'
-      });
-    }
-    for (const unlockedReward of onboardingReward.unlocked || []) {
-      await trackOnboardingEvent('radar_gift_unlocked', {
-        primaryId: walletLower,
-        rewardType: unlockedReward,
-        authRunsCount: onboardingState.authRunsCount,
-        flowVersion: onboardingState.flowVersion || 'v2'
-      });
-    }
-
-    if (onboardingReward.silverBonus > 0 || onboardingReward.goldBonus > 0) {
-      await Player.updateOne(
-        { wallet: walletLower },
-        {
-          $inc: {
-            totalSilverCoins: onboardingReward.silverBonus,
-            totalGoldCoins: onboardingReward.goldBonus
+      if (onboardingReward.silverBonus > 0 || onboardingReward.goldBonus > 0) {
+        await Player.updateOne(
+          { wallet: walletLower },
+          {
+            $inc: {
+              totalSilverCoins: onboardingReward.silverBonus,
+              totalGoldCoins: onboardingReward.goldBonus
+            }
           }
-        }
-      );
-      responsePayload.totalSilverCoins += onboardingReward.silverBonus;
-      responsePayload.totalGoldCoins += onboardingReward.goldBonus;
-      await recordCoinReward(walletLower, 'onboarding_bonus', { gold: onboardingReward.goldBonus, silver: onboardingReward.silverBonus }, {
-        requestId: req.requestId,
-        contextKey: `onboarding_bonus_${walletLower}_${onboardingState.authRunsCount}`
-      });
+        );
+        responsePayload.totalSilverCoins += onboardingReward.silverBonus;
+        responsePayload.totalGoldCoins += onboardingReward.goldBonus;
+
+        const onboardingReason = onboardingState.authRunsCount === 2
+          ? 'second_race_bonus'
+          : onboardingState.authRunsCount === 3
+            ? 'third_race_bonus'
+            : null;
+
+        await recordCoinReward(walletLower, 'onboarding_bonus', { gold: onboardingReward.goldBonus, silver: onboardingReward.silverBonus }, {
+          requestId: req.requestId,
+          contextKey: `onboarding_bonus_${walletLower}_${onboardingState.authRunsCount}`,
+          reason: onboardingReason
+        });
+      }
+    } catch (onboardingErr) {
+      logger.error({ err: onboardingErr, wallet: walletLower, requestId: req.requestId }, 'Onboarding reward side effects failed after leaderboard result persisted');
     }
 
     logger.info({

--- a/utils/coinHistory.js
+++ b/utils/coinHistory.js
@@ -30,6 +30,7 @@ async function recordCoinReward(primaryId, type, amounts = {}, opts = {}) {
       primaryId: normalizedPrimaryId,
       type,
       contextKey: opts.contextKey || null,
+      reason: opts.reason || null,
       gold,
       silver,
       createdAt: opts.createdAt || new Date()


### PR DESCRIPTION
### Motivation
- Fix a production crash where `CoinTransaction` schema rejected `type: 'onboarding_bonus'` and caused `POST /api/leaderboard/save` to return 500 after a verified result was already persisted. 
- Ensure onboarding reward side effects (analytics, onboarding state save, coin history write) do not break core leaderboard result and raceCount persistence. 
- Record provenance for onboarding bonuses so second/third run bonuses can be audited and remain idempotent. 

### Description
- Added `onboarding_bonus` to the `CoinTransaction` enum and introduced `ONBOARDING_BONUS_REASONS` (`second_race_bonus`, `third_race_bonus`) in `models/CoinTransaction.js`. 
- Added optional `reason` metadata to the `CoinTransaction` schema and exported the new constants. 
- Extended `utils/coinHistory.js` (`recordCoinReward`) to persist `reason` when provided and preserve existing idempotency by checking `contextKey`. 
- Wrapped onboarding side effects in `routes/leaderboard.js` inside a safe `try/catch`, mapping `authRunsCount` to onboarding `reason`, logging errors, and continuing the successful leaderboard response so result persistence is never rolled back by history failures. 

### Testing
- Ran targeted tests `node --test tests/coinHistory.test.js tests/onboarding.service.test.js`, and all targeted tests passed. 
- When running the broader `npm test` script earlier, one unrelated integration test path hit test-environment transaction behavior and produced a failure, while the onboarding/coin-history tests remained green.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a026450268c832699d6dd169cd816f3)