### PR TITLE
Lower score block and strengthen left tilt for share image (score-v8)

### DIFF
--- a/utils/shareImageRenderer.js
+++ b/utils/shareImageRenderer.js
@@ -9,11 +9,11 @@ const GENERATED_DIR = path.join(__dirname, '..', 'generated', 'share-images');
 
 const OUTPUT_WIDTH = 1600;
 const OUTPUT_HEIGHT = 800;
-const RENDER_VERSION = 'score-v7-tilted-calculator';
+const RENDER_VERSION = 'score-v8-lower-left-tilt';
 
 const SCORE_BOX = {
   x: 485,
-  y: 292,
+  y: 315,
   width: 560,
   height: 165
 };
@@ -23,8 +23,8 @@ const DIGIT_HEIGHT = 124;
 const SEGMENT_THICKNESS = 14;
 const SLANT = 4;
 const DIGIT_GAP = 10;
-const SCORE_SKEW_X = -10;
-const SCORE_ROTATE_DEG = -4;
+const SCORE_SKEW_X = -14;
+const SCORE_ROTATE_DEG = -5;
 
 const DIGIT_SEGMENTS = {
   '0': ['a', 'b', 'c', 'd', 'e', 'f'],


### PR DESCRIPTION
### Motivation
- Improve visual alignment of the generated score with the in-template score window by lowering the whole score block and increasing its leftward skew so digits sit vertically centered and appear more parallel to the score panel.

### Description
- Updated `utils/shareImageRenderer.js` to bump `RENDER_VERSION` to `score-v8-lower-left-tilt`, move `SCORE_BOX.y` from `292` to `315`, increase `SCORE_SKEW_X` from `-10` to `-14`, and change `SCORE_ROTATE_DEG` from `-4` to `-5`, while preserving all vector-digit, gradient, glow, and auto-fit logic.

### Testing
- Loaded the module with `node -e "require('./utils/shareImageRenderer')"` to verify the file parses and loads without runtime errors (succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a06656d63b883268077a66fba4b3855)