### PR TITLE
Generate dynamic score images for share previews

### DIFF
--- a/app.js
+++ b/app.js
@@ -165,6 +165,13 @@ function createApp() {
     }
   }));
 
+  app.use('/generated', express.static(path.join(__dirname, 'generated'), {
+    fallthrough: false,
+    setHeaders: (res) => {
+      res.setHeader('Cache-Control', 'public, max-age=31536000, immutable');
+    }
+  }));
+
 
   const enableSharePreviewPublic = String(process.env.ENABLE_SHARE_PREVIEW_PUBLIC || '').toLowerCase() === 'true';
   if (enableSharePreviewPublic) {
@@ -256,7 +263,7 @@ function createApp() {
       const frontendBaseUrl = (process.env.FRONTEND_BASE_URL || 'https://ursasstube.fun').trim().replace(/\/+$/, '');
       const isCrawler = isShareCrawler(req.get('user-agent'));
       const share = shareId ? await ShareEvent.findOne({ shareId }) : null;
-      const imageUrl = `${baseUrl}/img/score_result1600x800.png`;
+      const imageUrl = share?.previewImageUrl || `${baseUrl}/img/score_result1600x800.png`;
       const absoluteShareUrl = `${baseUrl}/share/${encodeURIComponent(shareId || 'unknown')}`;
       const html = `<!doctype html><html lang="en"><head><meta charset="utf-8" /><meta name="viewport" content="width=device-width, initial-scale=1" /><title>URSASS TUBE</title><meta property="og:type" content="website" /><meta property="og:title" content="URSASS TUBE" /><meta property="og:description" content="Can you beat my score in Ursass Tube?" /><meta property="og:image" content="${escapeHtml(imageUrl)}" /><meta property="og:image:width" content="1600" /><meta property="og:image:height" content="800" /><meta property="og:url" content="${escapeHtml(absoluteShareUrl)}" /><meta name="twitter:card" content="summary_large_image" /><meta name="twitter:title" content="URSASS TUBE" /><meta name="twitter:description" content="Can you beat my score in Ursass Tube?" /><meta name="twitter:image" content="${escapeHtml(imageUrl)}" /></head><body><p>Play Ursass Tube</p><a href="${escapeHtml(frontendBaseUrl)}/">Open game</a></body></html>`;
       res.setHeader('Content-Type', 'text/html; charset=utf-8');

--- a/routes/share.js
+++ b/routes/share.js
@@ -9,6 +9,7 @@ const { getUtcDayKey, getYesterdayUtcDayKey } = require('../utils/utcDay');
 const { buildWebReferralUrl, buildTelegramReferralUrl } = require('../utils/referral');
 const { grantGoldReward } = require('../utils/goldRewards');
 const logger = require('../utils/logger');
+const { renderShareScoreImage } = require('../utils/shareImageRenderer');
 
 const SHARE_REWARD_DELAY_MS = Number(process.env.SHARE_REWARD_DELAY_MS || 30000);
 const SHARE_DAILY_REWARD_GOLD = Number(process.env.SHARE_DAILY_REWARD_GOLD || 20);
@@ -110,7 +111,7 @@ router.post('/start', shareStartLimiter, async (req, res) => {
     const baseUrl = getPublicBaseUrl(req);
     const walletAddress = link.wallet || null;
     const referralCode = player.referralCode || '';
-    const previewImageUrl = `${baseUrl}/img/score_result1600x800.png`;
+    let previewImageUrl = `${baseUrl}/img/score_result1600x800.png`;
     const shareId = crypto.randomUUID();
     const webShareUrl = `${baseUrl}/share/${shareId}`;
     const telegramShareUrl = buildTelegramReferralUrl();
@@ -118,6 +119,13 @@ router.post('/start', shareStartLimiter, async (req, res) => {
     const hasConnectedXAccount = Boolean(player.xUserId);
     const shouldUsePaidXApi = shouldUseXApiShare() && hasConnectedXAccount;
     const intentUrl = shouldUsePaidXApi ? null : `https://twitter.com/intent/tweet?text=${encodeURIComponent(postText)}`;
+
+    try {
+      const rendered = await renderShareScoreImage({ shareId, score: scoreAtShare });
+      previewImageUrl = `${baseUrl}${rendered.relativeUrl}`;
+    } catch (renderError) {
+      logger.warn({ err: renderError?.message, shareId, requestId: req.requestId }, 'Share image render fallback to base template');
+    }
 
     await ShareEvent.create({
       primaryId,

--- a/utils/shareImageRenderer.js
+++ b/utils/shareImageRenderer.js
@@ -1,0 +1,109 @@
+const fs = require('fs');
+const path = require('path');
+let sharp;
+try { sharp = require('sharp'); } catch (_) { sharp = null; }
+
+const BASE_TEMPLATE_PATH = path.join(__dirname, '..', 'img', 'score_result1600x800.png');
+const GENERATED_DIR = path.join(__dirname, '..', 'generated', 'share-images');
+
+const SCORE_LAYOUT = {
+  x: 610,
+  y: 404,
+  width: 510,
+  height: 155,
+  fontFamily: "'Arial Black', Impact, 'Anton', sans-serif",
+  fontSizeDefault: 170,
+  fontSizeMin: 110,
+  fontSizeMax: 190,
+  letterSpacing: 1.5,
+  skewX: -8,
+  gradientStart: '#ffffff',
+  gradientEnd: '#c59bff',
+  glowColor: '#7d3cff',
+  strokeColor: '#f7ecff'
+};
+
+function clamp(value, min, max) {
+  return Math.max(min, Math.min(max, value));
+}
+
+function escapeXml(value) {
+  return String(value ?? '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function estimateWidth(text, fontSize) {
+  return text.length * fontSize * 0.62;
+}
+
+function buildSkewTransform(cx, cy, skewX) {
+  return `translate(${cx} ${cy}) skewX(${skewX}) translate(${-cx} ${-cy})`;
+}
+
+async function renderShareScoreImage({ shareId, score }) {
+  if (!sharp) {
+    const err = new Error('PNG rendering unavailable');
+    err.code = 'share_png_unavailable';
+    throw err;
+  }
+
+  if (!/^[a-zA-Z0-9_-]+$/.test(String(shareId || ''))) {
+    const err = new Error('Invalid shareId');
+    err.code = 'invalid_share_id';
+    throw err;
+  }
+
+  const normalizedScore = Math.max(0, Math.floor(Number(score || 0)));
+  const templateMeta = await sharp(BASE_TEMPLATE_PATH).metadata();
+  const width = templateMeta.width || 1600;
+  const height = templateMeta.height || 800;
+
+  const scaleX = width / 1600;
+  const scaleY = height / 800;
+  const layout = {
+    x: Math.round(SCORE_LAYOUT.x * scaleX),
+    y: Math.round(SCORE_LAYOUT.y * scaleY),
+    width: Math.round(SCORE_LAYOUT.width * scaleX),
+    height: Math.round(SCORE_LAYOUT.height * scaleY)
+  };
+
+  const scoreText = String(normalizedScore);
+  const defaultSize = SCORE_LAYOUT.fontSizeDefault * scaleY;
+  const sizeFromWidth = defaultSize * (layout.width / Math.max(estimateWidth(scoreText, defaultSize), 1));
+  const fontSize = clamp(sizeFromWidth, SCORE_LAYOUT.fontSizeMin * scaleY, SCORE_LAYOUT.fontSizeMax * scaleY);
+  const centerX = Math.round(layout.x + (layout.width / 2));
+  const centerY = Math.round(layout.y + (layout.height / 2));
+
+  const svg = Buffer.from(
+    `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}" viewBox="0 0 ${width} ${height}">` +
+      '<defs>' +
+        '<linearGradient id="scoreGradient" x1="0%" y1="0%" x2="0%" y2="100%">' +
+          `<stop offset="0%" stop-color="${SCORE_LAYOUT.gradientStart}"/>` +
+          `<stop offset="100%" stop-color="${SCORE_LAYOUT.gradientEnd}"/>` +
+        '</linearGradient>' +
+        '<filter id="scoreGlow" x="-40%" y="-40%" width="180%" height="180%">' +
+          `<feDropShadow dx="0" dy="2" stdDeviation="5" flood-color="${SCORE_LAYOUT.glowColor}" flood-opacity="0.95"/>` +
+          `<feDropShadow dx="0" dy="9" stdDeviation="8" flood-color="${SCORE_LAYOUT.glowColor}" flood-opacity="0.72"/>` +
+        '</filter>' +
+      '</defs>' +
+      `<text x="${centerX}" y="${centerY}" font-family="${SCORE_LAYOUT.fontFamily}" font-size="${Math.round(fontSize)}" font-weight="900" letter-spacing="${SCORE_LAYOUT.letterSpacing}" fill="url(#scoreGradient)" stroke="${SCORE_LAYOUT.strokeColor}" stroke-width="2" paint-order="stroke fill" dominant-baseline="middle" text-anchor="middle" filter="url(#scoreGlow)" transform="${buildSkewTransform(centerX, centerY, SCORE_LAYOUT.skewX)}">${escapeXml(scoreText)}</text>` +
+    '</svg>'
+  );
+
+  fs.mkdirSync(GENERATED_DIR, { recursive: true });
+  const outputPath = path.join(GENERATED_DIR, `${shareId}.png`);
+  await sharp(BASE_TEMPLATE_PATH).composite([{ input: svg, blend: 'over' }]).png({ compressionLevel: 8 }).toFile(outputPath);
+
+  return {
+    outputPath,
+    relativeUrl: `/generated/share-images/${encodeURIComponent(shareId)}.png`
+  };
+}
+
+module.exports = {
+  renderShareScoreImage
+};


### PR DESCRIPTION
### Motivation
- Share previews must show the player score on top of the new `img/score_result1600x800.png` template so X/Twitter previews display the final image.
- Old SVG overlay coordinates no longer match the new template and must be reimplemented for correct placement and styling.

### Description
- Added `utils/shareImageRenderer.js` which composes an SVG score overlay (large bold, gradient fill, stroke and glow, slight skew) over `img/score_result1600x800.png` using `sharp` and writes `generated/share-images/<shareId>.png`, returning a public relative URL. 
- Updated `POST /api/share/start` in `routes/share.js` to call the renderer, persist `previewImageUrl`/`imageUrl` into `ShareEvent`, and fall back to the static template if rendering fails. 
- Exposed generated assets via `app.use('/generated', express.static(...))` in `app.js` with long cache headers. 
- Updated `/share/:shareId` OG/Twitter meta tags in `app.js` to prefer the generated `previewImageUrl` from `ShareEvent` with a fallback to the base template.

### Testing
- Ran the targeted test command: `npm test -- tests/share.test.js` which exercised the share flow and image generation path. 
- Rendering is exercised via the new `utils/shareImageRenderer.js` and debug helper; share image logic completed successfully in local runs. 
- The wider automated test run completed but reported unrelated failures in other areas of the suite (store/leaderboard flows); no share-image related failures were observed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06378fb3c08326b8403a35894cd51b)