### PR TITLE
Harden Telegram authentication for leaderboard save endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Versioned aliases are also available under `/api/v1/*` (backward-compatible with
 | `GET` | `/health` | Health check |
 | `GET` | `/metrics` | Prometheus metrics endpoint |
 | `GET` | `/api/leaderboard/top?wallet=` | Get top 10 players with `displayName` per entry (optional: include requesting player's position) |
-| `POST` | `/api/leaderboard/save` | Save game result (requires EIP-191 signature) |
+| `POST` | `/api/leaderboard/save` | Save game result (wallet mode: EIP-191 signature; telegram mode: Bearer sessionToken or validated Telegram initData) |
 | `GET` | `/api/leaderboard/player/:wallet` | Get player info and history |
 | `GET` | `/api/leaderboard/verified-results/:wallet` | Get verified game results for a wallet |
 | `GET` | `/api/store/upgrades/:wallet` | Get player upgrades, rides, and balance |
@@ -308,6 +308,7 @@ The store now contains **two parallel product systems**:
 - **EIP-191 signatures** are required for all write operations that modify player state. The server reconstructs the signed message and verifies it matches the submitted wallet address using `ethers.js`.
 - **Rate limiting is differentiated**: strict for `POST /api/leaderboard/save`, moderate for other write endpoints, and softer for read endpoints.
 - **Anti-cheat validation** on `POST /api/leaderboard/save` rejects results with implausible values (score > 999,999; distance > 99,999 m; gold or silver coins > 999 per game).
+- **Telegram leaderboard auth is server-verified**: `telegramId` in request body is payload data only and is never trusted as authentication proof. Use `Authorization: Bearer <sessionToken>` or valid `X-Telegram-Init-Data`.
 - **Score anomaly metric** is tracked per player: `averageScore`, `scoreToAverageRatio` (`bestScore / averageScore`), and `suspiciousScorePattern` for extreme outliers.
 - **Timestamp validation** accepts both unix seconds and milliseconds, allows stale results up to 2 hours old (`MAX_RESULT_TIMESTAMP_AGE_MS`), and allows up to 3 minutes future skew (`MAX_RESULT_FUTURE_SKEW_MS`).
 - **Replay protection** – each game result signature can only be submitted once.

--- a/routes/leaderboard.js
+++ b/routes/leaderboard.js
@@ -12,6 +12,8 @@ const { verifySignature, createMessageToVerify } = require('../utils/verifySigna
 const { saveResultLimiter, readLimiter } = require('../middleware/rateLimiter');
 const logger = require('../utils/logger');
 const { markSuspicious } = require('../middleware/requestMetrics');
+const { validateTelegramInitData } = require('../utils/telegramAuth');
+const { verifySessionToken } = require('../utils/sessionToken');
 const {
   logSecurityEvent,
   normalizeWallet,
@@ -168,6 +170,78 @@ function buildSharePostText(score, referralLink = '') {
   return parts.join('\n');
 }
 
+
+
+async function resolveVerifiedTelegramLeaderboardAuth(req, { walletLower, telegramId }) {
+  const authorization = req.get('authorization') || '';
+  const bearerMatch = authorization.match(/^Bearer\s+(.+)$/i);
+  const token = bearerMatch ? bearerMatch[1].trim() : '';
+  const telegramIdFromBody = telegramId == null ? '' : String(telegramId).trim();
+
+  if (token) {
+    try {
+      const decoded = verifySessionToken(token);
+      const tokenPrimaryId = String(decoded?.primaryId || '').trim().toLowerCase();
+      const tokenTelegramId = decoded?.telegramId == null ? '' : String(decoded.telegramId).trim();
+      if (!tokenPrimaryId || tokenPrimaryId !== walletLower) {
+        return { ok: false, status: 401, error: 'Telegram identity verification failed' };
+      }
+      if (telegramIdFromBody && tokenTelegramId && tokenTelegramId !== telegramIdFromBody) {
+        return { ok: false, status: 401, error: 'Telegram identity verification failed' };
+      }
+      if (!tokenTelegramId) {
+        return { ok: false, status: 401, error: 'Telegram identity verification failed' };
+      }
+
+      const link = await AccountLink.findOne({ primaryId: tokenPrimaryId, telegramId: tokenTelegramId });
+      if (!link) {
+        return { ok: false, status: 401, error: 'Telegram identity verification failed' };
+      }
+
+      return {
+        ok: true,
+        link,
+        primaryId: tokenPrimaryId,
+        telegramId: tokenTelegramId,
+        telegramUsername: link.telegramUsername || null
+      };
+    } catch (error) {
+      return { ok: false, status: 401, error: 'Telegram identity verification failed' };
+    }
+  }
+
+  const initData = String(req.get('x-telegram-init-data') || req.body?.telegramInitData || req.body?.initData || '').trim();
+  if (!initData) {
+    return { ok: false, status: 401, error: 'Telegram auth proof required' };
+  }
+
+  if (!process.env.TELEGRAM_BOT_TOKEN) {
+    return { ok: false, status: 503, error: 'Telegram auth is not configured' };
+  }
+
+  const validation = validateTelegramInitData(initData, process.env.TELEGRAM_BOT_TOKEN);
+  if (!validation.valid) {
+    return { ok: false, status: 401, error: 'Telegram identity verification failed' };
+  }
+
+  const verifiedTelegramId = String(validation.user.id);
+  if (telegramIdFromBody && telegramIdFromBody !== verifiedTelegramId) {
+    return { ok: false, status: 401, error: 'Telegram identity verification failed' };
+  }
+
+  const link = await AccountLink.findOne({ primaryId: walletLower, telegramId: verifiedTelegramId });
+  if (!link) {
+    return { ok: false, status: 401, error: 'Telegram identity verification failed' };
+  }
+
+  return {
+    ok: true,
+    link,
+    primaryId: walletLower,
+    telegramId: verifiedTelegramId,
+    telegramUsername: link.telegramUsername || null
+  };
+}
 function buildLeaderboardEntry(player, displayName, position) {
   return {
     position,
@@ -357,10 +431,18 @@ router.post('/save', saveResultLimiter, async (req, res) => {
     }
 
     const aiConfig = aiValidation.sanitized;
+    let verifiedTelegramAuth = null;
+    if (isTelegramAuth) {
+      verifiedTelegramAuth = await resolveVerifiedTelegramLeaderboardAuth(req, { walletLower, telegramId });
+      if (!verifiedTelegramAuth.ok) {
+        return res.status(verifiedTelegramAuth.status).json({ error: verifiedTelegramAuth.error });
+      }
+      logger.info({ wallet: walletLower }, 'Telegram identity verified');
+    }
+
     let hasAiAccess = hasAiModeAccess(walletLower);
-    if (!hasAiAccess && isTelegramAuth && telegramId) {
-      const tgLink = await AccountLink.findOne({ telegramId: String(telegramId) });
-      hasAiAccess = hasAiModeAccessByTelegramUsername(tgLink?.telegramUsername);
+    if (!hasAiAccess && isTelegramAuth) {
+      hasAiAccess = hasAiModeAccessByTelegramUsername(verifiedTelegramAuth?.telegramUsername);
     }
 
     if (aiConfig?.enabled && !hasAiAccess) {
@@ -429,15 +511,7 @@ router.post('/save', saveResultLimiter, async (req, res) => {
 
     logger.info({ serverTime: now, clientTimestamp: ts, ageMs }, 'Result timestamp check');
 
-    if (isTelegramAuth) {
-      // Verify that the telegramId matches the claimed primaryId (wallet) via AccountLink
-      const link = await AccountLink.findOne({ telegramId: String(telegramId) });
-      if (!link || link.primaryId !== walletLower) {
-        return res.status(401).json({ error: 'Telegram identity verification failed' });
-      }
-
-      logger.info({ wallet: walletLower }, 'Telegram identity verified');
-    } else {
+    if (!isTelegramAuth) {
       // Signature verification
       // Keep the exact wallet string provided by client in signed payload.
       // EIP-191 signatures are case-sensitive for message contents,

--- a/tests/api.integration.test.js
+++ b/tests/api.integration.test.js
@@ -16,6 +16,7 @@ const { setDonationVerifierForTests, resetDonationVerifier } = require('../utils
 const { setTelegramStarsClientForTests } = require('../utils/telegramStarsService');
 const { resetTelegramWebhookReplayStore } = require('../utils/telegramWebhookReplay');
 const crypto = require('crypto');
+const { signSessionToken } = require('../utils/sessionToken');
 
 const { createApp } = require('../app');
 
@@ -28,6 +29,24 @@ function queryResult(result) {
   };
 }
 
+
+
+function makeTelegramInitData({ telegramId, botToken, authDate = Math.floor(Date.now() / 1000) }) {
+  const user = JSON.stringify({ id: Number(telegramId), first_name: 'Test' });
+  const params = new URLSearchParams();
+  params.set('auth_date', String(authDate));
+  params.set('query_id', 'AAEAAAE');
+  params.set('user', user);
+
+  const dataCheckString = [...params.entries()]
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([key, value]) => `${key}=${value}`)
+    .join('\n');
+  const secretKey = crypto.createHmac('sha256', 'WebAppData').update(botToken).digest();
+  const hash = crypto.createHmac('sha256', secretKey).update(dataCheckString).digest('hex');
+  params.set('hash', hash);
+  return params.toString();
+}
 async function startServer() {
   const app = createApp();
   return new Promise((resolve) => {
@@ -44,6 +63,8 @@ let donationPayments;
 test.before(() => {
   process.env.TELEGRAM_BOT_SECRET = 'test-secret';
   process.env.TELEGRAM_WEBHOOK_SECRET = 'webhook-secret';
+  process.env.TELEGRAM_BOT_TOKEN = 'test-bot-token';
+  process.env.SESSION_SECRET = 'test-session-secret';
   originalStartSession = mongoose.startSession;
   mongoose.startSession = async () => {
     const err = new Error('Transactions unsupported in tests');
@@ -326,6 +347,88 @@ Timestamp: ${timestamp}`;
   await server.close();
 });
 
+
+
+
+test('POST /api/leaderboard/save telegram auth requires proof and rejects raw telegramId+wallet', async () => {
+  GameResult.findOne = () => queryResult(null);
+  Player.findOne = () => queryResult(null);
+
+  const { server, baseUrl } = await startServer();
+  const res = await fetch(`${baseUrl}/api/leaderboard/save`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ wallet: '0x5555555555555555555555555555555555555555', score: 10, distance: 5, telegramId: '555', authMode: 'telegram', timestamp: Date.now() })
+  });
+  assert.equal(res.status, 401);
+  const body = await res.json();
+  assert.equal(body.error, 'Telegram auth proof required');
+  await server.close();
+});
+
+test('POST /api/leaderboard/save telegram auth rejects sessionToken primaryId mismatch', async () => {
+  AccountLink.findOne = async (q = {}) => (q.primaryId === '0x5555555555555555555555555555555555555555' && q.telegramId === '555' ? { primaryId: '0x5555555555555555555555555555555555555555', telegramId: '555', telegramUsername: 'validuser' } : null);
+  GameResult.findOne = () => queryResult(null);
+  Player.findOne = () => queryResult(null);
+
+  const token = signSessionToken({ primaryId: '0x4444444444444444444444444444444444444444', telegramId: '555', authMode: 'telegram' });
+  const { server, baseUrl } = await startServer();
+  const res = await fetch(`${baseUrl}/api/leaderboard/save`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', authorization: `Bearer ${token}` },
+    body: JSON.stringify({ wallet: '0x5555555555555555555555555555555555555555', score: 10, distance: 5, telegramId: '555', authMode: 'telegram', timestamp: Date.now() })
+  });
+  assert.equal(res.status, 401);
+  await server.close();
+});
+
+test('POST /api/leaderboard/save telegram auth accepts valid initData with matching link', async () => {
+  AccountLink.findOne = async (q = {}) => (q.primaryId === '0x5555555555555555555555555555555555555555' && q.telegramId === '555' ? { primaryId: '0x5555555555555555555555555555555555555555', telegramId: '555', telegramUsername: 'validuser' } : null);
+  GameResult.findOne = () => queryResult(null);
+  Player.findOne = () => queryResult(null);
+
+  const initData = makeTelegramInitData({ telegramId: '555', botToken: process.env.TELEGRAM_BOT_TOKEN });
+  const { server, baseUrl } = await startServer();
+  const res = await fetch(`${baseUrl}/api/leaderboard/save`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', 'x-telegram-init-data': initData },
+    body: JSON.stringify({ wallet: '0x5555555555555555555555555555555555555555', score: 10, distance: 5, telegramId: '555', authMode: 'telegram', timestamp: Date.now() })
+  });
+  assert.equal(res.status, 200);
+  await server.close();
+});
+
+test('POST /api/leaderboard/save telegram auth rejects initData telegramId mismatch with body', async () => {
+  AccountLink.findOne = async () => ({ primaryId: '0x5555555555555555555555555555555555555555', telegramId: '555', telegramUsername: 'validuser' });
+  GameResult.findOne = () => queryResult(null);
+  Player.findOne = () => queryResult(null);
+
+  const initData = makeTelegramInitData({ telegramId: '555', botToken: process.env.TELEGRAM_BOT_TOKEN });
+  const { server, baseUrl } = await startServer();
+  const res = await fetch(`${baseUrl}/api/leaderboard/save`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', 'x-telegram-init-data': initData },
+    body: JSON.stringify({ wallet: '0x5555555555555555555555555555555555555555', score: 10, distance: 5, telegramId: '999', authMode: 'telegram', timestamp: Date.now() })
+  });
+  assert.equal(res.status, 401);
+  await server.close();
+});
+
+test('POST /api/leaderboard/save telegram auth accepts valid session token with matching link', async () => {
+  AccountLink.findOne = async (q = {}) => (q.primaryId === '0x5555555555555555555555555555555555555555' && q.telegramId === '555' ? { primaryId: '0x5555555555555555555555555555555555555555', telegramId: '555', telegramUsername: 'validuser' } : null);
+  GameResult.findOne = () => queryResult(null);
+  Player.findOne = () => queryResult(null);
+
+  const token = signSessionToken({ primaryId: '0x5555555555555555555555555555555555555555', telegramId: '555', authMode: 'telegram' });
+  const { server, baseUrl } = await startServer();
+  const res = await fetch(`${baseUrl}/api/leaderboard/save`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', authorization: `Bearer ${token}` },
+    body: JSON.stringify({ wallet: '0x5555555555555555555555555555555555555555', score: 10, distance: 5, telegramId: '555', authMode: 'telegram', timestamp: Date.now() })
+  });
+  assert.equal(res.status, 200);
+  await server.close();
+});
 
 test('POST /api/store/buy returns insufficient funds', async () => {
   const wallet = Wallet.createRandom();
@@ -1584,6 +1687,8 @@ test('POST /api/telegram/webhook rejects requests with missing or invalid secret
   assert.equal(validSecret.status, 200);
 
   process.env.TELEGRAM_WEBHOOK_SECRET = 'webhook-secret';
+  process.env.TELEGRAM_BOT_TOKEN = 'test-bot-token';
+  process.env.SESSION_SECRET = 'test-session-secret';
   await server.close();
 });
 


### PR DESCRIPTION
### Motivation
- Close a security hole in `POST /api/leaderboard/save` where raw `telegramId` + `wallet` from the client were treated as proof of identity and could be forged.
- Ensure Telegram-backed leaderboard saves require server-verified identity (session token or validated Telegram initData) while keeping wallet signature flow unchanged.
- Prevent AI-access checks from using unverified telegram identifiers.

### Description
- Added `resolveVerifiedTelegramLeaderboardAuth(req, { walletLower, telegramId })` to `routes/leaderboard.js` which verifies identity by either `Authorization: Bearer <sessionToken>` via `verifySessionToken` or by validated Telegram `initData` via `validateTelegramInitData` and returns a verified `AccountLink` or a safe error (401/503).
- Updated `POST /api/leaderboard/save` flow to call the new resolver for `authMode === 'telegram'`, reject when verification fails, and only then use `verifiedTelegramAuth.telegramUsername` for AI access checks.
- Preserved existing wallet signature (EIP-191) verification and all anti-cheat, timestamp, duplicate-prevention, and persistence logic for non-Telegram saves.
- Added integration tests covering telegram proof requirements and session/initData verification paths and updated `README.md` to document the new requirements.

### Testing
- Ran `npm run check:syntax` and it passed (syntax check passed for 112 JavaScript files).
- Ran full test suite with `npm test`; result included many pre-existing/integration failures in this environment and the run is not fully green.
- Focused integration assertions for the new Telegram checks show: the test asserting that raw `telegramId`+`wallet` is rejected passed, while tests for session-token and initData positive/mismatch cases were exercised but failed in this environment (see test output: one telegram test passed, four telegram-related tests failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10979edb8883269d963062104278fe)