### PR TITLE
Fix coin history lookup for linked wallet and Telegram accounts

### DIFF
--- a/routes/account.js
+++ b/routes/account.js
@@ -21,6 +21,7 @@ const { computeRank } = require('../services/leaderboardInsightsService');
 const { buildReferralUrl, buildCanonicalShareUrl, buildWebReferralUrl, buildTelegramReferralUrl } = require('../utils/referral');
 const { getUtcDayKey, getYesterdayUtcDayKey } = require('../utils/utcDay');
 const { findLink } = require('../middleware/requireAuth');
+const { resolveCoinHistoryIds } = require('../utils/coinHistory');
 
 const WALLET_TIMESTAMP_WINDOW_MS = Number(process.env.WALLET_AUTH_TIMESTAMP_WINDOW_MS || 10 * 60 * 1000);
 
@@ -420,8 +421,10 @@ router.get('/me/coin-history', readLimiter, requireAuth, async (req, res) => {
     const rawLimit = Number(req.query?.limit);
     const limit = Number.isFinite(rawLimit) ? Math.min(Math.max(Math.floor(rawLimit), 1), 200) : 50;
 
+    const historyIds = await resolveCoinHistoryIds({ primaryId, authLink: req.authLink });
+
     const rows = await CoinTransaction
-      .find({ primaryId })
+      .find({ primaryId: { $in: historyIds } })
       .sort({ createdAt: -1 })
       .limit(limit)
       .select('type gold silver createdAt');

--- a/tests/account-coin-history.test.js
+++ b/tests/account-coin-history.test.js
@@ -31,22 +31,24 @@ test('GET /api/account/me/coin-history - requires auth', async () => {
   }
 });
 
-test('GET /api/account/me/coin-history - returns rows with default limit', async () => {
+test('GET /api/account/me/coin-history - returns wallet-saved rows for wallet auth', async () => {
   const { server, baseUrl } = await startServer();
+  const originalFindOne = AccountLink.findOne;
+  const originalFind = CoinTransaction.find;
   try {
-    AccountLink.findOne = async (q) => (q.primaryId === 'tg_hist1'
-      ? { primaryId: 'tg_hist1', telegramId: '1', wallet: null }
-      : null);
+    AccountLink.findOne = async (q) => {
+      if (q.wallet === '0xabc') return { primaryId: '0xabc', wallet: '0xabc', telegramId: null };
+      return null;
+    };
 
     CoinTransaction.find = (query) => {
-      assert.equal(query.primaryId, 'tg_hist1');
+      assert.deepEqual(query, { primaryId: { $in: ['0xabc'] } });
       return {
         sort: () => ({
           limit: (value) => {
             assert.equal(value, 50);
             return {
               select: async () => ([
-                { type: 'share', gold: 20, silver: 0, createdAt: new Date('2026-04-28T10:00:00Z') },
                 { type: 'ride', gold: 5, silver: 3, createdAt: new Date('2026-04-28T09:00:00Z') }
               ])
             };
@@ -55,13 +57,78 @@ test('GET /api/account/me/coin-history - returns rows with default limit', async
       };
     };
 
-    const r = await get(baseUrl, '/api/account/me/coin-history', { 'X-Primary-Id': 'tg_hist1' });
+    const r = await get(baseUrl, '/api/account/me/coin-history', { 'X-Wallet': '0xAbC' });
     assert.equal(r.status, 200, JSON.stringify(r.body));
-    assert.equal(Array.isArray(r.body.items), true);
-    assert.equal(r.body.items.length, 2);
-    assert.equal(r.body.items[0].type, 'share');
-    assert.equal(r.body.items[1].silver, 3);
+    assert.equal(r.body.items.length, 1);
+    assert.equal(r.body.items[0].type, 'ride');
   } finally {
+    AccountLink.findOne = originalFindOne;
+    CoinTransaction.find = originalFind;
+    server.close();
+  }
+});
+
+test('GET /api/account/me/coin-history - returns wallet-saved rows for linked Telegram auth primaryId', async () => {
+  const { server, baseUrl } = await startServer();
+  const originalFindOne = AccountLink.findOne;
+  const originalFind = CoinTransaction.find;
+  try {
+    AccountLink.findOne = async (q) => {
+      if (q.primaryId === 'tg_777') return { primaryId: 'tg_777', wallet: '0xabc', telegramId: '777' };
+      return null;
+    };
+
+    CoinTransaction.find = (query) => {
+      assert.deepEqual(query, { primaryId: { $in: ['tg_777', '0xabc'] } });
+      return {
+        sort: () => ({
+          limit: () => ({
+            select: async () => ([
+              { type: 'onboarding_bonus', gold: 100, silver: 0, createdAt: new Date('2026-04-28T10:00:00Z') }
+            ])
+          })
+        })
+      };
+    };
+
+    const r = await get(baseUrl, '/api/account/me/coin-history', { 'X-Primary-Id': 'tg_777' });
+    assert.equal(r.status, 200, JSON.stringify(r.body));
+    assert.equal(r.body.items.length, 1);
+    assert.equal(r.body.items[0].type, 'onboarding_bonus');
+  } finally {
+    AccountLink.findOne = originalFindOne;
+    CoinTransaction.find = originalFind;
+    server.close();
+  }
+});
+
+test('GET /api/account/me/coin-history - empty history returns items array', async () => {
+  const { server, baseUrl } = await startServer();
+  const originalFindOne = AccountLink.findOne;
+  const originalFind = CoinTransaction.find;
+  try {
+    AccountLink.findOne = async (q) => {
+      if (q.primaryId === 'tg_empty') return { primaryId: 'tg_empty', wallet: null, telegramId: '555' };
+      return null;
+    };
+
+    CoinTransaction.find = (query) => {
+      assert.deepEqual(query, { primaryId: { $in: ['tg_empty'] } });
+      return {
+        sort: () => ({
+          limit: () => ({
+            select: async () => ([])
+          })
+        })
+      };
+    };
+
+    const r = await get(baseUrl, '/api/account/me/coin-history', { 'X-Primary-Id': 'tg_empty' });
+    assert.equal(r.status, 200, JSON.stringify(r.body));
+    assert.deepEqual(r.body, { items: [] });
+  } finally {
+    AccountLink.findOne = originalFindOne;
+    CoinTransaction.find = originalFind;
     server.close();
   }
 });

--- a/utils/coinHistory.js
+++ b/utils/coinHistory.js
@@ -1,5 +1,32 @@
 const CoinTransaction = require('../models/CoinTransaction');
+const AccountLink = require('../models/AccountLink');
 const logger = require('./logger');
+
+
+function normalizeId(value) {
+  return String(value || '').trim().toLowerCase();
+}
+
+function uniqueNormalizedIds(values = []) {
+  return [...new Set(values.map(normalizeId).filter(Boolean))];
+}
+
+async function resolveCoinHistoryIds({ primaryId, authLink } = {}) {
+  const fromAuth = uniqueNormalizedIds([
+    primaryId,
+    authLink?.primaryId,
+    authLink?.wallet
+  ]);
+
+  if (!authLink?.wallet && fromAuth.length > 0) {
+    const link = await AccountLink.findOne({ primaryId: fromAuth[0] });
+    if (link?.wallet) {
+      return uniqueNormalizedIds([...fromAuth, link.wallet]);
+    }
+  }
+
+  return fromAuth;
+}
 
 async function recordCoinReward(primaryId, type, amounts = {}, opts = {}) {
   const normalizedPrimaryId = String(primaryId || '').trim().toLowerCase();
@@ -43,4 +70,4 @@ async function recordCoinReward(primaryId, type, amounts = {}, opts = {}) {
   }
 }
 
-module.exports = { recordCoinReward };
+module.exports = { recordCoinReward, normalizeId, uniqueNormalizedIds, resolveCoinHistoryIds };


### PR DESCRIPTION
### Motivation
- Coin rewards are often recorded under wallet IDs (normalized lowercase) but the coin-history route only queried `req.primaryId`, causing linked wallet/Telegram accounts to see empty history.
- The goal is to resolve all possible identifiers for the authenticated account (telegram primaryId, wallet, etc.) and query transactions across them so ride rewards and onboarding bonuses reappear in the Player Menu.
- Identifiers must be normalized, deduplicated, and handled safely for wallet-only and Telegram-linked users.

### Description
- Added helpers in `utils/coinHistory.js`: `normalizeId`, `uniqueNormalizedIds`, and `resolveCoinHistoryIds` to normalize, dedupe, and resolve wallet fallbacks via `AccountLink` lookup. 
- Updated `GET /api/account/me/coin-history` in `routes/account.js` to call `resolveCoinHistoryIds({ primaryId, authLink: req.authLink })` and query `CoinTransaction.find({ primaryId: { $in: historyIds } })`. 
- Preserved existing behavior for sorting by `createdAt` descending, applying the `limit`, and returning the same response shape `{ items: [...] }`. 
- Exported the new helpers from `utils/coinHistory.js` and added tests covering wallet-auth, linked-Telegram auth resolving wallet transactions, and empty-history behavior.

### Testing
- Ran `node --test tests/account-coin-history.test.js` which includes the auth requirement test plus three coin-history scenarios, and all tests passed. 
- Tests verify wallet-saved transactions are returned for wallet-auth users, linked Telegram-primaryId users see wallet-keyed transactions, and empty history returns `{ items: [] }`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a034dd21bb08326babd4538e701fbdc)