### PR TITLE
Fix Telegram game-over onboarding progression without wallet

### DIFF
--- a/routes/onboarding.js
+++ b/routes/onboarding.js
@@ -93,9 +93,11 @@ router.get('/state', readLimiter, asyncHandler(async (req, res) => {
   });
   logger.info({
     userId: primaryId,
+    primaryId,
     requestedPrimaryId,
-    resolvedWallet: identity.wallet || account?.wallet || null,
-    telegramId: identity.telegramId || account?.telegramId || null,
+    identity,
+    wallet: gameplayHistory.wallet || identity.wallet || account?.wallet || null,
+    telegramId: gameplayHistory.telegramId || identity.telegramId || account?.telegramId || null,
     screen,
     canUseAuthOnboarding,
     playerGamesPlayed: gameplayHistory.playerGamesPlayed,

--- a/services/onboardingService.js
+++ b/services/onboardingService.js
@@ -75,12 +75,42 @@ async function getOrCreateOnboardingState(primaryId) {
 
 async function getGameplayHistorySnapshot(primaryId) {
   const identity = await resolveIdentity(primaryId);
-  const wallet = identity.wallet;
+  const resolvedPrimaryId = identity.primaryId || null;
+  const wallet = identity.wallet || null;
+  const telegramId = identity.telegramId ? String(identity.telegramId).trim().toLowerCase() : null;
+
+  const walletCandidates = [
+    wallet,
+    resolvedPrimaryId,
+    telegramId,
+    telegramId ? `tg_${telegramId}` : null
+  ].filter(Boolean);
+  const uniqueWalletCandidates = [...new Set(walletCandidates)];
+
+  const playerQuery = [
+    wallet ? { wallet } : null,
+    resolvedPrimaryId ? { wallet: resolvedPrimaryId } : null,
+    telegramId ? { wallet: telegramId } : null,
+    telegramId ? { wallet: `tg_${telegramId}` } : null
+  ].filter(Boolean);
+
+  const playerPromise = playerQuery.length
+    ? Player.findOne({ $or: playerQuery }).sort({ xConnectedAt: -1, updatedAt: -1, createdAt: -1 }).select('gamesPlayed xConnectedAt').lean()
+    : null;
+
+  const leaderboardQuery = uniqueWalletCandidates.length
+    ? { verified: true, isValid: true, wallet: { $in: uniqueWalletCandidates } }
+    : null;
+
+  const gameResultQuery = uniqueWalletCandidates.length
+    ? { wallet: { $in: uniqueWalletCandidates } }
+    : null;
+
   const [player, leaderboardCompletedCount, gameResultCountAll, gameResultCountVerified] = await Promise.all([
-    wallet ? Player.findOne({ wallet }).select('gamesPlayed xConnected').lean() : null,
-    wallet ? PlayerRun.countDocuments({ wallet, verified: true, isValid: true }) : 0,
-    wallet ? GameResult.countDocuments({ wallet }) : 0,
-    wallet ? GameResult.countDocuments({ wallet, verified: true }) : 0
+    playerPromise,
+    leaderboardQuery ? PlayerRun.countDocuments(leaderboardQuery) : 0,
+    gameResultQuery ? GameResult.countDocuments(gameResultQuery) : 0,
+    gameResultQuery ? GameResult.countDocuments({ ...gameResultQuery, verified: true }) : 0
   ]);
 
   const playerGamesPlayed = Number(player?.gamesPlayed || 0);
@@ -88,8 +118,10 @@ async function getGameplayHistorySnapshot(primaryId) {
 
   return {
     raceCount,
-    xConnected: Boolean(player?.xConnected),
+    xConnected: Boolean(player?.xConnectedAt),
     identity,
+    wallet,
+    telegramId,
     playerGamesPlayed,
     leaderboardCompletedCount,
     gameResultCountAll,


### PR DESCRIPTION
### Motivation
- Telegram Mini App users without a linked wallet had `raceCount` stuck at 0 because onboarding history queries relied on `wallet` only, preventing `second_race_game_over`, `third_race_game_over`, and `share_result_game_over` from ever activating.

### Description
- Updated `getGameplayHistorySnapshot(primaryId)` in `services/onboardingService.js` to resolve full identity (`primaryId`, `wallet`, `telegramId`) and build a candidate identifier set for counting runs and results.
- Switched completed-run/result counting to multi-identifier queries using the candidate set (including `wallet`, `primaryId`, `telegramId`, and `tg_<telegramId>`) and `$in`-based filters against `PlayerRun` and `GameResult`.
- Changed player lookup to match any candidate identifier and derive `xConnected` from the matched player record (using `xConnectedAt`) instead of relying on wallet-only lookup.
- Added additional debug fields to onboarding logging in `routes/onboarding.js` to include `identity`, resolved `wallet`, `telegramId`, `primaryId`, and gameplay history counts for easier diagnosis.

### Testing
- Performed syntax checks: `node --check services/onboardingService.js` succeeded.
- Performed syntax checks: `node --check routes/onboarding.js` succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04a5c123d883269a116dfbb0e72c61)