### PR TITLE
Resolve wallet for onboarding radar boosts (linked accounts)

### DIFF
--- a/routes/onboarding.js
+++ b/routes/onboarding.js
@@ -45,6 +45,10 @@ function buildStateResponse(state, upgrades, gameplayHistory, screen) {
     xConnected: gameplayHistory.xConnected,
     screen
   });
+  const activeBoosts = {
+    radarObstaclesUntil: upgrades?.temporaryBoosts?.radarObstaclesUntil || null,
+    radarGoldUntil: upgrades?.temporaryBoosts?.radarGoldUntil || null
+  };
   return {
     completed: ONBOARDING_KEYS.every((key) => onboarding[key] !== 'none'),
     raceCount: gameplayHistory.raceCount,
@@ -59,10 +63,7 @@ function buildStateResponse(state, upgrades, gameplayHistory, screen) {
       radar_obstacles_24h: { available: gameplayHistory.raceCount >= 6, claimed: state.gifts.radarObstacles.claimed },
       radar_gold_24h: { available: gameplayHistory.raceCount >= 15, claimed: state.gifts.radarGold.claimed }
     },
-    activeBoosts: {
-      radarObstaclesUntil: upgrades?.temporaryBoosts?.radarObstaclesUntil || null,
-      radarGoldUntil: upgrades?.temporaryBoosts?.radarGoldUntil || null
-    }
+    activeBoosts
   };
 }
 
@@ -79,7 +80,8 @@ router.get('/state', readLimiter, async (req, res) => {
   if (canUseAuthOnboarding) applyRunProgress(state, gameplayHistory.raceCount);
   await state.save();
 
-  const upgrades = await PlayerUpgrades.findOne({ wallet: primaryId });
+  const upgradesWallet = identity.wallet || primaryId;
+  const upgrades = await PlayerUpgrades.findOne({ wallet: upgradesWallet });
   const screen = String(req.query?.screen || 'menu').trim();
   const response = buildStateResponse(state, upgrades, gameplayHistory, screen);
   const reason = response.activeOnboarding ? null : explainNoActiveOnboarding({
@@ -103,6 +105,7 @@ router.get('/state', readLimiter, async (req, res) => {
     xConnected: gameplayHistory.xConnected,
     onboardingStatuses: response.onboarding,
     activeOnboardingKey: response.activeOnboarding?.key || null,
+    activeBoosts: response.activeBoosts,
     reason
   }, 'Onboarding state resolved');
   return res.json(response);
@@ -131,8 +134,11 @@ router.post('/claim', async (req, res) => {
     const primaryId = resolvePrimaryIdFromRequest(req);
     if (!primaryId) return res.status(400).json({ error: 'primaryId_required' });
     const reward = String(req.body?.reward || '').trim();
+    const identity = await resolveIdentity(primaryId);
+    const wallet = identity.wallet || primaryId;
     const state = await getOrCreateOnboardingState(primaryId);
-    const claim = await claimReward({ state, primaryId, reward });
+    const claim = await claimReward({ state, primaryId, wallet, reward });
+    logger.info({ primaryId, wallet, reward, until: claim.until || null }, 'Onboarding reward claim processed');
     if (!claim.alreadyClaimed) {
       await trackOnboardingEvent('onboarding_reward_claimed', { primaryId, reward, flowVersion: state.flowVersion || 'v2' });
       await trackOnboardingEvent('radar_gift_claimed', { primaryId, reward, flowVersion: state.flowVersion || 'v2' });

--- a/services/onboardingService.js
+++ b/services/onboardingService.js
@@ -160,9 +160,14 @@ function resolveActiveOnboarding({ state, raceCount, xConnected, screen }) {
   return null;
 }
 
-async function claimReward({ state, primaryId, reward }) {
+async function claimReward({ state, primaryId, wallet, reward }) {
   if (!CLAIMABLE_REWARDS.has(reward)) throw Object.assign(new Error('unsupported_reward'), { statusCode: 400 });
-  const upgrades = await PlayerUpgrades.findOneAndUpdate({ wallet: primaryId }, { $setOnInsert: { wallet: primaryId } }, { upsert: true, new: true });
+  const normalizedWallet = String(wallet || primaryId || '').trim().toLowerCase();
+  const upgrades = await PlayerUpgrades.findOneAndUpdate(
+    { wallet: normalizedWallet },
+    { $setOnInsert: { wallet: normalizedWallet } },
+    { upsert: true, new: true }
+  );
   const until = new Date(Date.now() + 24 * 60 * 60 * 1000);
   if (reward === 'radar_obstacles_24h') {
     if (state.gifts.radarObstacles.claimed) return { alreadyClaimed: true, until: upgrades.temporaryBoosts?.radarObstaclesUntil || null };


### PR DESCRIPTION
### Motivation
- Linked/Telegram accounts used `primaryId` while `PlayerUpgrades` are keyed by `wallet`, causing successful `POST /api/onboarding/claim` to write boost timers under a different key and `GET /api/onboarding/state` to return null `activeBoosts`.
- The change ensures the same resolved wallet is used when reading and writing temporary radar boost timers so frontend timers render correctly for both wallet-only and linked users.

### Description
- In `routes/onboarding.js` GET `/state` resolve identity with `resolveIdentity(primaryId)` and use `const upgradesWallet = identity.wallet || primaryId` to query `PlayerUpgrades` so `activeBoosts` are read from the correct wallet record.
- In `routes/onboarding.js` POST `/claim` resolve identity and pass `wallet` (`identity.wallet || primaryId`) into `claimReward`, and add a claim log with `primaryId`, `wallet`, `reward`, and `until` for traceability.
- In `services/onboardingService.js` updated `claimReward` signature to accept `wallet`, normalize it, and use the normalized wallet for `PlayerUpgrades.findOneAndUpdate` so temporary boosts are persisted under the wallet key while `OnboardingState` remains keyed by `primaryId`.
- `buildStateResponse` now explicitly composes and returns `activeBoosts` with `radarObstaclesUntil` and `radarGoldUntil`, and `activeBoosts` is included in onboarding state logs to aid debugging.

### Testing
- Loaded the modified modules with `node -e "require('./routes/onboarding'); require('./services/onboardingService'); console.log('ok')"` and it printed `ok`, indicating the routes and service code load without runtime errors.
- No automated unit tests were present for this flow; integration verification expected: after claiming a radar gift the claim response includes `until` and a subsequent `GET /api/onboarding/state` returns `activeBoosts.radarObstaclesUntil` / `activeBoosts.radarGoldUntil` for both wallet-only and Telegram-linked users.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a037c8758008326b0629a4daa0cbcb0)