### PR TITLE
Restore Player Menu History and add CoinTransaction.direction

### DIFF
--- a/models/CoinTransaction.js
+++ b/models/CoinTransaction.js
@@ -1,6 +1,25 @@
 const mongoose = require('mongoose');
 
-const COIN_TRANSACTION_TYPES = ['share', 'ride', 'buy', 'referral', 'refer', 'task', 'onboarding_bonus'];
+const COIN_TRANSACTION_TYPES = [
+  'share',
+  'ride',
+  'race_reward',
+  'bonus_reward',
+  'buy',
+  'referral',
+  'refer',
+  'task',
+  'onboarding_bonus',
+  'share_reward',
+  'referral_bonus',
+  'onboarding',
+  'game_reward',
+  'store_purchase',
+  'upgrade_purchase',
+  'purchase_spend',
+  'spend',
+  'cost'
+];
 const ONBOARDING_BONUS_REASONS = ['second_race_bonus', 'third_race_bonus'];
 
 const coinTransactionSchema = new mongoose.Schema({
@@ -10,6 +29,7 @@ const coinTransactionSchema = new mongoose.Schema({
   reason: { type: String, default: null, enum: [...ONBOARDING_BONUS_REASONS, null] },
   gold: { type: Number, required: true, min: 0, default: 0 },
   silver: { type: Number, required: true, min: 0, default: 0 },
+  direction: { type: String, enum: ['income', 'spending'], default: 'income', index: true },
   createdAt: { type: Date, default: Date.now, index: true }
 }, { versionKey: false });
 

--- a/routes/account.js
+++ b/routes/account.js
@@ -21,7 +21,7 @@ const { computeRank } = require('../services/leaderboardInsightsService');
 const { buildReferralUrl, buildCanonicalShareUrl, buildWebReferralUrl, buildTelegramReferralUrl } = require('../utils/referral');
 const { getUtcDayKey, getYesterdayUtcDayKey } = require('../utils/utcDay');
 const { findLink } = require('../middleware/requireAuth');
-const { resolveCoinHistoryIds, PLAYER_MENU_INCOME_TYPES } = require('../utils/coinHistory');
+const { resolveCoinHistoryIds, SPENDING_HISTORY_TYPES } = require('../utils/coinHistory');
 
 const WALLET_TIMESTAMP_WINDOW_MS = Number(process.env.WALLET_AUTH_TIMESTAMP_WINDOW_MS || 10 * 60 * 1000);
 
@@ -429,26 +429,28 @@ router.get('/me/coin-history', readLimiter, requireAuth, async (req, res) => {
       ? { primaryId: { $in: historyIds } }
       : {
         primaryId: { $in: historyIds },
-        type: { $in: PLAYER_MENU_INCOME_TYPES },
         $or: [
           { gold: { $gt: 0 } },
           { silver: { $gt: 0 } }
-        ]
+        ],
+        direction: { $ne: 'spending' },
+        type: { $nin: SPENDING_HISTORY_TYPES }
       };
 
     const rows = await CoinTransaction
       .find(query)
       .sort({ createdAt: -1 })
       .limit(limit)
-      .select('type gold silver createdAt');
+      .select('type direction gold silver createdAt reason');
 
     return res.json({
       items: rows.map((row) => ({
         type: row.type,
         gold: row.gold || 0,
         silver: row.silver || 0,
-        direction: includeAll ? ((row.gold || 0) > 0 || (row.silver || 0) > 0 ? 'income' : 'spending') : 'income',
-        createdAt: row.createdAt
+        direction: row.direction || (includeAll ? (((row.gold || 0) > 0 || (row.silver || 0) > 0) ? 'income' : 'spending') : 'income'),
+        createdAt: row.createdAt,
+        reason: row.reason || null
       }))
     });
   } catch (error) {

--- a/routes/leaderboard.js
+++ b/routes/leaderboard.js
@@ -786,7 +786,7 @@ router.post('/save', saveResultLimiter, async (req, res) => {
 
     if (coins.gold > 0 || coins.silver > 0) {
       await safeSideEffect('coin_history_ride', async () => {
-        await recordCoinReward(walletLower, 'ride', { gold: coins.gold, silver: coins.silver }, { requestId: req.requestId });
+        await recordCoinReward(walletLower, 'race_reward', { gold: coins.gold, silver: coins.silver }, { requestId: req.requestId, direction: 'income' });
       });
     }
 

--- a/tests/account-coin-history.test.js
+++ b/tests/account-coin-history.test.js
@@ -44,10 +44,9 @@ test('GET /api/account/me/coin-history - returns wallet-saved rows for wallet au
     CoinTransaction.find = (query) => {
       assert.deepEqual(query, {
         primaryId: { $in: ['0xabc'] },
-        type: { $in: [
-          'share', 'share_reward', 'referral', 'referral_bonus', 'refer', 'task', 'onboarding_bonus', 'onboarding', 'race_reward', 'game_reward'
-        ] },
-        $or: [{ gold: { $gt: 0 } }, { silver: { $gt: 0 } }]
+        $or: [{ gold: { $gt: 0 } }, { silver: { $gt: 0 } }],
+        direction: { $ne: 'spending' },
+        type: { $nin: ['store_purchase', 'upgrade_purchase', 'purchase_spend', 'spend', 'cost'] }
       });
       return {
         sort: () => ({
@@ -88,10 +87,9 @@ test('GET /api/account/me/coin-history - returns wallet-saved rows for linked Te
     CoinTransaction.find = (query) => {
       assert.deepEqual(query, {
         primaryId: { $in: ['tg_777', '0xabc'] },
-        type: { $in: [
-          'share', 'share_reward', 'referral', 'referral_bonus', 'refer', 'task', 'onboarding_bonus', 'onboarding', 'race_reward', 'game_reward'
-        ] },
-        $or: [{ gold: { $gt: 0 } }, { silver: { $gt: 0 } }]
+        $or: [{ gold: { $gt: 0 } }, { silver: { $gt: 0 } }],
+        direction: { $ne: 'spending' },
+        type: { $nin: ['store_purchase', 'upgrade_purchase', 'purchase_spend', 'spend', 'cost'] }
       });
       return {
         sort: () => ({
@@ -128,10 +126,9 @@ test('GET /api/account/me/coin-history - empty history returns items array', asy
     CoinTransaction.find = (query) => {
       assert.deepEqual(query, {
         primaryId: { $in: ['tg_empty'] },
-        type: { $in: [
-          'share', 'share_reward', 'referral', 'referral_bonus', 'refer', 'task', 'onboarding_bonus', 'onboarding', 'race_reward', 'game_reward'
-        ] },
-        $or: [{ gold: { $gt: 0 } }, { silver: { $gt: 0 } }]
+        $or: [{ gold: { $gt: 0 } }, { silver: { $gt: 0 } }],
+        direction: { $ne: 'spending' },
+        type: { $nin: ['store_purchase', 'upgrade_purchase', 'purchase_spend', 'spend', 'cost'] }
       });
       return {
         sort: () => ({
@@ -166,8 +163,9 @@ test('GET /api/account/me/coin-history - filters income only, keeps limit and cr
     CoinTransaction.find = (query) => {
       assert.deepEqual(query, {
         primaryId: { $in: ['tg_filter'] },
-        type: { $in: ['share','share_reward','referral','referral_bonus','refer','task','onboarding_bonus','onboarding','race_reward','game_reward'] },
-        $or: [{ gold: { $gt: 0 } }, { silver: { $gt: 0 } }]
+        $or: [{ gold: { $gt: 0 } }, { silver: { $gt: 0 } }],
+        direction: { $ne: 'spending' },
+        type: { $nin: ['store_purchase', 'upgrade_purchase', 'purchase_spend', 'spend', 'cost'] }
       });
       return {
         sort: (sortArg) => {

--- a/utils/coinHistory.js
+++ b/utils/coinHistory.js
@@ -3,18 +3,7 @@ const AccountLink = require('../models/AccountLink');
 const logger = require('./logger');
 
 
-const PLAYER_MENU_INCOME_TYPES = [
-  'share',
-  'share_reward',
-  'referral',
-  'referral_bonus',
-  'refer',
-  'task',
-  'onboarding_bonus',
-  'onboarding',
-  'race_reward',
-  'game_reward'
-];
+const SPENDING_HISTORY_TYPES = ['store_purchase', 'upgrade_purchase', 'purchase_spend', 'spend', 'cost'];
 
 
 function normalizeId(value) {
@@ -74,6 +63,7 @@ async function recordCoinReward(primaryId, type, amounts = {}, opts = {}) {
       reason: opts.reason || null,
       gold,
       silver,
+      direction: opts.direction === 'spending' ? 'spending' : 'income',
       createdAt: opts.createdAt || new Date()
     });
 
@@ -89,5 +79,5 @@ module.exports = {
   normalizeId,
   uniqueNormalizedIds,
   resolveCoinHistoryIds,
-  PLAYER_MENU_INCOME_TYPES
+  SPENDING_HISTORY_TYPES
 };

--- a/utils/donationService.js
+++ b/utils/donationService.js
@@ -364,7 +364,7 @@ async function creditDonationPayment(payment, options = {}) {
   player.totalSilverCoins += silver;
   player.updatedAt = rewardGrantedAt;
   await player.save();
-  await recordCoinReward(payment.wallet, 'buy', { gold, silver }, { requestId: options.requestId, createdAt: rewardGrantedAt });
+  await recordCoinReward(payment.wallet, 'buy', { gold, silver }, { requestId: options.requestId, createdAt: rewardGrantedAt, direction: 'spending' });
 
   return rewardUpdate;
 }

--- a/utils/referralRewards.js
+++ b/utils/referralRewards.js
@@ -44,11 +44,11 @@ async function maybeGrantReferralRewards(player, opts = {}) {
 
   // Award gold to referrer
   await addGold(referrer.wallet, REFERRER_GOLD, 'referral_referrer', opts);
-  await recordCoinReward(referrer.wallet, 'refer', { gold: REFERRER_GOLD }, opts);
+  await recordCoinReward(referrer.wallet, 'refer', { gold: REFERRER_GOLD }, { ...opts, direction: 'income' });
 
   // Award gold to referee (current player)
   await addGold(player.wallet, REFEREE_GOLD, 'referral_referee', opts);
-  await recordCoinReward(player.wallet, 'referral', { gold: REFEREE_GOLD }, opts);
+  await recordCoinReward(player.wallet, 'referral', { gold: REFEREE_GOLD }, { ...opts, direction: 'income' });
 
   // Mark as granted
   player.referralRewardGranted = true;


### PR DESCRIPTION
### Motivation
- The player menu history stopped showing reward rows because the backend and frontend were using a strict allowlist and dynamic injection that hid legacy reward types and table markup.
- The goal is to restore visibility of legitimate positive rewards (races, bonuses, referrals, shares, onboarding) while still hiding spending/purchases from the default player-menu history.
- Ensure recording paths explicitly tag spending vs income so frontend filtering can rely on `direction` rather than fragile type lists.

### Description
- Added `direction` to the `CoinTransaction` schema with enum `['income','spending']`, default `income`, and indexed it, and expanded `COIN_TRANSACTION_TYPES` to include legacy and spend types in `models/CoinTransaction.js`.
- Updated `recordCoinReward` in `utils/coinHistory.js` to persist `direction` from `opts.direction` (defaulting to `income`) and preserved the previous positive-amount validation behavior.
- Changed `/api/account/me/coin-history` in `routes/account.js` to query positive `gold`/`silver` rows and exclude entries where `direction === 'spending'` or `type` is one of explicit spending types (`store_purchase`, `upgrade_purchase`, `purchase_spend`, `spend`, `cost`), and to include `direction` and `reason` in the response items.
- Updated reward writers to mark direction explicitly: race rewards are recorded as `race_reward` with `direction: 'income'` in `routes/leaderboard.js`, referral/refer writes include `direction: 'income'` in `utils/referralRewards.js`, and donation purchase writes record `direction: 'spending'` in `utils/donationService.js` so purchases are excluded from default history.
- Adjusted `tests/account-coin-history.test.js` to assert the new query shape (positive amounts + `direction != 'spending'` + spend-type exclusion) and included the `direction` expectation in API tests.

### Testing
- Ran the updated unit/integration tests with `node --test tests/coinHistory.test.js tests/account-coin-history.test.js` and all tests passed.
- During development an initial `npm test` run showed assertion mismatches while updating the query/tests; after aligning code and tests the focused test run above succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a099273e2c88326b8bc51cdfed83c2b)