### PR TITLE
Fix leaderboard display names for Telegram-authenticated players

### DIFF
--- a/routes/leaderboard.js
+++ b/routes/leaderboard.js
@@ -44,6 +44,11 @@ const SHARE_HASHTAGS = '#UrsassTube #Ursas #Ursasplanet #GameChallenge #HighScor
 const TOP_CACHE_TTL_MS = getTopLeaderboardCacheTtlMs();
 
 
+function isValidEvmWallet(value) {
+  return /^0x[0-9a-fA-F]{40}$/.test(String(value || '').trim());
+}
+
+
 function isDuplicateSaveError(error) {
   if (!error) return false;
   if (error.alreadySaved || error.code === 409 || error.code === 11000) {
@@ -186,7 +191,7 @@ router.get('/top', readLimiter, async (req, res) => {
     const isPrimaryIdQuery = walletQuery.startsWith('tg_');
     if (walletQuery && !wallet && isPrimaryIdQuery) {
       const link = await AccountLink.findOne({
-        $or: [{ primaryId: walletQuery }, { wallet: walletQuery }]
+        $or: [{ primaryId: walletQuery }, { wallet: walletQuery }, { telegramId: walletQuery.replace(/^tg_/, '') }]
       });
       wallet = link?.primaryId || null;
     }
@@ -215,16 +220,31 @@ router.get('/top', readLimiter, async (req, res) => {
     // AccountLink.primaryId = tg_<id> (when they first logged in via TG).
     // So we search by both primaryId and wallet fields.
     const wallets = topPlayers.map(p => p.wallet).filter(Boolean);
+    const telegramIdsFromPlayers = wallets
+      .map((value) => {
+        const raw = String(value || '').trim();
+        if (!raw) return null;
+        if (raw.startsWith('tg_')) return raw.slice(3);
+        if (/^\d+$/.test(raw)) return raw;
+        return null;
+      })
+      .filter(Boolean);
+
     const links = await AccountLink.find({
       $or: [
         { primaryId: { $in: wallets } },
-        { wallet: { $in: wallets } }
+        { wallet: { $in: wallets } },
+        { telegramId: { $in: telegramIdsFromPlayers } }
       ]
     });
     const linkMap = {};
     for (const link of links) {
       if (link.primaryId) linkMap[link.primaryId] = link;
       if (link.wallet) linkMap[link.wallet] = link;
+      if (link.telegramId) {
+        linkMap[`tg_${link.telegramId}`] = link;
+        linkMap[String(link.telegramId)] = link;
+      }
     }
 
     let playerPosition = null;
@@ -234,7 +254,7 @@ router.get('/top', readLimiter, async (req, res) => {
         .select('wallet bestScore bestDistance averageScore scoreToAverageRatio totalGoldCoins totalSilverCoins gamesPlayed nickname leaderboardDisplay');
       if (playerData) {
         playerRecord = playerData;
-        const playerLink = await AccountLink.findOne({ $or: [{ primaryId: wallet }, { wallet }] });
+        const playerLink = await AccountLink.findOne({ $or: [{ primaryId: wallet }, { wallet }, { telegramId: String(wallet || '').replace(/^tg_/, '') }] });
 
         if (playerData.bestScore > 0) {
           const position = await Player.countDocuments({
@@ -247,7 +267,7 @@ router.get('/top', readLimiter, async (req, res) => {
               leaderboardDisplay: playerData.leaderboardDisplay,
               nickname: playerData.nickname,
               telegramUsername: playerLink ? playerLink.telegramUsername : null,
-              wallet: playerLink ? playerLink.wallet : null
+              wallet: playerLink?.wallet || (isValidEvmWallet(playerData.wallet) ? playerData.wallet : null)
             }),
             position + 1
           );
@@ -258,7 +278,7 @@ router.get('/top', readLimiter, async (req, res) => {
               leaderboardDisplay: playerData.leaderboardDisplay,
               nickname: playerData.nickname,
               telegramUsername: playerLink ? playerLink.telegramUsername : null,
-              wallet: playerLink ? playerLink.wallet : null
+              wallet: playerLink?.wallet || (isValidEvmWallet(playerData.wallet) ? playerData.wallet : null)
             }),
             null
           );
@@ -283,7 +303,7 @@ router.get('/top', readLimiter, async (req, res) => {
             leaderboardDisplay: player.leaderboardDisplay,
             nickname: player.nickname,
             telegramUsername: linkMap[player.wallet] ? linkMap[player.wallet].telegramUsername : null,
-            wallet: linkMap[player.wallet] ? linkMap[player.wallet].wallet : null
+            wallet: linkMap[player.wallet]?.wallet || (isValidEvmWallet(player.wallet) ? player.wallet : null)
           }),
           index + 1
         )

--- a/services/displayNamePolicyService.js
+++ b/services/displayNamePolicyService.js
@@ -3,18 +3,47 @@ function shortenWallet(wallet) {
   return `${wallet.slice(0, 6)}…${wallet.slice(-4)}`;
 }
 
+function normalizeTelegramUsername(username) {
+  return String(username || '').trim().replace(/^@/, '');
+}
+
+function resolveLeaderboardDisplayName({ nickname, wallet, telegramUsername }) {
+  const cleanNickname = String(nickname || '').trim();
+  if (cleanNickname) return cleanNickname;
+
+  const shortWallet = shortenWallet(wallet);
+  if (shortWallet) return shortWallet;
+
+  const cleanTelegram = normalizeTelegramUsername(telegramUsername);
+  if (cleanTelegram) return `@${cleanTelegram}`;
+
+  return 'Player';
+}
+
 function resolveDisplayNameFromPreferences({ leaderboardDisplay, nickname, telegramUsername, wallet }) {
-  switch (leaderboardDisplay || 'wallet') {
+  const cleanNickname = String(nickname || '').trim();
+  const shortWallet = shortenWallet(wallet);
+  const cleanTelegram = normalizeTelegramUsername(telegramUsername);
+
+  switch (leaderboardDisplay) {
     case 'nickname':
-      return nickname || shortenWallet(wallet) || (telegramUsername ? `@${telegramUsername}` : null) || 'Player';
-    case 'telegram':
-      return telegramUsername
-        ? `@${telegramUsername}`
-        : (nickname || shortenWallet(wallet) || 'Player');
+      if (cleanNickname) return cleanNickname;
+      break;
     case 'wallet':
+      if (shortWallet) return shortWallet;
+      break;
+    case 'telegram':
+      if (cleanTelegram) return `@${cleanTelegram}`;
+      break;
     default:
-      return shortenWallet(wallet) || (telegramUsername ? `@${telegramUsername}` : (nickname || 'Player'));
+      break;
   }
+
+  return resolveLeaderboardDisplayName({
+    nickname: cleanNickname,
+    wallet,
+    telegramUsername: cleanTelegram
+  });
 }
 
 function resolveDisplayNameFromLink(link, primaryId) {
@@ -45,6 +74,8 @@ function resolveDisplayNameFromLink(link, primaryId) {
 
 module.exports = {
   shortenWallet,
+  normalizeTelegramUsername,
+  resolveLeaderboardDisplayName,
   resolveDisplayNameFromPreferences,
   resolveDisplayNameFromLink
 };

--- a/utils/leaderboardTopCache.js
+++ b/utils/leaderboardTopCache.js
@@ -1,7 +1,7 @@
 const logger = require('./logger');
 
 const DEFAULT_TTL_MS = Math.max(1_000, Number(process.env.LEADERBOARD_TOP_CACHE_TTL_MS || 30_000));
-const CACHE_KEY = process.env.LEADERBOARD_TOP_CACHE_KEY || 'leaderboard:top:public:v1';
+const CACHE_KEY = process.env.LEADERBOARD_TOP_CACHE_KEY || 'leaderboard:top:public:v2';
 
 const memoryState = {
   value: null,


### PR DESCRIPTION
### Motivation
- Telegram-authenticated players were shown incorrectly on the leaderboard because Telegram primary IDs or `tg_...` values were sometimes treated as wallets and the display-name fallback order was not deterministic.

### Description
- Implemented a deterministic display-name policy `nickname > wallet > telegram username > Player` and added `normalizeTelegramUsername` to strip leading `@` and trim whitespace in `services/displayNamePolicyService.js`.
- Made `leaderboardDisplay` preference conditional so it only applies when the preferred source exists, otherwise falling back to the deterministic priority in `services/displayNamePolicyService.js`.
- Enhanced `/api/leaderboard/top` in `routes/leaderboard.js` to resolve AccountLink entries for top players by `primaryId`, `wallet`, and `telegramId`, build a robust `linkMap` (including `tg_<id>` and raw `<id>` keys), and ensure only valid EVM wallets are treated as wallets when resolving display names.
- Bumped the leaderboard top cache key from `v1` to `v2` in `utils/leaderboardTopCache.js` so stale cached payloads with old display names are invalidated.

### Testing
- Ran `NODE_ENV=test node --test tests/leaderboard-display-name.test.js` which executed 3 tests and all passed.
- Existing leaderboard-related integration tests were exercised during the run invoked from the repository test harness and did not show failures related to these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06163bc270832696d295d735fb3027)