### PR TITLE
Fix /api/share/confirm 500 and align share rewards with totalGoldCoins

### DIFF
--- a/routes/share.js
+++ b/routes/share.js
@@ -217,7 +217,7 @@ router.post('/confirm', shareConfirmLimiter, async (req, res) => {
         awarded: shareEvent.goldAwarded > 0,
         goldAwarded: shareEvent.goldAwarded,
         shareStreak: player ? player.shareStreak : 0,
-        totalGold: player ? player.gold : 0
+        totalGold: player ? player.totalGoldCoins : 0
       });
     }
 
@@ -247,7 +247,7 @@ router.post('/confirm', shareConfirmLimiter, async (req, res) => {
         awarded: false,
         reason: 'already_rewarded_today',
         shareStreak: player ? player.shareStreak : 0,
-        totalGold: player ? player.gold : 0
+        totalGold: player ? player.totalGoldCoins : 0
       });
     }
 
@@ -274,7 +274,7 @@ router.post('/confirm', shareConfirmLimiter, async (req, res) => {
         awarded: (shareEventRefreshed?.goldAwarded || 0) > 0,
         goldAwarded: shareEventRefreshed?.goldAwarded || 0,
         shareStreak: player ? player.shareStreak : 0,
-        totalGold: player ? player.gold : 0
+        totalGold: player ? player.totalGoldCoins : 0
       });
     }
 
@@ -320,8 +320,23 @@ router.post('/confirm', shareConfirmLimiter, async (req, res) => {
     });
 
   } catch (error) {
-    logger.error({ err: error }, 'POST /share/confirm error');
-    return res.status(500).json({ error: 'Server error' });
+    logger.error({
+      route: 'POST /api/share/confirm',
+      requestId: req.requestId,
+      errorName: error?.name,
+      errorMessage: error?.message,
+      errorCode: error?.code,
+      errorStack: error?.stack,
+      errorRaw: String(error),
+      body: {
+        shareId: req.body?.shareId,
+        primaryId: req.body?.primaryId
+      }
+    }, 'POST /share/confirm error');
+    return res.status(500).json({
+      error: 'Server error',
+      requestId: req.requestId
+    });
   }
 });
 

--- a/utils/goldRewards.js
+++ b/utils/goldRewards.js
@@ -18,53 +18,76 @@ async function grantGoldReward(primaryId, amount, type, contextKey, opts = {}) {
     const existing = await CoinTransaction.findOne({ contextKey: useContextKey });
     if (existing) {
       const player = await Player.findOne({ wallet: normalizedPrimaryId });
-      return { balance: player ? player.gold : null, history: existing, created: false };
+      return { balance: player ? player.totalGoldCoins : null, history: existing, created: false };
     }
   }
 
   let session = null;
+  const isTxnUnsupportedError = (error) => {
+    const message = String(error?.message || '');
+    return (
+      error?.code === 20 ||
+      error?.name === 'IllegalOperation' ||
+      message.includes('Transaction numbers are only allowed on a replica set member or mongos')
+    );
+  };
+
+  const executeRewardWork = async (session = null) => {
+    const playerQuery = Player.findOneAndUpdate(
+      { wallet: normalizedPrimaryId },
+      { $inc: { totalGoldCoins: normalizedAmount } },
+      { new: true }
+    );
+    if (session) playerQuery.session(session);
+    const updatedPlayer = await playerQuery;
+    if (!updatedPlayer) throw new Error('player_not_found');
+
+    const historyDoc = {
+      primaryId: normalizedPrimaryId,
+      type,
+      contextKey: useContextKey,
+      gold: normalizedAmount,
+      silver: 0,
+      createdAt: opts.createdAt || new Date()
+    };
+    const created = await CoinTransaction.create([historyDoc], session ? { session } : undefined);
+    const createdHistory = Array.isArray(created) ? created[0] : created;
+    return { updatedPlayer, createdHistory };
+  };
+
   try {
     if (typeof mongoose.startSession === 'function') {
       session = await mongoose.startSession();
     }
 
-    let createdHistory = null;
-    let updatedPlayer = null;
-
-    const work = async () => {
-      const playerQuery = Player.findOneAndUpdate(
-        { wallet: normalizedPrimaryId },
-        { $inc: { gold: normalizedAmount } },
-        { new: true }
-      );
-      if (session) playerQuery.session(session);
-      updatedPlayer = await playerQuery;
-      if (!updatedPlayer) throw new Error('player_not_found');
-
-      const historyDoc = {
-        primaryId: normalizedPrimaryId,
-        type,
-        contextKey: useContextKey,
-        gold: normalizedAmount,
-        silver: 0,
-        createdAt: opts.createdAt || new Date()
-      };
-      const created = await CoinTransaction.create([historyDoc], session ? { session } : undefined);
-      createdHistory = Array.isArray(created) ? created[0] : created;
-    };
+    let rewardResult = null;
 
     if (session) {
-      await session.withTransaction(work);
+      try {
+        await session.withTransaction(async () => {
+          rewardResult = await executeRewardWork(session);
+        });
+      } catch (error) {
+        if (isTxnUnsupportedError(error)) {
+          logger.warn(
+            { primaryId: normalizedPrimaryId, contextKey: useContextKey, requestId: opts.requestId, errorMessage: error?.message, errorCode: error?.code },
+            'grantGoldReward transaction unsupported; using non-transactional fallback'
+          );
+          rewardResult = await executeRewardWork();
+        } else {
+          throw error;
+        }
+      }
     } else {
-      await work();
+      rewardResult = await executeRewardWork();
     }
 
-    return { balance: updatedPlayer.gold, history: createdHistory, created: true };
+    return { balance: rewardResult.updatedPlayer.totalGoldCoins, history: rewardResult.createdHistory, created: true };
   } catch (error) {
     if (useContextKey && error && error.code === 11000) {
       const existing = await CoinTransaction.findOne({ contextKey: useContextKey });
       const player = await Player.findOne({ wallet: normalizedPrimaryId });
-      return { balance: player ? player.gold : null, history: existing, created: false };
+      return { balance: player ? player.totalGoldCoins : null, history: existing, created: false };
     }
 
     logger.error({ err: error, primaryId: normalizedPrimaryId, amount: normalizedAmount, type, contextKey: useContextKey, requestId: opts.requestId }, 'grantGoldReward failed');


### PR DESCRIPTION
### Motivation
- Share reward logic used `Player.gold` while the rest of the economy uses `Player.totalGoldCoins`, causing inconsistent balances and 500s in the confirm flow.
- Mongo transactions can be unsupported on some Railway Mongo setups which causes reward operations to fail hard instead of falling back.

### Description
- Replaced all uses of `Player.gold` with `Player.totalGoldCoins` in `utils/goldRewards.js` and `routes/share.js` so reward reads/writes use the canonical balance field.
- Updated `grantGoldReward()` to increment `{ $inc: { totalGoldCoins: amount } }`, return `balance: updatedPlayer.totalGoldCoins`, and ensure idempotent duplicate-key recovery returns `totalGoldCoins`.
- Added a transaction-unsupported detection and fallback in `grantGoldReward()` so if `withTransaction` fails due to non-replica set Mongo, the code logs a warning and runs a non-transactional fallback to apply the reward and create the history.
- Improved `/api/share/confirm` error logging to include `route`, `requestId`, detailed error metadata, and `shareId`/`primaryId`, and changed 500 responses to include `requestId` for traceability.

### Testing
- Loaded modified modules with Node using `node -e "require('./utils/goldRewards'); require('./routes/share'); console.log('ok')"` which printed `ok` indicating modules load without syntax/runtime errors.
- No other automated test suites were run in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a061f91e6948326b45ea145a9546fee)