### PR TITLE
Render share score with vector 7-segment digits and polish styling

### DIFF
--- a/utils/shareImageRenderer.js
+++ b/utils/shareImageRenderer.js
@@ -1,7 +1,6 @@
 const fs = require('fs');
 const path = require('path');
 const logger = require('./logger');
-const { spawnSync } = require('child_process');
 let sharp;
 try { sharp = require('sharp'); } catch (_) { sharp = null; }
 
@@ -10,97 +9,128 @@ const GENERATED_DIR = path.join(__dirname, '..', 'generated', 'share-images');
 
 const OUTPUT_WIDTH = 1600;
 const OUTPUT_HEIGHT = 800;
-const RENDER_VERSION = 'score-v4-fontfix';
+const RENDER_VERSION = 'score-v6-polished';
 
 const SCORE_BOX = {
-  x: 600,
-  y: 285,
-  width: 520,
-  height: 190
+  x: 515,
+  y: 292,
+  width: 560,
+  height: 165
 };
 
-function escapeXml(value) {
-  return String(value ?? '')
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#39;');
+const DIGIT_WIDTH = 78;
+const DIGIT_HEIGHT = 128;
+const SEGMENT_THICKNESS = 18;
+const SLANT = 8;
+const DIGIT_GAP = 12;
+
+const DIGIT_SEGMENTS = {
+  '0': ['a', 'b', 'c', 'd', 'e', 'f'],
+  '1': ['b', 'c'],
+  '2': ['a', 'b', 'g', 'e', 'd'],
+  '3': ['a', 'b', 'g', 'c', 'd'],
+  '4': ['f', 'g', 'b', 'c'],
+  '5': ['a', 'f', 'g', 'c', 'd'],
+  '6': ['a', 'f', 'g', 'e', 'c', 'd'],
+  '7': ['a', 'b', 'c'],
+  '8': ['a', 'b', 'c', 'd', 'e', 'f', 'g'],
+  '9': ['a', 'b', 'c', 'd', 'f', 'g']
+};
+
+function polygon(points) {
+  return points.map(([x, y]) => `${x},${y}`).join(' ');
 }
 
-function getScoreFontSize(scoreText) {
-  const len = scoreText.length;
-  if (len <= 5) return 168;
-  if (len === 6) return 150;
-  if (len === 7) return 132;
-  return 116;
+function createHorizontalSegment(y, xStart = 0, xEnd = DIGIT_WIDTH) {
+  const t = SEGMENT_THICKNESS;
+  const inset = Math.max(4, Math.round(t * 0.45));
+  const skew = SLANT;
+  return polygon([
+    [xStart + inset + skew, y],
+    [xEnd - inset + skew, y],
+    [xEnd + skew, y + t / 2],
+    [xEnd - inset + skew, y + t],
+    [xStart + inset + skew, y + t],
+    [xStart + skew, y + t / 2]
+  ]);
 }
 
-function buildOverlaySvg({ scoreText, fontSize, debugBox }) {
-  const centerX = SCORE_BOX.x + (SCORE_BOX.width / 2);
-  const centerY = SCORE_BOX.y + (SCORE_BOX.height / 2);
+function createVerticalSegment(x, yStart, yEnd) {
+  const t = SEGMENT_THICKNESS;
+  const inset = Math.max(4, Math.round(t * 0.42));
+  const skew = SLANT;
+  return polygon([
+    [x + skew, yStart + inset],
+    [x + t + skew, yStart],
+    [x + t + skew, yEnd - inset],
+    [x + t / 2 + skew, yEnd],
+    [x + skew, yEnd - inset],
+    [x + skew - t / 2, yStart + inset]
+  ]);
+}
+
+function getSegmentPolygon(segmentId) {
+  const t = SEGMENT_THICKNESS;
+  const middleY = Math.round((DIGIT_HEIGHT - t) / 2);
+
+  const segmentMap = {
+    a: createHorizontalSegment(0),
+    g: createHorizontalSegment(middleY),
+    d: createHorizontalSegment(DIGIT_HEIGHT - t),
+    f: createVerticalSegment(0, t / 2 + 2, middleY + t / 2 - 2),
+    b: createVerticalSegment(DIGIT_WIDTH - t, t / 2 + 2, middleY + t / 2 - 2),
+    e: createVerticalSegment(0, middleY + t / 2 + 2, DIGIT_HEIGHT - t / 2 - 2),
+    c: createVerticalSegment(DIGIT_WIDTH - t, middleY + t / 2 + 2, DIGIT_HEIGHT - t / 2 - 2)
+  };
+
+  return segmentMap[segmentId] || '';
+}
+
+function buildVectorDigits(scoreText) {
+  let xOffset = 0;
+  let svg = '';
+
+  for (const digit of scoreText) {
+    const activeSegments = DIGIT_SEGMENTS[digit] || [];
+    svg += `<g transform="translate(${xOffset} 0)">`;
+    for (const segmentId of activeSegments) {
+      const points = getSegmentPolygon(segmentId);
+      svg += `<polygon points="${points}" fill="url(#scoreGradient)" stroke="#10051f" stroke-width="2.5" stroke-linejoin="round"/>`;
+    }
+    svg += '</g>';
+    xOffset += DIGIT_WIDTH + DIGIT_GAP;
+  }
+
+  return svg;
+}
+
+function buildOverlaySvg({ scoreText, debugBox, startX, startY, scale, totalWidth }) {
+  const digitsBoundsWidth = totalWidth * scale;
+  const digitsBoundsHeight = DIGIT_HEIGHT * scale;
 
   return Buffer.from(
     `<svg width="1600" height="800" viewBox="0 0 1600 800" xmlns="http://www.w3.org/2000/svg">` +
       '<defs>' +
         '<linearGradient id="scoreGradient" x1="0%" y1="0%" x2="100%" y2="100%">' +
           '<stop offset="0%" stop-color="#ffffff"/>' +
-          '<stop offset="35%" stop-color="#d8c7ff"/>' +
-          '<stop offset="70%" stop-color="#a855f7"/>' +
-          '<stop offset="100%" stop-color="#22d3ee"/>' +
+          '<stop offset="30%" stop-color="#e7d7ff"/>' +
+          '<stop offset="60%" stop-color="#b779ff"/>' +
+          '<stop offset="100%" stop-color="#38e8ff"/>' +
         '</linearGradient>' +
-        '<filter id="scoreGlow" x="-30%" y="-30%" width="160%" height="160%">' +
-          '<feDropShadow dx="0" dy="0" stdDeviation="8" flood-color="#8b5cf6" flood-opacity="0.65"/>' +
-          '<feDropShadow dx="0" dy="0" stdDeviation="14" flood-color="#22d3ee" flood-opacity="0.35"/>' +
+        '<filter id="scoreGlow" x="-40%" y="-40%" width="180%" height="180%">' +
+          '<feDropShadow dx="0" dy="0" stdDeviation="5" flood-color="#8b5cf6" flood-opacity="0.65"/>' +
+          '<feDropShadow dx="0" dy="0" stdDeviation="10" flood-color="#22d3ee" flood-opacity="0.35"/>' +
         '</filter>' +
       '</defs>' +
       (debugBox
-        ? `<rect x="${SCORE_BOX.x}" y="${SCORE_BOX.y}" width="${SCORE_BOX.width}" height="${SCORE_BOX.height}" fill="none" stroke="red" stroke-width="4"/>`
+        ? `<rect x="${SCORE_BOX.x}" y="${SCORE_BOX.y}" width="${SCORE_BOX.width}" height="${SCORE_BOX.height}" fill="none" stroke="red" stroke-width="4"/>` +
+          `<rect x="${startX}" y="${startY}" width="${digitsBoundsWidth}" height="${digitsBoundsHeight}" fill="none" stroke="lime" stroke-width="2.5"/>`
         : '') +
-      `<text x="${centerX}" y="${centerY}" text-anchor="middle" dominant-baseline="middle" font-size="${fontSize}" font-weight="900" font-family="DejaVu Sans Condensed, DejaVu Sans, Liberation Sans, Arial, sans-serif" letter-spacing="2" fill="url(#scoreGradient)" stroke="rgba(10, 6, 30, 0.75)" stroke-width="5" paint-order="stroke fill" filter="url(#scoreGlow)">${escapeXml(scoreText)}</text>` +
+      `<g transform="translate(${startX} ${startY}) scale(${scale})" filter="url(#scoreGlow)">` +
+        buildVectorDigits(scoreText) +
+      '</g>' +
     '</svg>'
   );
-}
-
-
-let fontDiagnosticsLogged = false;
-
-function runFontCommand(cmd, args) {
-  const res = spawnSync(cmd, args, { encoding: 'utf8' });
-  if (res.error) {
-    logger.warn({ cmd, args, error: res.error.message }, 'Font diagnostics command unavailable');
-    return { ok: false, unavailable: true };
-  }
-  if (res.status !== 0) {
-    logger.warn({ cmd, args, status: res.status, stderr: res.stderr?.trim() }, 'Font diagnostics command failed');
-    return { ok: false, unavailable: false };
-  }
-  logger.info({ cmd, args, output: (res.stdout || '').trim() }, 'Font diagnostics command output');
-  return { ok: true, unavailable: false };
-}
-
-function logFontDiagnostics() {
-  if (fontDiagnosticsLogged) return;
-  fontDiagnosticsLogged = true;
-
-  logger.info({
-    fontconfigPath: process.env.FONTCONFIG_PATH,
-    fontconfigFile: process.env.FONTCONFIG_FILE,
-    sharpVersions: sharp?.versions,
-    baseTemplatePath: BASE_TEMPLATE_PATH,
-    baseTemplateExists: fs.existsSync(BASE_TEMPLATE_PATH)
-  }, 'Share image font runtime diagnostics');
-
-  const debugFonts = String(process.env.DEBUG_SHARE_IMAGE_FONTS || '').toLowerCase() === 'true';
-  if (!debugFonts) return;
-
-  const dejavu = runFontCommand('fc-match', ['DejaVu Sans Condensed']);
-  const liberation = runFontCommand('fc-match', ['Liberation Sans']);
-  runFontCommand('sh', ['-c', 'fc-list | head']);
-
-  if (!dejavu.ok || !liberation.ok) {
-    logger.warn('fontconfig unavailable, SVG text may render incorrectly');
-  }
 }
 
 async function renderShareScoreImage({ shareId, score }) {
@@ -116,20 +146,32 @@ async function renderShareScoreImage({ shareId, score }) {
     throw err;
   }
 
-  logFontDiagnostics();
+  let scoreText = String(Math.floor(Number(score)));
+  if (!/^\d+$/.test(scoreText)) {
+    scoreText = '0';
+  }
 
-  const scoreText = String(Math.max(0, Math.floor(Number(score) || 0)));
-  const fontSize = getScoreFontSize(scoreText);
   const debugBox = String(process.env.DEBUG_SHARE_IMAGE_BOX || '').toLowerCase() === 'true';
 
+  const digitCount = scoreText.length;
+  const totalWidth = (digitCount * DIGIT_WIDTH) + ((digitCount - 1) * DIGIT_GAP);
+  const scale = Math.min(
+    SCORE_BOX.width / totalWidth,
+    SCORE_BOX.height / DIGIT_HEIGHT,
+    1.0
+  );
+
+  const startX = SCORE_BOX.x + ((SCORE_BOX.width - (totalWidth * scale)) / 2);
+  const startY = SCORE_BOX.y + ((SCORE_BOX.height - (DIGIT_HEIGHT * scale)) / 2);
+
   const baseMeta = await sharp(BASE_TEMPLATE_PATH).metadata();
-  const overlaySvg = buildOverlaySvg({ scoreText, fontSize, debugBox });
+  const overlaySvg = buildOverlaySvg({ scoreText, debugBox, startX, startY, scale, totalWidth });
 
   fs.mkdirSync(GENERATED_DIR, { recursive: true });
   const outputPath = path.join(GENERATED_DIR, `${shareId}-${RENDER_VERSION}.png`);
 
   await sharp(BASE_TEMPLATE_PATH)
-    .resize(OUTPUT_WIDTH, OUTPUT_HEIGHT, { fit: 'fill' })
+    .resize(1600, 800, { fit: 'fill' })
     .composite([{ input: overlaySvg, blend: 'over', top: 0, left: 0 }])
     .png({ compressionLevel: 8 })
     .toFile(outputPath);
@@ -141,25 +183,35 @@ async function renderShareScoreImage({ shareId, score }) {
     throw err;
   }
 
+  const relativeUrl = `/generated/share-images/${encodeURIComponent(shareId)}-${RENDER_VERSION}.png`;
+
   logger.info({
     shareId,
     scoreText,
+    renderMode: 'vector-digits',
+    renderVersion: RENDER_VERSION,
     scoreBox: SCORE_BOX,
-    fontSize,
+    digitWidth: DIGIT_WIDTH,
+    digitHeight: DIGIT_HEIGHT,
+    gap: DIGIT_GAP,
+    totalWidth,
+    scale,
+    startX,
+    startY,
     outputPath,
+    relativeUrl,
     templateWidth: baseMeta.width,
     templateHeight: baseMeta.height,
     outputWidth: outputMeta.width,
     outputHeight: outputMeta.height
-  }, 'Share score image rendered');
+  }, 'Share vector score image rendered');
 
   return {
     outputPath,
-    relativeUrl: `/generated/share-images/${encodeURIComponent(shareId)}-${RENDER_VERSION}.png`
+    relativeUrl
   };
 }
 
 module.exports = {
-  renderShareScoreImage,
-  getScoreFontSize
+  renderShareScoreImage
 };


### PR DESCRIPTION
### Motivation
- Replace dependency on system fonts and SVG text rendering with a deterministic vector digit renderer to avoid font fallback issues and improve visual consistency.
- Improve the visual style of the score (gradient, glow, and digit geometry) and tighten the score layout inside the score box.
- Simplify runtime by removing external font diagnostics and subprocess usage that were only used for font probing.

### Description
- Replace text-based SVG score rendering with a custom vector 7-segment digit renderer implemented via polygon shapes and the new `buildVectorDigits`/segment polygon helpers, with constants `DIGIT_WIDTH`, `DIGIT_HEIGHT`, `SEGMENT_THICKNESS`, `SLANT`, and `DIGIT_GAP`.
- Update layout calculation to compute `totalWidth`, `scale`, `startX`, and `startY` so digits are centered and scaled to fit `SCORE_BOX`, and draw a debug rectangle when `DEBUG_SHARE_IMAGE_BOX` is enabled.
- Adjust `SCORE_BOX` coordinates and bump `RENDER_VERSION` to `score-v6-polished`, change the gradient colors and glow filter, and add `renderMode`/render metadata and `relativeUrl` in log and return value.
- Remove `escapeXml`, font diagnostics logging, `spawnSync` usage, and `getScoreFontSize`, and update the `renderShareScoreImage` flow to validate/normalize `score`, generate the overlay SVG from vector digits, composite it onto the base template with `sharp`, and emit the output PNG in `generated/share-images`.

### Testing
- Ran the existing automated test suite and the tests completed successfully.
- No new automated tests were added in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a065c3416448326841227c700f2e39e)