### PR TITLE
Handle onboarding async errors to prevent 502s and preserve CORS

### DIFF
--- a/routes/onboarding.js
+++ b/routes/onboarding.js
@@ -18,6 +18,7 @@ const {
 const { trackOnboardingEvent } = require('../services/onboardingAnalytics');
 
 const router = express.Router();
+const asyncHandler = (handler) => (req, res, next) => Promise.resolve(handler(req, res, next)).catch(next);
 
 function explainNoActiveOnboarding({ screen, raceCount, xConnected, onboarding }) {
   if (screen === 'menu') {
@@ -66,7 +67,7 @@ function buildStateResponse(state, upgrades, gameplayHistory, screen) {
   };
 }
 
-router.get('/state', readLimiter, async (req, res) => {
+router.get('/state', readLimiter, asyncHandler(async (req, res) => {
   const primaryId = resolvePrimaryIdFromRequest(req);
   if (!primaryId) return res.status(400).json({ error: 'primaryId_required' });
 
@@ -106,9 +107,9 @@ router.get('/state', readLimiter, async (req, res) => {
     reason
   }, 'Onboarding state resolved');
   return res.json(response);
-});
+}));
 
-router.post('/event', async (req, res) => {
+router.post('/event', asyncHandler(async (req, res) => {
   const primaryId = resolvePrimaryIdFromRequest(req);
   if (!primaryId) return res.status(400).json({ error: 'primaryId_required' });
   const key = String(req.body?.key || '').trim();
@@ -124,10 +125,9 @@ router.post('/event', async (req, res) => {
   const gameplayHistory = await getGameplayHistorySnapshot(primaryId);
   const upgrades = await PlayerUpgrades.findOne({ wallet: primaryId });
   return res.json({ success: true, state: buildStateResponse(state, upgrades, gameplayHistory, screen || 'menu') });
-});
+}));
 
-router.post('/claim', async (req, res) => {
-  try {
+router.post('/claim', asyncHandler(async (req, res) => {
     const primaryId = resolvePrimaryIdFromRequest(req);
     if (!primaryId) return res.status(400).json({ error: 'primaryId_required' });
     const reward = String(req.body?.reward || '').trim();
@@ -138,9 +138,6 @@ router.post('/claim', async (req, res) => {
       await trackOnboardingEvent('radar_gift_claimed', { primaryId, reward, flowVersion: state.flowVersion || 'v2' });
     }
     return res.json({ success: true, reward, ...claim });
-  } catch (error) {
-    return res.status(error.statusCode || 500).json({ error: error.message || 'claim_failed' });
-  }
-});
+}));
 
 module.exports = router;


### PR DESCRIPTION
### Motivation
- Production 502s and missing CORS headers pointed to unhandled async errors in onboarding routes that could crash request handling before global error/CORS middleware ran. 
- Ensure onboarding route promise rejections are forwarded to Express error middleware so error responses preserve CORS headers and do not surface as gateway 502s.

### Description
- Add a small `asyncHandler` wrapper in `routes/onboarding.js` and wrap `/state`, `/event`, and `/claim` handlers so rejected promises are passed to Express `next` for centralized error handling. 
- No schema changes to `PlayerUpgrades` were required as `temporaryBoosts` already exists and call sites use null-safe access patterns. 
- Verified `/api/leaderboard/save` side-effects are already isolated via `safeSideEffect(...)`, so onboarding side-effect failures are logged and do not break the save response. 
- Confirmed CORS middleware in `app.js` is mounted before routes and the global error handler re-applies CORS headers for allowed origins on error responses.

### Testing
- Ran `npm install` successfully in the workspace. 
- Ran `npm run check:syntax` and syntax check passed for project files. 
- Executed the full test run (`npm test`), which exercised many suites (many tests passed) but also showed unrelated failing/slow tests in the current branch, so targeted verification was used. 
- Ran targeted unit tests `node --test tests/onboarding.temporary-boosts.test.js tests/app-route-registry.test.js` and both passed. 
- Started the app (`npm start`) to verify startup path and saw the server boot (syntax checks passed) while the local environment showed an expected missing `MONGO_URL` that leaves the DB connection degraded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a037e089224832690cfb8fa4b9957f3)