### PR TITLE
Fix unsafe logger.debug usage in store upgrades route

### DIFF
--- a/routes/store.js
+++ b/routes/store.js
@@ -546,7 +546,7 @@ router.get('/upgrades/:wallet', readLimiter, async (req, res) => {
     const aiModeAccess = aiByWallet || aiByTelegramUsername;
     effects.ai_mode_access = aiModeAccess;
 
-    logger.debug({
+    logger.info({
       route: "GET /api/store/upgrades",
       identifier,
       authMode: identity.authMode,


### PR DESCRIPTION
### Motivation
- The `GET /api/store/upgrades/:wallet` route was throwing `TypeError: logger.debug is not a function` in production, causing 500 responses, so logging must not be able to crash API routes.

### Description
- Replaced the unsupported `logger.debug({...}, 'Store upgrades balance resolved')` call with `logger.info({...}, 'Store upgrades balance resolved')` in `routes/store.js` and ensured there are no remaining `logger.debug(` usages in the backend repository.

### Testing
- Ran `rg "logger\.debug\(" -n` before the change (found an occurrence) and after the change (no matches), and both checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05e0c06a988326ad4586f12d330dfc)