### PR TITLE
Make getOrCreatePlayerUpgrades atomic

### DIFF
--- a/routes/store.js
+++ b/routes/store.js
@@ -158,12 +158,44 @@ function parseTelegramInitDataIdentity(initDataRaw) {
 }
 
 async function getOrCreatePlayerUpgrades(wallet) {
-  let upgrades = await PlayerUpgrades.findOne({ wallet });
-  if (!upgrades) {
-    upgrades = new PlayerUpgrades({ wallet, ...NEW_PLAYER_GOLD_UPGRADE_DEFAULTS });
-    await upgrades.save();
+  const normalizedWallet = String(wallet || '').trim().toLowerCase();
+
+  if (!normalizedWallet) {
+    const err = new Error('missing_upgrade_account_key');
+    err.statusCode = 400;
+    throw err;
   }
-  return upgrades;
+
+  try {
+    return await PlayerUpgrades.findOneAndUpdate(
+      { wallet: normalizedWallet },
+      {
+        $setOnInsert: {
+          wallet: normalizedWallet,
+          ...NEW_PLAYER_GOLD_UPGRADE_DEFAULTS,
+          freeRidesRemaining: 3,
+          paidRidesRemaining: 0,
+          freeRidesResetAt: new Date(),
+          recentRideSessionIds: [],
+          temporaryBoosts: {
+            radarObstaclesUntil: null,
+            radarGoldUntil: null
+          }
+        }
+      },
+      {
+        new: true,
+        upsert: true,
+        setDefaultsOnInsert: true
+      }
+    );
+  } catch (error) {
+    if (error?.code === 11000) {
+      const existing = await PlayerUpgrades.findOne({ wallet: normalizedWallet });
+      if (existing) return existing;
+    }
+    throw error;
+  }
 }
 
 async function resolvePrimaryIdFromIdentifier(identifier) {


### PR DESCRIPTION
### Motivation
- Prevent races when multiple parallel `GET /api/store/upgrades` requests attempt to create the same `PlayerUpgrades` record, which could trigger duplicate-key errors on the unique `wallet` field.
- Ensure callers get a clear error for missing/empty account keys instead of proceeding with invalid input.

### Description
- Replaced the `getOrCreatePlayerUpgrades` implementation with an atomic `PlayerUpgrades.findOneAndUpdate(..., { upsert: true })` using `$setOnInsert` and `new: true` to insert-or-return in one DB operation.
- Added wallet normalization via `String(...).trim().toLowerCase()` and explicit validation that throws a `400` error with message `missing_upgrade_account_key` when the wallet is empty.
- Provided initial defaults in `$setOnInsert` (`freeRidesRemaining`, `paidRidesRemaining`, `freeRidesResetAt`, `recentRideSessionIds`, `temporaryBoosts`, plus `...NEW_PLAYER_GOLD_UPGRADE_DEFAULTS`).
- Added recovery for duplicate-key conflicts (`error.code === 11000`) by re-reading the existing `PlayerUpgrades` document and returning it when present.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05dc5a0310832697824a3cd6b33e6f)