### PR TITLE
Fix X preview: use single web URL and static 1600x800 share image

### DIFF
--- a/app.js
+++ b/app.js
@@ -31,6 +31,24 @@ function escapeHtml(value) {
     .replace(/'/g, '&#39;');
 }
 
+
+function isShareCrawler(userAgent) {
+  const normalized = String(userAgent || '').toLowerCase();
+  if (!normalized) return false;
+  const crawlerTokens = [
+    'twitterbot',
+    'facebookexternalhit',
+    'telegrambot',
+    'discordbot',
+    'slackbot',
+    'whatsapp',
+    'crawler',
+    'spider',
+    'preview'
+  ];
+  return crawlerTokens.some((token) => normalized.includes(token));
+}
+
 function getPublicBaseUrl(req) {
   const configured = (process.env.PUBLIC_BASE_URL || process.env.APP_BASE_URL || '').trim();
   if (configured) return configured.replace(/\/+$/, '');
@@ -140,6 +158,12 @@ function createApp() {
   });
 
   app.use(express.json({ limit: '1mb' }));
+  app.use('/img', express.static(path.join(__dirname, 'img'), {
+    fallthrough: false,
+    setHeaders: (res) => {
+      res.setHeader('Cache-Control', 'public, max-age=86400');
+    }
+  }));
 
 
   const enableSharePreviewPublic = String(process.env.ENABLE_SHARE_PREVIEW_PUBLIC || '').toLowerCase() === 'true';
@@ -230,25 +254,20 @@ function createApp() {
       const shareId = String(req.params.shareId || '').trim();
       const baseUrl = getPublicBaseUrl(req);
       const frontendBaseUrl = (process.env.FRONTEND_BASE_URL || 'https://ursasstube.fun').trim().replace(/\/+$/, '');
-      const isCrawler = isSocialPreviewCrawler(req.get('user-agent'));
-      const fallbackImage = `${baseUrl}/img/score_result.png`;
+      const isCrawler = isShareCrawler(req.get('user-agent'));
       const share = shareId ? await ShareEvent.findOne({ shareId }) : null;
+      const imageUrl = `${baseUrl}/img/score_result1600x800.png`;
+      const absoluteShareUrl = `${baseUrl}/share/${encodeURIComponent(shareId || 'unknown')}`;
+      const html = `<!doctype html><html lang="en"><head><meta charset="utf-8" /><meta name="viewport" content="width=device-width, initial-scale=1" /><title>URSASS TUBE</title><meta property="og:type" content="website" /><meta property="og:title" content="URSASS TUBE" /><meta property="og:description" content="Can you beat my score in Ursass Tube?" /><meta property="og:image" content="${escapeHtml(imageUrl)}" /><meta property="og:image:width" content="1600" /><meta property="og:image:height" content="800" /><meta property="og:url" content="${escapeHtml(absoluteShareUrl)}" /><meta name="twitter:card" content="summary_large_image" /><meta name="twitter:title" content="URSASS TUBE" /><meta name="twitter:description" content="Can you beat my score in Ursass Tube?" /><meta name="twitter:image" content="${escapeHtml(imageUrl)}" /></head><body><p>Play Ursass Tube</p><a href="${escapeHtml(frontendBaseUrl)}/">Open game</a></body></html>`;
+      res.setHeader('Content-Type', 'text/html; charset=utf-8');
 
-      if (!isCrawler) {
-        if (!share) return res.redirect(302, `${frontendBaseUrl}/`);
-        const refHint = share.referralCode ? `&ref_hint=${encodeURIComponent(share.referralCode)}` : '';
-        return res.redirect(302, `${frontendBaseUrl}/?utm_source=x&utm_medium=social&utm_campaign=score_share&share=${encodeURIComponent(shareId)}${refHint}`);
+      if (isCrawler) {
+        return res.status(200).send(html);
       }
 
-      const score = Math.max(0, Number(share?.scoreAtShare || 0));
-      const refCode = share?.referralCode || 'URSAS';
-      const title = share ? `I scored ${score} in Ursass Tube 🐻` : 'Play Ursass Tube 🐻';
-      const description = `Can you beat me? Use ref code ${refCode}.`;
-      const imageUrl = share?.previewImageUrl || fallbackImage;
-      const absoluteShareUrl = `${baseUrl}/share/${encodeURIComponent(shareId || 'unknown')}`;
-      const html = `<!doctype html><html lang="en"><head><meta charset="utf-8" /><meta name="viewport" content="width=device-width, initial-scale=1" /><title>${escapeHtml(title)}</title><meta property="og:type" content="website" /><meta property="og:title" content="${escapeHtml(title)}" /><meta property="og:description" content="${escapeHtml(description)}" /><meta property="og:image" content="${escapeHtml(imageUrl)}" /><meta property="og:url" content="${escapeHtml(absoluteShareUrl)}" /><meta property="og:site_name" content="Ursass Tube" /><meta name="twitter:card" content="summary_large_image" /><meta name="twitter:title" content="${escapeHtml(title)}" /><meta name="twitter:description" content="${escapeHtml(description)}" /><meta name="twitter:image" content="${escapeHtml(imageUrl)}" /><meta name="twitter:image:alt" content="Ursass Tube score card" /></head><body><p>Play Ursass Tube</p></body></html>`;
-      res.setHeader('Content-Type', 'text/html; charset=utf-8');
-      return res.status(200).send(html);
+      if (!share) return res.redirect(302, `${frontendBaseUrl}/`);
+      const refHint = share.referralCode ? `&ref_hint=${encodeURIComponent(share.referralCode)}` : '';
+      return res.status(200).send(html.replace('</body></html>', `<script>window.location.replace('${frontendBaseUrl}/?utm_source=x&utm_medium=social&utm_campaign=score_share&share=${encodeURIComponent(shareId)}${refHint}');</script></body></html>`));
     } catch (error) {
       logger.error({ err: error.message, requestId: req.requestId }, 'GET /share/:shareId error');
       return res.redirect(302, `${(process.env.FRONTEND_BASE_URL || 'https://ursasstube.fun').trim().replace(/\/+$/, '')}/`);

--- a/routes/share.js
+++ b/routes/share.js
@@ -71,17 +71,13 @@ function getPublicBaseUrl(req) {
   return `${req.protocol}://${req.get('host')}`;
 }
 
-function buildSharePostText(score, referralCode, webShareUrl, telegramShareUrl) {
+function buildSharePostText(score, referralCode, webShareUrl) {
   const normalizedScore = Math.max(0, Math.floor(Number(score || 0)));
   const parts = [
     `I scored ${normalizedScore} in Ursass Tube 🐻`,
     'Can you beat me?',
     '',
-    'Play Web:',
     webShareUrl,
-    '',
-    'Play Telegram:',
-    telegramShareUrl,
     '',
     `Get bonus — use my ref code: ${referralCode}`,
     '',
@@ -114,13 +110,11 @@ router.post('/start', shareStartLimiter, async (req, res) => {
     const baseUrl = getPublicBaseUrl(req);
     const walletAddress = link.wallet || null;
     const referralCode = player.referralCode || '';
-    const previewImageUrl = walletAddress
-      ? `${baseUrl}/api/leaderboard/share/image/${walletAddress}.png`
-      : `${baseUrl}/img/score_result.png`;
+    const previewImageUrl = `${baseUrl}/img/score_result1600x800.png`;
     const shareId = crypto.randomUUID();
     const webShareUrl = `${baseUrl}/share/${shareId}`;
     const telegramShareUrl = buildTelegramReferralUrl();
-    const postText = buildSharePostText(scoreAtShare, referralCode, webShareUrl, telegramShareUrl);
+    const postText = buildSharePostText(scoreAtShare, referralCode, webShareUrl);
     const hasConnectedXAccount = Boolean(player.xUserId);
     const shouldUsePaidXApi = shouldUseXApiShare() && hasConnectedXAccount;
     const intentUrl = shouldUsePaidXApi ? null : `https://twitter.com/intent/tweet?text=${encodeURIComponent(postText)}`;

--- a/routes/x.js
+++ b/routes/x.js
@@ -127,10 +127,19 @@ function getPublicBaseUrl(req) {
 }
 
 
-const STATIC_SHARE_IMAGE_PATH = path.join(__dirname, '..', 'img', 'score_result.png');
+const PRIMARY_STATIC_SHARE_IMAGE_PATH = path.join(__dirname, '..', 'img', 'score_result1600x800.png');
+const FALLBACK_STATIC_SHARE_IMAGE_PATH = path.join(__dirname, '..', 'img', 'score_result.png');
 
 async function loadStaticShareImagePng() {
-  return fs.readFile(STATIC_SHARE_IMAGE_PATH);
+  try {
+    return await fs.readFile(PRIMARY_STATIC_SHARE_IMAGE_PATH);
+  } catch (error) {
+    if (error && error.code === 'ENOENT') {
+      logger.warn({ missingPath: PRIMARY_STATIC_SHARE_IMAGE_PATH }, 'Primary share image missing, using fallback image');
+      return fs.readFile(FALLBACK_STATIC_SHARE_IMAGE_PATH);
+    }
+    throw error;
+  }
 }
 function buildSharePostText(score, referralUrl) {
   const normalizedScore = Math.max(0, Math.floor(Number(score || 0)));


### PR DESCRIPTION
### Motivation
- X (Twitter) composer picked the Telegram `t.me` link when multiple URLs were present, overriding the prepared share card image. 
- The intent text must contain only the public web share URL so X will render our large card image `score_result1600x800.png` (ASCII `x`).
- Crawlers need a public `/share/:shareId` HTML endpoint with proper OG/Twitter meta tags so card previews load reliably. 

### Description
- Updated `/api/share/start` (in `routes/share.js`) so `buildSharePostText` includes only `webShareUrl` and no `telegramShareUrl`, while keeping score, referral code, and hashtags. 
- Standardized returned image fields in the share response so `imageUrl` and `postImageUrl` point to `https://<host>/img/score_result1600x800.png` and `previewUrl` remains `webShareUrl`, with `intentUrl` built from the single-URL post text. 
- Added public static serving for `/img` in `app.js` so `score_result1600x800.png` is served without auth and with caching headers. 
- Implemented `GET /share/:shareId` in `app.js` to emit required OpenGraph/Twitter meta tags (including `og:image`, `og:image:width`, `og:image:height`, and `twitter:card`) pointing to the 1600x800 image, and made the route crawler-aware so bots receive the meta HTML while regular users get a landing page with client-side redirect. 
- Added `isShareCrawler` detection tokens for common preview bots and `preview` keywords so crawlers are correctly identified. 
- Updated X media upload helper in `routes/x.js` to prefer `img/score_result1600x800.png` with a fallback to `img/score_result.png` and a warning log that includes the missing primary path when fallback is used. 
- Kept `telegramShareUrl` in the `/api/share/start` JSON payload for UI use but removed it from X intent text.

### Testing
- Ran `node --check routes/share.js` and it succeeded. 
- Ran `node --check routes/x.js` and it succeeded. 
- Ran `node --check app.js` and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0628779aec83269725581468a935b5)