### PR TITLE
Improve upgrades error logging and return requestId

### DIFF
--- a/routes/store.js
+++ b/routes/store.js
@@ -576,8 +576,22 @@ router.get('/upgrades/:wallet', readLimiter, async (req, res) => {
     });
 
   } catch (error) {
-    logger.error({ err: error }, 'GET /upgrades error');
-    res.status(500).json({ error: 'Server error' });
+    logger.error({
+      route: 'GET /api/store/upgrades/:wallet',
+      requestId: req.requestId,
+      identifier: req.params.wallet,
+      errorName: error?.name,
+      errorMessage: error?.message,
+      errorCode: error?.code,
+      errorStack: error?.stack,
+      errorRaw: String(error)
+    }, 'GET /upgrades error');
+
+    res.status(error.statusCode || 500).json({
+      error: error?.message || 'Server error',
+      code: error?.code || null,
+      requestId: req.requestId || null
+    });
   }
 });
 


### PR DESCRIPTION
### Motivation
- Railway logs currently show an opaque `err: {}` for `GET /api/store/upgrades/:wallet`, hiding real exceptions and making 500s hard to debug, so structured logging plus a `requestId` in responses is needed for correlation.

### Description
- Replace the catch block in `routes/store.js` for `GET /api/store/upgrades/:wallet` to log explicit fields (`route`, `requestId`, `identifier`, `errorName`, `errorMessage`, `errorCode`, `errorStack`, `errorRaw`) and update the JSON error response to include `error`, `code`, and `requestId` while preserving `error.statusCode` when present.

### Testing
- Ran repository checks (`rg`/`sed`) to locate the handler, applied the patch and verified the `git diff` then committed the change successfully. (succeeded)
- No automated unit tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05dba0921083268a8aa527cd1839bb)