### PR TITLE
Support Telegram auth for store purchases by resolving account key without wallet signature

### DIFF
--- a/routes/store.js
+++ b/routes/store.js
@@ -233,6 +233,32 @@ async function resolveStorePrimaryId(req) {
   return null;
 }
 
+
+async function resolveTelegramStoreAccountKey({ primaryId, telegramId }) {
+  const normalizedPrimaryId = String(primaryId || '').trim().toLowerCase();
+  const normalizedTelegramId = String(telegramId || '').trim();
+
+  const identifiers = [normalizedPrimaryId, normalizedTelegramId].filter(Boolean);
+  for (const identifier of identifiers) {
+    const resolvedPrimaryId = await resolvePrimaryIdFromIdentifier(identifier);
+    if (!resolvedPrimaryId) continue;
+
+    const player = await Player.findOne({ wallet: resolvedPrimaryId }).select({ wallet: 1 }).lean();
+    if (player?.wallet) {
+      return player.wallet;
+    }
+  }
+
+  if (normalizedTelegramId) {
+    const tgLink = await AccountLink.findOne({ telegramId: normalizedTelegramId }).lean();
+    if (tgLink?.primaryId) {
+      return String(tgLink.primaryId).trim().toLowerCase();
+    }
+  }
+
+  return null;
+}
+
 async function prepareUpgrades(upgrades, { persist = false } = {}) {
   const ridesChanged = upgrades.refreshFreeRides();
   const shieldChanged = normalizeShieldUpgrades(upgrades);
@@ -635,7 +661,12 @@ router.post('/buy', writeLimiter, async (req, res) => {
     if (isTelegramAuth) {
       if ((!primaryId && !telegramId) || !requestedUpgradeKey || !timestamp) {
         return res.status(400).json({
-          error: 'Missing Telegram identity'
+          error: 'telegram_identity_missing'
+        });
+      }
+      if (!telegramInitData) {
+        return res.status(400).json({
+          error: 'telegram_identity_missing'
         });
       }
     } else {
@@ -738,15 +769,14 @@ router.post('/buy', writeLimiter, async (req, res) => {
         return failPurchase(401, 'telegram_verification_failed', 'Telegram identity verification failed');
       }
 
-      const link = await AccountLink.findOne({ telegramId: verifiedTelegramId });
-      if (!link) {
-        return failPurchase(401, 'telegram_verification_failed', 'Telegram identity verification failed');
-      }
-      if (providedPrimaryId && link.primaryId !== providedPrimaryId) {
-        return failPurchase(401, 'telegram_verification_failed', 'Telegram identity verification failed');
-      }
+      accountKey = await resolveTelegramStoreAccountKey({
+        primaryId: providedPrimaryId,
+        telegramId: verifiedTelegramId
+      });
 
-      accountKey = link.wallet || link.primaryId || `tg_${verifiedTelegramId}`;
+      if (!accountKey) {
+        return failPurchase(404, 'player_not_found', 'Player not found');
+      }
     } else {
       // Signature verification
       const message = `Buy upgrade\nWallet: ${accountKey}\nUpgrade: ${requestedUpgradeKey}\nTier: ${tier !== undefined ? tier : 0}\nTimestamp: ${ts}`;


### PR DESCRIPTION
### Motivation
- Telegram-only users could not complete purchases because the store flow enforced wallet-first signature authentication and required a linked EVM wallet. 
- Purchases must resolve to the same account key used for balances/rides so Telegram purchases decrement gold/silver and update upgrades consistently.

### Description
- Modified `routes/store.js` to add `resolveTelegramStoreAccountKey` which resolves an account key from `primaryId` or `telegramId` using the same `AccountLink`/`Player` resolution used by store balance endpoints. 
- Changed `POST /api/store/buy` Telegram-mode validation to require `primaryId` or `telegramId`, `upgradeKey`, `timestamp`, and `telegramInitData`, returning `telegram_identity_missing` when not provided. 
- In Telegram auth path the code now verifies `telegramInitData` via `validateTelegramInitData`, does not require wallet signature or an EVM wallet, and sets `accountKey` via the new resolver; the wallet-auth path remains unchanged (requires `wallet`, `signature`, and `timestamp`). 
- Purchase processing now consistently uses the resolved `accountKey` for `Player.findOne`, `PlayerUpgrades.findOne` / creation, `SecurityEvent` logging, and `CoinTransaction.primaryId`, and returns clear errors `telegram_verification_failed` and `player_not_found`; existing insufficient balance errors (`insufficient_gold` / `insufficient_silver`) are preserved. 

### Testing
- Ran a syntax check `node -c routes/store.js` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04c2313b5083269b1711344a98c32c)