### PR TITLE
Treat duplicate leaderboard saves as idempotent success (return alreadySaved 200)

### DIFF
--- a/routes/leaderboard.js
+++ b/routes/leaderboard.js
@@ -43,6 +43,25 @@ const SHARE_COPY_TEMPLATE = 'I scored {score} in Ursass Tube 🐻\nCan you beat 
 const SHARE_HASHTAGS = '#UrsassTube #Ursas #Ursasplanet #GameChallenge #HighScore';
 const TOP_CACHE_TTL_MS = getTopLeaderboardCacheTtlMs();
 
+
+function isDuplicateSaveError(error) {
+  if (!error) return false;
+  if (error.alreadySaved || error.code === 409 || error.code === 11000) {
+    return true;
+  }
+
+  const keyPattern = error.keyPattern || {};
+  const keyValue = error.keyValue || {};
+  const duplicateKeys = new Set([
+    ...Object.keys(keyPattern),
+    ...Object.keys(keyValue)
+  ]);
+
+  return duplicateKeys.has('signature') || duplicateKeys.has('runId') ||
+    (duplicateKeys.has('wallet') && duplicateKeys.has('timestamp'));
+}
+
+
 function escapeHtml(value) {
   return String(value ?? '')
     .replace(/&/g, '&amp;')
@@ -815,7 +834,7 @@ router.post('/save', saveResultLimiter, async (req, res) => {
     });
 
   } catch (error) {
-    if (error?.alreadySaved || error?.code === 409 || error?.code === 11000) {
+    if (isDuplicateSaveError(error)) {
       return res.status(200).json({
         success: true,
         alreadySaved: true,

--- a/tests/api.integration.test.js
+++ b/tests/api.integration.test.js
@@ -283,6 +283,50 @@ test('POST /api/leaderboard/save accepts valid signature and treats replay as al
   await server.close();
 });
 
+test('POST /api/leaderboard/save returns alreadySaved on duplicate key conflict from persistence layer', async () => {
+  const wallet = Wallet.createRandom();
+
+  GameResult.findOne = () => queryResult(null);
+  let createCalls = 0;
+  GameResult.create = async () => {
+    createCalls += 1;
+    if (createCalls === 1) {
+      const err = new Error('E11000 duplicate key error collection: gameresults index: signature_1 dup key');
+      err.code = 11000;
+      err.keyPattern = { signature: 1 };
+      throw err;
+    }
+    return [];
+  };
+  Player.findOne = () => queryResult(null);
+
+  const { server, baseUrl } = await startServer();
+  const timestamp = Date.now();
+  const message = `Save game result
+Wallet: ${wallet.address}
+Score: 200
+Distance: 80
+GoldCoins: 0
+SilverCoins: 0
+Timestamp: ${timestamp}`;
+  const signature = await wallet.signMessage(message);
+
+  const res = await fetch(`${baseUrl}/api/leaderboard/save`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', origin: 'https://ursasstube.fun' },
+    body: JSON.stringify({ wallet: wallet.address, score: 200, distance: 80, signature, timestamp })
+  });
+
+  assert.equal(res.status, 200);
+  assert.equal(res.headers.get('access-control-allow-origin'), '*');
+  const body = await res.json();
+  assert.equal(body.success, true);
+  assert.equal(body.alreadySaved, true);
+
+  await server.close();
+});
+
+
 test('POST /api/store/buy returns insufficient funds', async () => {
   const wallet = Wallet.createRandom();
   const walletLower = wallet.address.toLowerCase();


### PR DESCRIPTION
### Motivation
- Client retries or racing persistence can trigger DB uniqueness errors for previously-saved runs and those errors were surfacing as 5xx, confusing frontends and breaking idempotency expectations.

### Description
- Added `isDuplicateSaveError(error)` in `routes/leaderboard.js` to classify duplicate/save-replay errors (checks `alreadySaved`, `code === 409/11000`, and `keyPattern`/`keyValue` for `signature`, `runId`, or `wallet+timestamp`).
- Updated `POST /api/leaderboard/save` error handler to return HTTP `200` with `{ success: true, alreadySaved: true }` when a duplicate save is detected so retries are treated as success and normal Express/CORS headers are preserved.
- Added an integration test `POST /api/leaderboard/save returns alreadySaved on duplicate key conflict from persistence layer` to simulate a persistence-layer duplicate-key conflict and assert the `200` response, `alreadySaved: true` body, and presence of `Access-Control-Allow-Origin` header.

### Testing
- Ran the integration subset via `npm test -- tests/api.integration.test.js -t "leaderboard/save"`, which executed leaderboard-related tests; several tests passed but there were existing unrelated timeouts/failures in this environment.
- Ran the specific new test with `node --test tests/api.integration.test.js -t "POST /api/leaderboard/save returns alreadySaved on duplicate key conflict from persistence layer"`, which executed but was marked failing in this test environment and needs follow-up to stabilize (observed in CI output).
- The existing replay-acceptance test (`POST /api/leaderboard/save accepts valid signature and treats replay as already saved`) remains in the suite to preserve and verify prior replay behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a038a3871888326affdaefd467815f7)