### PR TITLE
Fix /api/leaderboard/save crash and make post-save side-effects safe

### DIFF
--- a/routes/leaderboard.js
+++ b/routes/leaderboard.js
@@ -289,6 +289,9 @@ router.get('/top', readLimiter, async (req, res) => {
 
 // ✅ POST: Save game result with signature verification
 router.post('/save', saveResultLimiter, async (req, res) => {
+  let clientRunId = null;
+  let resultHash = null;
+  let walletLower = null;
   try {
     const { wallet, score, distance, goldCoins, silverCoins, signature, timestamp, authMode, telegramId, aiSettings } = req.body;
 
@@ -308,7 +311,7 @@ router.post('/save', saveResultLimiter, async (req, res) => {
       }
     }
 
-    const walletLower = normalizeWallet(wallet);
+    walletLower = normalizeWallet(wallet);
     const aiValidation = validateAiSettings(aiSettings);
     if (!aiValidation.valid) {
       return res.status(400).json({ error: aiValidation.error });
@@ -451,8 +454,8 @@ router.post('/save', saveResultLimiter, async (req, res) => {
 
     const scoreValue = Math.floor(score);
     const distanceValue = Math.floor(distance);
-    const clientRunId = typeof req.body?.clientRunId === 'string' ? req.body.clientRunId.trim() : null;
-    const resultHash = crypto
+    clientRunId = typeof req.body?.clientRunId === 'string' ? req.body.clientRunId.trim() : null;
+    resultHash = crypto
       .createHash('sha256')
       .update(`${walletLower}:${scoreValue}:${distanceValue}:${coins.gold}:${coins.silver}:${timestamp}`)
       .digest('hex');
@@ -748,10 +751,9 @@ router.post('/save', saveResultLimiter, async (req, res) => {
       });
     }
 
-    await invalidateLeaderboardCache([
-      LEADERBOARD_CACHE_KEYS.anonymousTop,
-      LEADERBOARD_CACHE_KEYS.personalizedTop(walletLower)
-    ]);
+    await safeSideEffect('invalidate_top_cache', async () => {
+      await invalidateTopLeaderboardCache('leaderboard_save_result');
+    });
 
     // Grant referral rewards on first valid run (non-blocking, errors logged internally)
     try {
@@ -794,8 +796,6 @@ router.post('/save', saveResultLimiter, async (req, res) => {
       prevRank: runContext?.prevRank ?? null,
       isFirstRunAfterAuth: runContext?.isFirstRunAfterAuth ?? false
     });
-
-    invalidateTopLeaderboardCache('leaderboard_save_result');
 
     res.json({
       success: true,


### PR DESCRIPTION
### Motivation
- Prevent gateway 502s caused by runtime errors during `POST /api/leaderboard/save` error handling when block-scoped variables were referenced before initialization. 
- Ensure post-save side effects (onboarding, coin history, cache invalidation, referral rewards, rank updates, insights) cannot crash the main response path.
- Keep CORS middleware behavior intact so browser CORS errors no longer occur when the backend returns normally.

### Description
- Hoisted request-context variables `walletLower`, `clientRunId`, and `resultHash` to the outer scope of the `/save` handler so the `catch` block and error logger cannot throw `ReferenceError` if an error occurs early. (file: `routes/leaderboard.js`)
- Replaced direct cache-key invalidation that could be crash-prone with a safe side-effect wrapper calling `invalidateTopLeaderboardCache('leaderboard_save_result')`, ensuring cache invalidation cannot fail the response.
- Preserved and relied on existing `safeSideEffect` wrappers used for onboarding and coin-history branches; non-blocking operations (referral rewards, rank update) remain isolated in their own `try/catch` scopes.
- Verified CORS middleware is mounted before routes in `app.js` so normal Access-Control headers are applied when requests complete successfully.

### Testing
- Ran `npm test`: test suite executed; leaderboard signature and related leaderboard tests passed, one unrelated test failed (`POST /api/store/buy returns insufficient funds`) which is pre-existing and not caused by this change. (status: suite ran, one unrelated failing test)
- Started the app with `npm start` and probed health: `curl /health` returned HTTP `200`. (status: OK)
- Verified local logs show the new safe side-effect and hoisted variables are used during the save flow and top cache invalidation is invoked without crashing. (status: observed in local run logs)
- Attempt to fetch Railway logs failed because the Railway CLI is not available in this environment and `npx railway` installation is blocked by registry permissions (npm 403), so remote Railway logs could not be retrieved. (status: unavailable)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0388d9b04c8326b9450ba1ea34a9c7)