### PR TITLE
Filter player coin history to income-only by default

### DIFF
--- a/routes/account.js
+++ b/routes/account.js
@@ -21,7 +21,7 @@ const { computeRank } = require('../services/leaderboardInsightsService');
 const { buildReferralUrl, buildCanonicalShareUrl, buildWebReferralUrl, buildTelegramReferralUrl } = require('../utils/referral');
 const { getUtcDayKey, getYesterdayUtcDayKey } = require('../utils/utcDay');
 const { findLink } = require('../middleware/requireAuth');
-const { resolveCoinHistoryIds } = require('../utils/coinHistory');
+const { resolveCoinHistoryIds, PLAYER_MENU_INCOME_TYPES } = require('../utils/coinHistory');
 
 const WALLET_TIMESTAMP_WINDOW_MS = Number(process.env.WALLET_AUTH_TIMESTAMP_WINDOW_MS || 10 * 60 * 1000);
 
@@ -422,9 +422,22 @@ router.get('/me/coin-history', readLimiter, requireAuth, async (req, res) => {
     const limit = Number.isFinite(rawLimit) ? Math.min(Math.max(Math.floor(rawLimit), 1), 200) : 50;
 
     const historyIds = await resolveCoinHistoryIds({ primaryId, authLink: req.authLink });
+    const mode = String(req.query?.mode || 'income').trim().toLowerCase();
+    const includeAll = mode === 'all';
+
+    const query = includeAll
+      ? { primaryId: { $in: historyIds } }
+      : {
+        primaryId: { $in: historyIds },
+        type: { $in: PLAYER_MENU_INCOME_TYPES },
+        $or: [
+          { gold: { $gt: 0 } },
+          { silver: { $gt: 0 } }
+        ]
+      };
 
     const rows = await CoinTransaction
-      .find({ primaryId: { $in: historyIds } })
+      .find(query)
       .sort({ createdAt: -1 })
       .limit(limit)
       .select('type gold silver createdAt');
@@ -434,6 +447,7 @@ router.get('/me/coin-history', readLimiter, requireAuth, async (req, res) => {
         type: row.type,
         gold: row.gold || 0,
         silver: row.silver || 0,
+        direction: includeAll ? ((row.gold || 0) > 0 || (row.silver || 0) > 0 ? 'income' : 'spending') : 'income',
         createdAt: row.createdAt
       }))
     });

--- a/tests/account-coin-history.test.js
+++ b/tests/account-coin-history.test.js
@@ -42,14 +42,20 @@ test('GET /api/account/me/coin-history - returns wallet-saved rows for wallet au
     };
 
     CoinTransaction.find = (query) => {
-      assert.deepEqual(query, { primaryId: { $in: ['0xabc'] } });
+      assert.deepEqual(query, {
+        primaryId: { $in: ['0xabc'] },
+        type: { $in: [
+          'share', 'share_reward', 'referral', 'referral_bonus', 'refer', 'task', 'onboarding_bonus', 'onboarding', 'race_reward', 'game_reward'
+        ] },
+        $or: [{ gold: { $gt: 0 } }, { silver: { $gt: 0 } }]
+      });
       return {
         sort: () => ({
           limit: (value) => {
             assert.equal(value, 50);
             return {
               select: async () => ([
-                { type: 'ride', gold: 5, silver: 3, createdAt: new Date('2026-04-28T09:00:00Z') }
+                { type: 'share', gold: 5, silver: 3, createdAt: new Date('2026-04-28T09:00:00Z') }
               ])
             };
           }
@@ -60,7 +66,8 @@ test('GET /api/account/me/coin-history - returns wallet-saved rows for wallet au
     const r = await get(baseUrl, '/api/account/me/coin-history', { 'X-Wallet': '0xAbC' });
     assert.equal(r.status, 200, JSON.stringify(r.body));
     assert.equal(r.body.items.length, 1);
-    assert.equal(r.body.items[0].type, 'ride');
+    assert.equal(r.body.items[0].type, 'share');
+    assert.equal(r.body.items[0].direction, 'income');
   } finally {
     AccountLink.findOne = originalFindOne;
     CoinTransaction.find = originalFind;
@@ -79,7 +86,13 @@ test('GET /api/account/me/coin-history - returns wallet-saved rows for linked Te
     };
 
     CoinTransaction.find = (query) => {
-      assert.deepEqual(query, { primaryId: { $in: ['tg_777', '0xabc'] } });
+      assert.deepEqual(query, {
+        primaryId: { $in: ['tg_777', '0xabc'] },
+        type: { $in: [
+          'share', 'share_reward', 'referral', 'referral_bonus', 'refer', 'task', 'onboarding_bonus', 'onboarding', 'race_reward', 'game_reward'
+        ] },
+        $or: [{ gold: { $gt: 0 } }, { silver: { $gt: 0 } }]
+      });
       return {
         sort: () => ({
           limit: () => ({
@@ -113,7 +126,13 @@ test('GET /api/account/me/coin-history - empty history returns items array', asy
     };
 
     CoinTransaction.find = (query) => {
-      assert.deepEqual(query, { primaryId: { $in: ['tg_empty'] } });
+      assert.deepEqual(query, {
+        primaryId: { $in: ['tg_empty'] },
+        type: { $in: [
+          'share', 'share_reward', 'referral', 'referral_bonus', 'refer', 'task', 'onboarding_bonus', 'onboarding', 'race_reward', 'game_reward'
+        ] },
+        $or: [{ gold: { $gt: 0 } }, { silver: { $gt: 0 } }]
+      });
       return {
         sort: () => ({
           limit: () => ({
@@ -126,6 +145,76 @@ test('GET /api/account/me/coin-history - empty history returns items array', asy
     const r = await get(baseUrl, '/api/account/me/coin-history', { 'X-Primary-Id': 'tg_empty' });
     assert.equal(r.status, 200, JSON.stringify(r.body));
     assert.deepEqual(r.body, { items: [] });
+  } finally {
+    AccountLink.findOne = originalFindOne;
+    CoinTransaction.find = originalFind;
+    server.close();
+  }
+});
+
+
+test('GET /api/account/me/coin-history - filters income only, keeps limit and createdAt desc', async () => {
+  const { server, baseUrl } = await startServer();
+  const originalFindOne = AccountLink.findOne;
+  const originalFind = CoinTransaction.find;
+  try {
+    AccountLink.findOne = async (q) => {
+      if (q.primaryId === 'tg_filter') return { primaryId: 'tg_filter', wallet: null, telegramId: '999' };
+      return null;
+    };
+
+    CoinTransaction.find = (query) => {
+      assert.deepEqual(query, {
+        primaryId: { $in: ['tg_filter'] },
+        type: { $in: ['share','share_reward','referral','referral_bonus','refer','task','onboarding_bonus','onboarding','race_reward','game_reward'] },
+        $or: [{ gold: { $gt: 0 } }, { silver: { $gt: 0 } }]
+      });
+      return {
+        sort: (sortArg) => {
+          assert.deepEqual(sortArg, { createdAt: -1 });
+          return {
+            limit: (v) => {
+              assert.equal(v, 3);
+              return {
+                select: async () => ([
+                  { type: 'task', gold: 10, silver: 0, createdAt: new Date('2026-05-01T10:00:00Z') },
+                  { type: 'referral', gold: 100, silver: 0, createdAt: new Date('2026-05-01T09:00:00Z') },
+                  { type: 'onboarding_bonus', gold: 0, silver: 100, createdAt: new Date('2026-05-01T08:00:00Z') }
+                ])
+              };
+            }
+          };
+        }
+      };
+    };
+
+    const r = await get(baseUrl, '/api/account/me/coin-history?limit=3', { 'X-Primary-Id': 'tg_filter' });
+    assert.equal(r.status, 200, JSON.stringify(r.body));
+    assert.equal(r.body.items.length, 3);
+    assert.deepEqual(r.body.items.map((i) => i.type), ['task', 'referral', 'onboarding_bonus']);
+    assert.ok(r.body.items.every((i) => i.direction === 'income'));
+  } finally {
+    AccountLink.findOne = originalFindOne;
+    CoinTransaction.find = originalFind;
+    server.close();
+  }
+});
+
+
+test('GET /api/account/me/coin-history?mode=all - includes unfiltered rows', async () => {
+  const { server, baseUrl } = await startServer();
+  const originalFindOne = AccountLink.findOne;
+  const originalFind = CoinTransaction.find;
+  try {
+    AccountLink.findOne = async (q) => (q.primaryId === 'tg_all' ? { primaryId: 'tg_all', wallet: null, telegramId: '111' } : null);
+    CoinTransaction.find = (query) => {
+      assert.deepEqual(query, { primaryId: { $in: ['tg_all'] } });
+      return { sort: () => ({ limit: () => ({ select: async () => ([{ type: 'buy', gold: 400, silver: 0, createdAt: new Date('2026-05-02T00:00:00Z') }]) }) }) };
+    };
+
+    const r = await get(baseUrl, '/api/account/me/coin-history?mode=all', { 'X-Primary-Id': 'tg_all' });
+    assert.equal(r.status, 200, JSON.stringify(r.body));
+    assert.equal(r.body.items[0].type, 'buy');
   } finally {
     AccountLink.findOne = originalFindOne;
     CoinTransaction.find = originalFind;

--- a/utils/coinHistory.js
+++ b/utils/coinHistory.js
@@ -3,6 +3,20 @@ const AccountLink = require('../models/AccountLink');
 const logger = require('./logger');
 
 
+const PLAYER_MENU_INCOME_TYPES = [
+  'share',
+  'share_reward',
+  'referral',
+  'referral_bonus',
+  'refer',
+  'task',
+  'onboarding_bonus',
+  'onboarding',
+  'race_reward',
+  'game_reward'
+];
+
+
 function normalizeId(value) {
   return String(value || '').trim().toLowerCase();
 }
@@ -70,4 +84,10 @@ async function recordCoinReward(primaryId, type, amounts = {}, opts = {}) {
   }
 }
 
-module.exports = { recordCoinReward, normalizeId, uniqueNormalizedIds, resolveCoinHistoryIds };
+module.exports = {
+  recordCoinReward,
+  normalizeId,
+  uniqueNormalizedIds,
+  resolveCoinHistoryIds,
+  PLAYER_MENU_INCOME_TYPES
+};


### PR DESCRIPTION
### Motivation
- Player menu currently shows spending/deduction transactions which should be hidden from the player view. 
- The history must display only positive coin accruals (share/referral/onboarding/task/race/game and future rewards) and never show spending as positive.
- Apply filtering at query/response time without changing historical DB records.

### Description
- Added an explicit allowlist `PLAYER_MENU_INCOME_TYPES` in `utils/coinHistory.js` with known income types and future-friendly aliases. 
- Updated `GET /api/account/me/coin-history` in `routes/account.js` to default to an income-only query that requires `type` in `PLAYER_MENU_INCOME_TYPES` and `gold > 0 OR silver > 0`, preserved `createdAt` desc sorting and `limit`, and added an optional `mode=all` to return unfiltered history when explicitly requested. 
- Added a `direction` field to response items (default `'income'` in normal mode, computed `'income'`/`'spending'` when `mode=all`).
- Extended `tests/account-coin-history.test.js` to assert the new query shape, income-only filtering, positive-amount filtering, `limit` and sort behavior, and `mode=all` behavior; kept `utils/coinHistory.js` unit tests for reward recording unchanged except exporting the new constant.

### Testing
- Ran `node --test tests/account-coin-history.test.js tests/coinHistory.test.js`, all tests passed (8 passed, 0 failed). 
- Verified the coin-history route returns only income rows by default and returns unfiltered rows when `?mode=all` is provided.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a07434bc2e883269c89babbb5356d4d)