### PR TITLE
Harden store ride consume auth and anti-cheat

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,8 +312,11 @@ The store now contains **two parallel product systems**:
 - **Score anomaly metric** is tracked per player: `averageScore`, `scoreToAverageRatio` (`bestScore / averageScore`), and `suspiciousScorePattern` for extreme outliers.
 - **Timestamp validation** accepts both unix seconds and milliseconds, allows stale results up to 2 hours old (`MAX_RESULT_TIMESTAMP_AGE_MS`), and allows up to 3 minutes future skew (`MAX_RESULT_FUTURE_SKEW_MS`).
 - **Replay protection** – each game result signature can only be submitted once.
-- **Ride anti-cheat** on `POST /api/store/consume-ride`: every consume request must include a unique `rideSessionId`; duplicate IDs are rejected without spending another ride.
-- Legacy `POST /api/store/use-ride` is still supported for backward compatibility (without strict `rideSessionId` enforcement), but migration to `/consume-ride` is recommended.
+- **Ride consume is authenticated**: `POST /api/store/consume-ride` requires `Authorization: Bearer <sessionToken>` and consumes rides only for the authenticated `primaryId`.
+- `rideSessionId` is **mandatory** on `POST /api/store/consume-ride` (`string`, trimmed, length `8..128`), otherwise API returns `400 { "error": "invalid_ride_session_id" }`.
+- Optional `wallet` in body is treated as a consistency check only; if provided for another account, API returns `403 { "error": "account_mismatch" }`.
+- **Duplicate anti-cheat**: repeated `rideSessionId` returns `409` with `antiCheatTriggered: true` and does not consume additional rides.
+- Legacy `POST /api/store/use-ride` is deprecated and disabled by default, returning `410 { "error": "legacy_use_ride_disabled" }`. It can be temporarily re-enabled only with `ALLOW_LEGACY_USE_RIDE=true`, and still uses the same authenticated + strict `rideSessionId` path.
 - **Structured JSON logging** (stdout/stderr) for easy ingestion in Railway/ELK/Cloud logging
 - **Security event trail**: suspicious actions (invalid timestamps/scores, duplicate ride sessions, rapid purchase bursts) are persisted in `SecurityEvent`.
 - **Prometheus metrics** are exposed on `/metrics` (default Node process metrics + request latency + suspicious events counter).

--- a/routes/store.js
+++ b/routes/store.js
@@ -8,6 +8,7 @@ const { listDonationProducts, listDonationPayments, createDonationPayment, submi
 const { verifySignature } = require('../utils/verifySignature');
 const { validateTelegramInitData } = require('../utils/telegramAuth');
 const { writeLimiter, readLimiter } = require('../middleware/rateLimiter');
+const { requireAuth } = require('../middleware/requireAuth');
 const SecurityEvent = require('../models/SecurityEvent');
 const CoinTransaction = require('../models/CoinTransaction');
 const logger = require('../utils/logger');
@@ -523,15 +524,18 @@ function createPurchaseAudit({ wallet, req, res, purchaseDetails }) {
  * GET /api/store/upgrades/:wallet
  * Get all upgrades + rides + effects
  */
-router.get('/upgrades/:wallet', readLimiter, async (req, res) => {
+router.get('/upgrades/:wallet', readLimiter, requireAuth, async (req, res) => {
   try {
     const identifier = String(req.params.wallet || '').trim().toLowerCase();
-    const identity = await resolveStoreAccountIdentity(req);
-    if (!identity?.accountKey) {
-      return res.status(404).json({ error: 'Account not found' });
+    const accountKey = String(req.primaryId || '').trim().toLowerCase();
+    const linkedWallet = String(req.authLink?.wallet || '').trim().toLowerCase();
+    if (!accountKey) {
+      return res.status(401).json({ error: 'authentication_required' });
     }
-
-    const { accountKey, telegramUsername } = identity;
+    if (identifier && identifier !== accountKey && identifier !== linkedWallet) {
+      return res.status(403).json({ error: 'account_mismatch' });
+    }
+    const telegramUsername = String(req.authLink?.telegramUsername || '').trim();
 
     const upgrades = await getOrCreatePlayerUpgrades(accountKey);
     await prepareUpgrades(upgrades, { persist: true });
@@ -549,10 +553,10 @@ router.get('/upgrades/:wallet', readLimiter, async (req, res) => {
     logger.info({
       route: "GET /api/store/upgrades",
       identifier,
-      authMode: identity.authMode,
-      primaryId: identity.primaryId,
-      telegramId: identity.telegramId,
-      wallet: identity.wallet,
+      authMode: req.auth?.authMode || 'session',
+      primaryId: accountKey,
+      telegramId: req.authLink?.telegramId || '',
+      wallet: linkedWallet,
       accountKey,
       foundPlayer: Boolean(player),
       balance: { gold, silver },
@@ -1077,27 +1081,17 @@ function purchasePrice(config, tier, beforeSnapshot) {
 const consumeRideHandler = async (req, res) => {
   try {
     const { wallet, rideSessionId } = req.body;
-    if (!wallet) return res.status(400).json({ error: 'Missing wallet' });
+    const accountKey = String(req.primaryId || '').trim().toLowerCase();
+    if (!accountKey) return res.status(401).json({ error: 'authentication_required' });
 
-    const resolverReq = {
-      params: { wallet },
-      body: req.body,
-      get: (headerName) => req.get(headerName)
-    };
-    const identity = await resolveStoreAccountIdentity(resolverReq);
-    const accountKey = identity?.accountKey;
-    if (!accountKey) return res.status(404).json({ error: 'Account not found' });
-    const isLegacyUseRideRoute = req.path === '/use-ride';
-
-    let sessionId = null;
-    if (rideSessionId && typeof rideSessionId === 'string' && rideSessionId.trim().length >= 8) {
-      sessionId = rideSessionId.trim();
-    } else if (!isLegacyUseRideRoute) {
-      return res.status(400).json({
-        error: 'Missing or invalid rideSessionId',
-        details: 'Pass a unique rideSessionId for every game start to enable anti-cheat duplicate protection.'
-      });
+    const linkedWallet = String(req.authLink?.wallet || '').trim().toLowerCase();
+    const normalizedBodyWallet = String(wallet || '').trim().toLowerCase();
+    if (normalizedBodyWallet && normalizedBodyWallet !== accountKey && normalizedBodyWallet !== linkedWallet) {
+      return res.status(403).json({ error: 'account_mismatch' });
     }
+    if (typeof rideSessionId !== 'string') return res.status(400).json({ error: 'invalid_ride_session_id' });
+    const sessionId = rideSessionId.trim();
+    if (sessionId.length < 8 || sessionId.length > 128) return res.status(400).json({ error: 'invalid_ride_session_id' });
     const upgrades = await getOrCreatePlayerUpgrades(accountKey);
     await prepareUpgrades(upgrades);
     
@@ -1144,11 +1138,9 @@ const consumeRideHandler = async (req, res) => {
       return res.status(403).json({ error: 'Failed to consume ride' });
     }
     
-   if (sessionId) {
-      upgrades.recentRideSessionIds.push(sessionId);
-      if (upgrades.recentRideSessionIds.length > 30) {
-        upgrades.recentRideSessionIds = upgrades.recentRideSessionIds.slice(-30);
-      }
+    upgrades.recentRideSessionIds.push(sessionId);
+    if (upgrades.recentRideSessionIds.length > 30) {
+      upgrades.recentRideSessionIds = upgrades.recentRideSessionIds.slice(-30);
     }
     upgrades.updatedAt = new Date();
     await upgrades.save();
@@ -1156,13 +1148,9 @@ const consumeRideHandler = async (req, res) => {
     logger.info({ wallet: accountKey, freeRidesRemaining: upgrades.freeRidesRemaining, paidRidesRemaining: upgrades.paidRidesRemaining }, 'Ride consumed');
     
 
-    const antiCheat = sessionId
-      ? { duplicateSessionCheck: true, rideSessionId: sessionId }
-      : { duplicateSessionCheck: false, warning: 'Legacy /use-ride call without rideSessionId. Please migrate to /consume-ride with rideSessionId.' };
-
     res.json({
       success: true,
-      antiCheat,
+      antiCheat: { duplicateSessionCheck: true, rideSessionId: sessionId },
       rides: buildRidesData(upgrades)
     });
 
@@ -1172,21 +1160,30 @@ const consumeRideHandler = async (req, res) => {
   }
 };
 
-router.post('/consume-ride', writeLimiter, consumeRideHandler);
-router.post('/use-ride', writeLimiter, consumeRideHandler);
+router.post('/consume-ride', writeLimiter, requireAuth, consumeRideHandler);
+router.post('/use-ride', writeLimiter, requireAuth, (req, res, next) => {
+  const allowLegacyUseRide = String(process.env.ALLOW_LEGACY_USE_RIDE || 'false').trim().toLowerCase() === 'true';
+  if (!allowLegacyUseRide) {
+    return res.status(410).json({ error: 'legacy_use_ride_disabled' });
+  }
+  return consumeRideHandler(req, res, next);
+});
 
 /**
  * GET /api/store/rides/:wallet
  * Get rides info
  */
-router.get('/rides/:wallet', readLimiter, async (req, res) => {
+router.get('/rides/:wallet', readLimiter, requireAuth, async (req, res) => {
   try {
-    const identity = await resolveStoreAccountIdentity(req);
-    if (!identity?.accountKey) {
-      return res.status(404).json({ error: 'Account not found' });
+    const accountKey = String(req.primaryId || '').trim().toLowerCase();
+    if (!accountKey) return res.status(401).json({ error: 'authentication_required' });
+    const requestedWallet = String(req.params.wallet || '').trim().toLowerCase();
+    const linkedWallet = String(req.authLink?.wallet || '').trim().toLowerCase();
+    if (requestedWallet && requestedWallet !== accountKey && requestedWallet !== linkedWallet) {
+      return res.status(403).json({ error: 'account_mismatch' });
     }
 
-    const upgrades = await getOrCreatePlayerUpgrades(identity.accountKey);
+    const upgrades = await getOrCreatePlayerUpgrades(accountKey);
     await prepareUpgrades(upgrades, { persist: true });
 
     const ridesData = buildRidesData(upgrades);

--- a/tests/api.integration.test.js
+++ b/tests/api.integration.test.js
@@ -57,6 +57,17 @@ async function startServer() {
   });
 }
 
+async function buildAuthHeaders(primaryId, wallet) {
+  const normalizedPrimaryId = String(primaryId).toLowerCase();
+  const normalizedWallet = String(wallet).toLowerCase();
+  await new AccountLink({ primaryId: normalizedPrimaryId, wallet: normalizedWallet }).save();
+  const token = signSessionToken({ primaryId: normalizedPrimaryId });
+  return {
+    authorization: `Bearer ${token}`,
+    'content-type': 'application/json'
+  };
+}
+
 let originalStartSession;
 let donationPayments;
 
@@ -1054,7 +1065,8 @@ test('GET /api/store/upgrades/:wallet returns ai_mode_access=true for whiteliste
   });
 
   const { server, baseUrl } = await startServer();
-  const res = await fetch(`${baseUrl}/api/store/upgrades/${wallet}`);
+  const headers = await buildAuthHeaders(wallet, wallet);
+  const res = await fetch(`${baseUrl}/api/store/upgrades/${wallet}`, { headers });
   assert.equal(res.status, 200);
   const body = await res.json();
   assert.equal(body.activeEffects.ai_mode_access, true);
@@ -1076,7 +1088,8 @@ test('GET /api/store/upgrades/:wallet for new wallet returns zeroed gold upgrade
   };
 
   const { server, baseUrl } = await startServer();
-  const res = await fetch(`${baseUrl}/api/store/upgrades/${wallet}`);
+  const headers = await buildAuthHeaders(wallet, wallet);
+  const res = await fetch(`${baseUrl}/api/store/upgrades/${wallet}`, { headers });
   assert.equal(res.status, 200);
   const body = await res.json();
 
@@ -1142,7 +1155,8 @@ test('GET /api/store/upgrades/:wallet normalizes legacy string levels and radar 
   });
 
   const { server, baseUrl } = await startServer();
-  const res = await fetch(`${baseUrl}/api/store/upgrades/${wallet}`);
+  const headers = await buildAuthHeaders(wallet, wallet);
+  const res = await fetch(`${baseUrl}/api/store/upgrades/${wallet}`, { headers });
   assert.equal(res.status, 200);
   const body = await res.json();
 
@@ -1182,7 +1196,8 @@ test('GET /api/store/upgrades/:wallet returns ai_mode_access=false for regular w
   });
 
   const { server, baseUrl } = await startServer();
-  const res = await fetch(`${baseUrl}/api/store/upgrades/${wallet}`);
+  const headers = await buildAuthHeaders(wallet, wallet);
+  const res = await fetch(`${baseUrl}/api/store/upgrades/${wallet}`, { headers });
   assert.equal(res.status, 200);
   const body = await res.json();
   assert.equal(body.activeEffects.ai_mode_access, false);
@@ -1250,6 +1265,74 @@ test('POST /api/leaderboard/save validates aiSettings fields', async () => {
   assert.equal(res.status, 400);
   const body = await res.json();
   assert.match(body.error, /distance must be integer >= 0/i);
+  await server.close();
+});
+
+test('store ride consume endpoints require auth and rideSessionId, enforce anti-cheat', async () => {
+  const wallet = Wallet.createRandom().address.toLowerCase();
+  const headers = await buildAuthHeaders(wallet, wallet);
+  const upgradesState = {
+    wallet,
+    freeRidesRemaining: 3,
+    paidRidesRemaining: 0,
+    freeRidesResetAt: new Date(),
+    recentRideSessionIds: [],
+    refreshFreeRides() { return false; },
+    getTotalRides() { return this.freeRidesRemaining + this.paidRidesRemaining; },
+    consumeRide() { if (this.freeRidesRemaining > 0) { this.freeRidesRemaining -= 1; return true; } return false; },
+    save: async function save() { return this; }
+  };
+  PlayerUpgrades.findOneAndUpdate = async () => upgradesState;
+
+  const { server, baseUrl } = await startServer();
+
+  const unauth = await fetch(`${baseUrl}/api/store/consume-ride`, { method: 'POST', headers: { 'content-type': 'application/json' }, body: JSON.stringify({ rideSessionId: 'session-001' }) });
+  assert.equal(unauth.status, 401);
+
+  const missingSession = await fetch(`${baseUrl}/api/store/consume-ride`, { method: 'POST', headers, body: JSON.stringify({}) });
+  assert.equal(missingSession.status, 400);
+  assert.equal((await missingSession.json()).error, 'invalid_ride_session_id');
+
+  const first = await fetch(`${baseUrl}/api/store/consume-ride`, { method: 'POST', headers, body: JSON.stringify({ rideSessionId: 'session-001' }) });
+  assert.equal(first.status, 200);
+  assert.equal((await first.json()).success, true);
+
+  const duplicate = await fetch(`${baseUrl}/api/store/consume-ride`, { method: 'POST', headers, body: JSON.stringify({ rideSessionId: 'session-001' }) });
+  assert.equal(duplicate.status, 409);
+  const duplicateBody = await duplicate.json();
+  assert.equal(duplicateBody.antiCheatTriggered, true);
+
+  const mismatch = await fetch(`${baseUrl}/api/store/consume-ride`, { method: 'POST', headers, body: JSON.stringify({ wallet: Wallet.createRandom().address.toLowerCase(), rideSessionId: 'session-002' }) });
+  assert.equal(mismatch.status, 403);
+  assert.equal((await mismatch.json()).error, 'account_mismatch');
+
+  const legacy = await fetch(`${baseUrl}/api/store/use-ride`, { method: 'POST', headers, body: JSON.stringify({ rideSessionId: 'session-003' }) });
+  assert.equal(legacy.status, 410);
+  assert.equal((await legacy.json()).error, 'legacy_use_ride_disabled');
+
+  await server.close();
+});
+
+test('GET /api/store/rides/:wallet requires auth and blocks mismatched wallet', async () => {
+  const wallet = Wallet.createRandom().address.toLowerCase();
+  const anotherWallet = Wallet.createRandom().address.toLowerCase();
+  const headers = await buildAuthHeaders(wallet, wallet);
+  PlayerUpgrades.findOneAndUpdate = async () => ({
+    freeRidesRemaining: 3,
+    paidRidesRemaining: 0,
+    freeRidesResetAt: new Date(),
+    refreshFreeRides() { return false; },
+    getTotalRides() { return 3; },
+    save: async function save() { return this; }
+  });
+  const { server, baseUrl } = await startServer();
+
+  const unauth = await fetch(`${baseUrl}/api/store/rides/${wallet}`);
+  assert.equal(unauth.status, 401);
+
+  const forbidden = await fetch(`${baseUrl}/api/store/rides/${anotherWallet}`, { headers });
+  assert.equal(forbidden.status, 403);
+
   await server.close();
 });
 


### PR DESCRIPTION
### Motivation
- Close several unsafe paths that allowed rides to be consumed without proper auth or without a ride session id, and ensure duplicate anti-cheat cannot be bypassed by legacy requests or by supplying arbitrary wallet identifiers in request body.

### Description
- Protect store routes by adding `requireAuth` to `POST /api/store/consume-ride`, `GET /api/store/rides/:wallet`, and `GET /api/store/upgrades/:wallet` and resolve account strictly from `req.primaryId` rather than body/params.  
- Treat optional `body.wallet` only as a consistency check and return `403 { error: "account_mismatch" }` if it does not match the authenticated `primaryId` or linked wallet.  
- Require `rideSessionId` for consumption: must be a `string`, trimmed, length `8..128`; invalid or missing -> `400 { error: "invalid_ride_session_id" }`.  
- Always run duplicate anti-cheat check against a validated `rideSessionId` and return `409 { error: "Ride already consumed for this session", antiCheatTriggered: true }` on duplicate.  
- Disable legacy `POST /api/store/use-ride` by default returning `410 { error: "legacy_use_ride_disabled" }`, and allow temporary re-enable only when `ALLOW_LEGACY_USE_RIDE=true` (it still requires auth + session id).  
- Update `README.md` Security section to document `Authorization: Bearer <sessionToken>`, mandatory `rideSessionId`, duplicate semantics, and legacy endpoint deprecation.  
- Add/adjust integration tests and a `buildAuthHeaders` helper to cover the new authenticated flows and anti-cheat behavior (`tests/api.integration.test.js`).

### Testing
- `npm run check:syntax` — passed (`Syntax check passed for 112 JavaScript files`).
- `npm test` — full suite was executed; there are unrelated, pre-existing test failures in this environment, however the newly added/updated store tests passed: `store ride consume endpoints require auth and rideSessionId, enforce anti-cheat` and `GET /api/store/rides/:wallet requires auth and blocks mismatched wallet`.  The PR includes these integration tests which validate 401/400/200/409/403/410 behaviors for consume/legacy routes and rides endpoint.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10993052008326a85afb8ec96509e4)