### PR TITLE
Guard Telegram polling with ENABLE_TELEGRAM_BOT flag

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -222,6 +222,12 @@ function scheduleBotRestart(delayMs = 5000) {
   }, delayMs);
 }
   function initBot() {
+  const isTelegramBotEnabled = String(process.env.ENABLE_TELEGRAM_BOT || '').toLowerCase() === 'true';
+  if (!isTelegramBotEnabled) {
+    console.log('Telegram bot polling skipped because ENABLE_TELEGRAM_BOT is not true');
+    return null;
+  }
+
   const token = process.env.TELEGRAM_BOT_TOKEN;
   if (!token) {
     console.warn('⚠️ TELEGRAM_BOT_TOKEN not set — bot disabled');

--- a/botWorker.js
+++ b/botWorker.js
@@ -6,6 +6,13 @@ async function startWorker() {
   try {
     await connectDB();
     console.log('🤖 Bot worker connected to DB');
+
+    const isTelegramBotEnabled = String(process.env.ENABLE_TELEGRAM_BOT || '').toLowerCase() === 'true';
+    if (!isTelegramBotEnabled) {
+      console.log('Telegram bot polling skipped because ENABLE_TELEGRAM_BOT is not true');
+      return;
+    }
+
     initBot();
   } catch (error) {
     console.error('❌ Bot worker failed to start:', error.message || error);

--- a/server.js
+++ b/server.js
@@ -28,6 +28,7 @@ logger.info(`Analytics enabled: ${telegramAnalyticsConfig.enabled}`);
 logger.info(`Analytics appName: ${telegramAnalyticsConfig.appName}`);
 
 const runBotInProcess = process.env.BOT_MODE !== 'worker' && process.env.START_BOT_IN_PROCESS !== 'false';
+const isTelegramBotEnabled = String(process.env.ENABLE_TELEGRAM_BOT || '').toLowerCase() === 'true';
 
 // Connect DB then optionally start bot in the same process
 connectDB()
@@ -37,6 +38,11 @@ connectDB()
 
     if (!runBotInProcess) {
       logger.info('BOT_MODE=worker (or START_BOT_IN_PROCESS=false): skipping bot in API process');
+      return;
+    }
+
+    if (!isTelegramBotEnabled) {
+      logger.info('Telegram bot polling skipped because ENABLE_TELEGRAM_BOT is not true');
       return;
     }
 


### PR DESCRIPTION
### Motivation
- Prevent `ETELEGRAM: 409 Conflict` errors caused by multiple simultaneous `getUpdates` pollers when Railway scales or overlapping restarts run more than one bot instance.
- Make the API safe to run without starting the Telegram poller by default and allow enabling the bot only on a single designated process.

### Description
- Add `ENABLE_TELEGRAM_BOT` check to `server.js` so the API process only calls `initBot()` when `ENABLE_TELEGRAM_BOT=true` and otherwise logs the skip.
- Add the same `ENABLE_TELEGRAM_BOT` guard to `botWorker.js` to prevent worker deployments from starting polling unless explicitly enabled.
- Add a defensive guard inside `initBot()` in `bot.js` to bail out early and log when `ENABLE_TELEGRAM_BOT` is not `true`, preventing accidental polling from any callsite.
- Emit the log message `Telegram bot polling skipped because ENABLE_TELEGRAM_BOT is not true` whenever polling is suppressed.

### Testing
- Ran syntax checks with `npm run check:syntax` and it passed for all project files.
- Ran the bot unit test with `NODE_ENV=test node --test tests/bot.test.js` and the test passed (1 passed, 0 failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a05e11562fc8326bcb5eeb2dadc0c71)