### PR TITLE
Fix backend crash by removing unresolved merge markers in leaderboard route

### DIFF
--- a/routes/leaderboard.js
+++ b/routes/leaderboard.js
@@ -665,15 +665,6 @@ router.post('/save', saveResultLimiter, async (req, res) => {
     }
 
 
-<<<<<<< codex/fix-onboarding-bonus-validation-crash
-    let onboardingReward = { silverBonus: 0, goldBonus: 0, granted: [], unlocked: [] };
-    try {
-      const onboardingState = await getOrCreateOnboardingState(walletLower);
-      onboardingReward = applyRunProgress(onboardingState, responsePayload.gamesPlayed);
-      await onboardingState.save();
-
-      for (const rewardType of onboardingReward.granted || []) {
-=======
     const onboardingReward = { silverBonus: 0, goldBonus: 0, granted: [], unlocked: [] };
     const safeSideEffect = async (name, fn) => {
       try {
@@ -700,7 +691,6 @@ router.post('/save', saveResultLimiter, async (req, res) => {
       await onboardingState.save();
 
       for (const rewardType of onboardingReward.granted) {
->>>>>>> dev
         await trackOnboardingEvent('onboarding_reward_granted', {
           primaryId: walletLower,
           rewardType,
@@ -708,11 +698,7 @@ router.post('/save', saveResultLimiter, async (req, res) => {
           flowVersion: onboardingState.flowVersion || 'v2'
         });
       }
-<<<<<<< codex/fix-onboarding-bonus-validation-crash
-      for (const unlockedReward of onboardingReward.unlocked || []) {
-=======
       for (const unlockedReward of onboardingReward.unlocked) {
->>>>>>> dev
         await trackOnboardingEvent('radar_gift_unlocked', {
           primaryId: walletLower,
           rewardType: unlockedReward,
@@ -733,7 +719,6 @@ router.post('/save', saveResultLimiter, async (req, res) => {
         );
         responsePayload.totalSilverCoins += onboardingReward.silverBonus;
         responsePayload.totalGoldCoins += onboardingReward.goldBonus;
-<<<<<<< codex/fix-onboarding-bonus-validation-crash
 
         const onboardingReason = onboardingState.authRunsCount === 2
           ? 'second_race_bonus'
@@ -747,17 +732,7 @@ router.post('/save', saveResultLimiter, async (req, res) => {
           reason: onboardingReason
         });
       }
-    } catch (onboardingErr) {
-      logger.error({ err: onboardingErr, wallet: walletLower, requestId: req.requestId }, 'Onboarding reward side effects failed after leaderboard result persisted');
-    }
-=======
-        await recordCoinReward(walletLower, 'onboarding_bonus', { gold: onboardingReward.goldBonus, silver: onboardingReward.silverBonus }, {
-          requestId: req.requestId,
-          contextKey: `onboarding_bonus_${walletLower}_${onboardingState.authRunsCount}`
-        });
-      }
     });
->>>>>>> dev
 
     logger.info({
       wallet: walletLower,


### PR DESCRIPTION
### Motivation
- The backend was failing to start due to unresolved Git conflict markers in the leaderboard result save flow, causing a `SyntaxError` and preventing the service from booting.
- The onboarding reward side-effect flow needed a correct, non-fatal execution model so post-save side effects do not crash the main request handler.

### Description
- Removed leftover merge conflict markers and duplicated/truncated lines from `routes/leaderboard.js` in the `/save` handler onboarding reward block. 
- Restored and kept the safe side-effect wrapper `safeSideEffect` to run onboarding and coin-history post-save tasks without surfacing errors to the main flow. 
- Preserved onboarding reward computation and the `onboardingReason` tagging (`second_race_bonus` / `third_race_bonus`) when calling `recordCoinReward` so coin-history writes remain informative.
- Cleaned up the block so there are no stray conflict tokens and the control flow is syntactically correct.

### Testing
- Searched for leftover conflict markers with `rg -n "<<<<<<<|=======|>>>>>>>" routes/leaderboard.js` and verified none remain. 
- Ran `npm run check:syntax` and the syntax checker passed for all files (`Syntax check passed for 110 JavaScript files`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0269c54af88326935d54de17dff752)