### PR TITLE
Make onboarding radar gift claims idempotent and duplicate-safe

### DIFF
--- a/routes/onboarding.js
+++ b/routes/onboarding.js
@@ -149,12 +149,23 @@ router.post('/claim', asyncHandler(async (req, res) => {
     const wallet = identity.wallet || primaryId;
     const state = await getOrCreateOnboardingState(primaryId);
     const claim = await claimReward({ state, primaryId, wallet, reward });
-    logger.info({ primaryId, wallet, reward, until: claim.until || null }, 'Onboarding reward claim processed');
+    logger.info({
+      primaryId,
+      wallet,
+      reward,
+      alreadyClaimed: claim.alreadyClaimed,
+      until: claim.until || null
+    }, 'Onboarding reward claim processed');
     if (!claim.alreadyClaimed) {
       await trackOnboardingEvent('onboarding_reward_claimed', { primaryId, reward, flowVersion: state.flowVersion || 'v2' });
       await trackOnboardingEvent('radar_gift_claimed', { primaryId, reward, flowVersion: state.flowVersion || 'v2' });
     }
-    return res.json({ success: true, reward, ...claim });
+    return res.json({
+      success: true,
+      reward,
+      alreadyClaimed: claim.alreadyClaimed,
+      until: claim.until || null
+    });
 }));
 
 module.exports = router;

--- a/services/onboardingService.js
+++ b/services/onboardingService.js
@@ -202,29 +202,80 @@ function resolveActiveOnboarding({ state, raceCount, xConnected, screen }) {
 
 async function claimReward({ state, primaryId, wallet, reward }) {
   if (!CLAIMABLE_REWARDS.has(reward)) throw Object.assign(new Error('unsupported_reward'), { statusCode: 400 });
+
   const normalizedWallet = String(wallet || primaryId || '').trim().toLowerCase();
   const upgrades = await PlayerUpgrades.findOneAndUpdate(
     { wallet: normalizedWallet },
     { $setOnInsert: { wallet: normalizedWallet } },
     { upsert: true, new: true }
   );
+
+  const rewardConfig = reward === 'radar_obstacles_24h'
+    ? {
+      stateGiftPath: 'radarObstacles',
+      boostPath: 'temporaryBoosts.radarObstaclesUntil',
+      currentBoostUntil: upgrades.temporaryBoosts?.radarObstaclesUntil
+    }
+    : {
+      stateGiftPath: 'radarGold',
+      boostPath: 'temporaryBoosts.radarGoldUntil',
+      currentBoostUntil: upgrades.temporaryBoosts?.radarGoldUntil
+    };
+
+  const giftState = state.gifts[rewardConfig.stateGiftPath];
+  const existingUntil = rewardConfig.currentBoostUntil;
+  const existingUntilMs = existingUntil ? new Date(existingUntil).getTime() : 0;
+
+  if (giftState.claimed || (existingUntilMs && existingUntilMs > Date.now())) {
+    giftState.claimed = true;
+    if (!giftState.activeUntil && existingUntil) {
+      giftState.activeUntil = existingUntil;
+      await state.save();
+    }
+    return { alreadyClaimed: true, until: existingUntil || giftState.activeUntil || null };
+  }
+
   const until = new Date(Date.now() + 24 * 60 * 60 * 1000);
-  if (reward === 'radar_obstacles_24h') {
-    if (state.gifts.radarObstacles.claimed) return { alreadyClaimed: true, until: upgrades.temporaryBoosts?.radarObstaclesUntil || null };
-    state.gifts.radarObstacles.claimed = true;
-    state.gifts.radarObstacles.activeUntil = until;
-    upgrades.temporaryBoosts = upgrades.temporaryBoosts || {};
-    upgrades.temporaryBoosts.radarObstaclesUntil = until;
+  const claimedPath = `gifts.${rewardConfig.stateGiftPath}.claimed`;
+  const activeUntilPath = `gifts.${rewardConfig.stateGiftPath}.activeUntil`;
+
+  const claimedState = await OnboardingState.findOneAndUpdate(
+    { primaryId: state.primaryId, [claimedPath]: { $ne: true } },
+    { $set: { [claimedPath]: true, [activeUntilPath]: until } },
+    { new: true }
+  );
+
+  if (!claimedState) {
+    const latestState = await OnboardingState.findOne({ primaryId: state.primaryId }).select(`gifts.${rewardConfig.stateGiftPath}`).lean();
+    const latestUntil = upgrades.temporaryBoosts?.[rewardConfig.stateGiftPath === 'radarObstacles' ? 'radarObstaclesUntil' : 'radarGoldUntil']
+      || latestState?.gifts?.[rewardConfig.stateGiftPath]?.activeUntil
+      || null;
+    return { alreadyClaimed: true, until: latestUntil };
   }
-  if (reward === 'radar_gold_24h') {
-    if (state.gifts.radarGold.claimed) return { alreadyClaimed: true, until: upgrades.temporaryBoosts?.radarGoldUntil || null };
-    state.gifts.radarGold.claimed = true;
-    state.gifts.radarGold.activeUntil = until;
-    upgrades.temporaryBoosts = upgrades.temporaryBoosts || {};
-    upgrades.temporaryBoosts.radarGoldUntil = until;
+
+  const updatedUpgrades = await PlayerUpgrades.findOneAndUpdate(
+    {
+      wallet: normalizedWallet,
+      $or: [
+        { [rewardConfig.boostPath]: { $exists: false } },
+        { [rewardConfig.boostPath]: null },
+        { [rewardConfig.boostPath]: { $lte: new Date() } }
+      ]
+    },
+    { $set: { [rewardConfig.boostPath]: until } },
+    { new: true }
+  );
+
+  if (!updatedUpgrades) {
+    const latestUpgrades = await PlayerUpgrades.findOne({ wallet: normalizedWallet }).select(rewardConfig.boostPath).lean();
+    const latestUntil = rewardConfig.stateGiftPath === 'radarObstacles'
+      ? latestUpgrades?.temporaryBoosts?.radarObstaclesUntil
+      : latestUpgrades?.temporaryBoosts?.radarGoldUntil;
+    return { alreadyClaimed: true, until: latestUntil || until };
   }
-  await upgrades.save();
-  await state.save();
+
+  state.gifts[rewardConfig.stateGiftPath].claimed = true;
+  state.gifts[rewardConfig.stateGiftPath].activeUntil = until;
   return { alreadyClaimed: false, until };
 }
 


### PR DESCRIPTION
### Motivation
- Prevent rapid duplicate `/api/onboarding/claim` requests (multiple FREE Radar clicks) from extending boost duration or creating multiple activation effects.
- Ensure claim handling is idempotent so repeated requests return the same result and do not change an already-active boost.

### Description
- Load `PlayerUpgrades` first and check existing `temporaryBoosts` so an active boost is detected before issuing a new one (changes in `services/onboardingService.js`).
- Short-circuit and return `{ alreadyClaimed: true, until }` when onboarding gift is already claimed or when an existing boost is still active, and backfill `state.gifts.*.activeUntil` from the upgrade record when missing (changes in `services/onboardingService.js`).
- Add an atomic guard using `OnboardingState.findOneAndUpdate` with `gifts.<X>.claimed != true` so only one request can transition the onboarding claim to claimed (changes in `services/onboardingService.js`).
- Update `PlayerUpgrades` with a conditional `findOneAndUpdate` that only sets the boost until when it does not exist or is expired, preventing duplicate requests from extending an active boost (changes in `services/onboardingService.js`).
- Update `/api/onboarding/claim` response shape to explicitly return `success`, `reward`, `alreadyClaimed`, and `until`, and include `alreadyClaimed`/`until` in the structured log (changes in `routes/onboarding.js`).

### Testing
- Ran a module-level smoke test with `node -e "require('./services/onboardingService'); require('./routes/onboarding'); console.log('ok')"` and it exited successfully (printed `ok`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07104da8048326ae44eaa46ca6d2f4)