### PR TITLE
Fix Share Result onboarding to use player-menu fallback

### DIFF
--- a/routes/onboarding.js
+++ b/routes/onboarding.js
@@ -24,6 +24,10 @@ function explainNoActiveOnboarding({ screen, raceCount, xConnected, onboarding }
     if (raceCount === 1 && onboarding.second_race_menu !== 'none') return `second_race_menu_status_${onboarding.second_race_menu}`;
     if (raceCount === 2 && onboarding.third_race_menu !== 'none') return `third_race_menu_status_${onboarding.third_race_menu}`;
   }
+  if (screen === 'player-menu') {
+    if (raceCount >= 3 && xConnected) return 'x_connected';
+    if (raceCount >= 3 && onboarding.share_result_player_menu !== 'none') return `share_result_player_menu_status_${onboarding.share_result_player_menu}`;
+  }
   if (screen === 'game-over') {
     if (raceCount === 1 && onboarding.second_race_game_over !== 'none') return `second_race_game_over_status_${onboarding.second_race_game_over}`;
     if (raceCount === 2 && onboarding.third_race_game_over !== 'none') return `third_race_game_over_status_${onboarding.third_race_game_over}`;

--- a/services/onboardingService.js
+++ b/services/onboardingService.js
@@ -13,7 +13,7 @@ const ONBOARDING_KEYS = [
   'third_race_game_over',
   'third_race_menu',
   'share_result_game_over',
-  'share_result_menu',
+  'share_result_player_menu',
   'store_start',
   'store_in',
   'gift_radar_obstacles_menu',
@@ -140,6 +140,7 @@ function applyRunProgress(state, raceCount) {
 function resolveActiveOnboarding({ state, raceCount, xConnected, screen }) {
   const isMenu = screen === 'menu';
   const isGameOver = screen === 'game-over';
+  const isPlayerMenu = screen === 'player-menu';
   const isStore = screen === 'store';
 
   if (raceCount === 0 && getStatus(state, 'first_race') === 'none' && isMenu) return { key: 'first_race', screen: 'menu', target: 'start_game', hook: 'Start your first race' };
@@ -148,7 +149,7 @@ function resolveActiveOnboarding({ state, raceCount, xConnected, screen }) {
   if (raceCount === 2 && isGameOver && getStatus(state, 'third_race_game_over') === 'none') return { key: 'third_race_game_over', screen: 'game-over', target: 'play_again', hook: 'Play again and get +100 gold' };
   if (raceCount === 2 && isMenu && getStatus(state, 'third_race_menu') === 'none') return { key: 'third_race_menu', screen: 'menu', target: 'start_game', hook: 'Play again and get +100 gold' };
   if (raceCount >= 3 && !xConnected && isGameOver && getStatus(state, 'share_result_game_over') === 'none') return { key: 'share_result_game_over', screen: 'game-over', target: 'connect_x_or_share_result', hook: 'Share your result and get a bonus' };
-  if (raceCount >= 3 && !xConnected && isMenu && getStatus(state, 'share_result_menu') === 'none') return { key: 'share_result_menu', screen: 'menu', target: 'connect_x_or_share_result', hook: 'Connect X and get a bonus' };
+  if (raceCount >= 3 && !xConnected && isPlayerMenu && getStatus(state, 'share_result_player_menu') === 'none') return { key: 'share_result_player_menu', screen: 'player-menu', target: 'player_menu_connect_x', hook: 'Connect X and get a bonus' };
   if (raceCount >= 3 && isMenu && getStatus(state, 'store_start') === 'none') return { key: 'store_start', screen: 'menu', target: 'store_button', hook: 'Open Store to upgrade your runs' };
   if (raceCount >= 3 && isStore && getStatus(state, 'store_in') === 'none') return { key: 'store_in', screen: 'store', target: 'ride_pack_plus3', hook: 'Upgrade with +3 rides pack' };
   if (raceCount >= 6 && !state.gifts.radarObstacles.claimed && isMenu && getStatus(state, 'gift_radar_obstacles_menu') === 'none') return { key: 'gift_radar_obstacles_menu', screen: 'menu', target: 'gift_icon', hook: 'Free radar obstacles 24h gift' };

--- a/tests/onboarding.service.test.js
+++ b/tests/onboarding.service.test.js
@@ -76,3 +76,32 @@ test('resolveActiveOnboarding does not return second-race keys when status is sk
   const activeGameOver = resolveActiveOnboarding({ state: completed, raceCount: 1, xConnected: false, screen: 'game-over' });
   assert.equal(activeGameOver, null);
 });
+
+test('resolveActiveOnboarding never returns share result onboarding on menu screen', () => {
+  const state = baseState();
+  const active = resolveActiveOnboarding({ state, raceCount: 3, xConnected: false, screen: 'menu' });
+  assert.notEqual(active?.key, 'share_result_game_over');
+  assert.notEqual(active?.key, 'share_result_player_menu');
+});
+
+test('resolveActiveOnboarding returns share_result_player_menu on player-menu for 3+ runs and disconnected X', () => {
+  const state = baseState();
+  const active = resolveActiveOnboarding({ state, raceCount: 3, xConnected: false, screen: 'player-menu' });
+  assert.deepEqual(active, {
+    key: 'share_result_player_menu',
+    screen: 'player-menu',
+    target: 'player_menu_connect_x',
+    hook: 'Connect X and get a bonus'
+  });
+});
+
+test('resolveActiveOnboarding still returns share_result_game_over on game-over for 3+ runs and disconnected X', () => {
+  const state = baseState();
+  const active = resolveActiveOnboarding({ state, raceCount: 3, xConnected: false, screen: 'game-over' });
+  assert.deepEqual(active, {
+    key: 'share_result_game_over',
+    screen: 'game-over',
+    target: 'connect_x_or_share_result',
+    hook: 'Share your result and get a bonus'
+  });
+});


### PR DESCRIPTION
### Motivation
- The share-result onboarding was shown on the main `menu` screen via `share_result_menu`, causing Connect X onboarding to appear in the wrong location.
- The intended UX is to never show share-result on the main menu and instead provide a fallback inside the Player Menu (`player-menu`).

### Description
- Replaced `share_result_menu` with `share_result_player_menu` in `ONBOARDING_KEYS` and onboarding state initialization in `services/onboardingService.js`.
- Updated `resolveActiveOnboarding` to recognize `screen === 'player-menu'` and return `share_result_player_menu` (with `target: 'player_menu_connect_x'` and `hook: 'Connect X and get a bonus'`) while keeping `share_result_game_over` behavior for `screen === 'game-over'` unchanged.
- Updated `routes/onboarding.js` `explainNoActiveOnboarding` to add `player-menu` handling and to report `share_result_player_menu` status separately from `share_result_game_over`.
- Added unit tests in `tests/onboarding.service.test.js` to assert that `menu` never returns share-result onboarding, `player-menu` returns `share_result_player_menu` when eligible, and `game-over` share-result still works.

### Testing
- Ran `node --test tests/onboarding.service.test.js` and all tests passed (`9` tests, `0` failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a026797b4348326859d9d051f91faa5)