### PR TITLE
Fix Mongo readiness gating and fast-fail DB-bound auth routes

### DIFF
--- a/app.js
+++ b/app.js
@@ -18,6 +18,7 @@ const Player = require('./models/Player');
 const ShareEvent = require('./models/ShareEvent');
 const { sanitizeReferralCode, buildReferralLandingUrl, isSocialPreviewCrawler } = require('./utils/referral');
 const { metricsMiddleware, renderMetricsText } = require('./middleware/requestMetrics');
+const { requireMongoReady } = require('./middleware/requireMongoReady');
 const { renderScoreSharePng } = require('./utils/shareCard');
 const { getPublicTelegramAnalyticsConfig } = require('./src/config/analytics');
 
@@ -57,22 +58,27 @@ function getPublicBaseUrl(req) {
 
 function getRouteRegistry() {
   return [
-    { path: '/leaderboard', router: leaderboardRoutes },
-    { path: '/store', router: storeRoutes },
-    { path: '/account', router: accountRoutes },
-    { path: '/game', router: gameRoutes },
+    { path: '/leaderboard', router: leaderboardRoutes, requireMongo: true },
+    { path: '/store', router: storeRoutes, requireMongo: true },
+    { path: '/account', router: accountRoutes, requireMongo: true },
+    { path: '/game', router: gameRoutes, requireMongo: true },
     { path: '', router: donationsRoutes },
-    { path: '/referral', router: referralRoutes },
-    { path: '/referrals', router: referralRoutes },
-    { path: '/share', router: shareRoutes },
-    { path: '/x', router: xRoutes },
-    { path: '/onboarding', router: onboardingRoutes }
+    { path: '/referral', router: referralRoutes, requireMongo: true },
+    { path: '/referrals', router: referralRoutes, requireMongo: true },
+    { path: '/share', router: shareRoutes, requireMongo: true },
+    { path: '/x', router: xRoutes, requireMongo: true },
+    { path: '/onboarding', router: onboardingRoutes, requireMongo: true }
   ];
 }
 
 function mountApiRoutes(app, basePrefix) {
-  for (const { path, router } of getRouteRegistry()) {
-    app.use(`${basePrefix}${path}`, router);
+  for (const { path, router, requireMongo } of getRouteRegistry()) {
+    const fullPath = `${basePrefix}${path}`;
+    if (requireMongo) {
+      app.use(fullPath, requireMongoReady, router);
+      continue;
+    }
+    app.use(fullPath, router);
   }
 }
 
@@ -310,6 +316,11 @@ function createApp() {
     res.json({
       status: readyState === 1 ? 'OK' : 'DEGRADED',
       timestamp: new Date(),
+      uptime: process.uptime(),
+      environment: {
+        nodeEnv: process.env.NODE_ENV || 'development',
+        railwayEnvironment: process.env.RAILWAY_ENVIRONMENT_NAME || null
+      },
       mongodb: mongoStatus,
       mongodbDetails: {
         readyState,

--- a/database.js
+++ b/database.js
@@ -1,28 +1,35 @@
 const mongoose = require('mongoose');
+const logger = require('./utils/logger');
+
+const RETRY_DELAY_MS = Number(process.env.MONGO_RETRY_DELAY_MS || 5000);
+
+function delay(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
 
 async function connectDB() {
-  try {
-    const mongoUri = process.env.MONGO_URL;
-    
-    if(!mongoUri) {
-      throw new Error('MONGO_URL is missing');
-    }
-    
-    await mongoose.connect(mongoUri, {
-      connectTimeoutMS: 10000,
-      serverSelectionTimeoutMS: 10000
-    });
-    
-    console.log('✅ MongoDB подключена');
-  } catch(error) {
-    console.error('❌ Ошибка MongoDB:', error.message);
+  const mongoUri = process.env.MONGO_URL;
 
-    if (!process.env.MONGO_URL) {
-      throw error;
-    }
+  if (!mongoUri) {
+    throw new Error('MONGO_URL is missing');
+  }
 
-    setTimeout(() => connectDB(), 5000);
-    throw error;
+  let attempt = 0;
+  while (true) {
+    attempt += 1;
+
+    try {
+      logger.info({ attempt }, 'MongoDB connect attempt');
+      await mongoose.connect(mongoUri, {
+        connectTimeoutMS: 10000,
+        serverSelectionTimeoutMS: 10000
+      });
+      logger.info({ attempt }, 'MongoDB connected');
+      return mongoose.connection;
+    } catch (error) {
+      logger.error({ err: error.message, attempt, retryInMs: RETRY_DELAY_MS }, 'MongoDB connection failed, retrying');
+      await delay(RETRY_DELAY_MS);
+    }
   }
 }
 

--- a/middleware/requireMongoReady.js
+++ b/middleware/requireMongoReady.js
@@ -1,0 +1,19 @@
+const mongoose = require('mongoose');
+
+function requireMongoReady(req, res, next) {
+  if ((process.env.NODE_ENV || '').toLowerCase() === 'test' && process.env.ENFORCE_MONGO_READINESS !== 'true') {
+    return next();
+  }
+
+  if (mongoose.connection?.readyState === 1) return next();
+
+  return res.status(503).json({
+    error: 'database_unavailable',
+    message: 'Database is not ready. Please retry shortly.',
+    mongodb: {
+      readyState: mongoose.connection?.readyState ?? null
+    }
+  });
+}
+
+module.exports = { requireMongoReady };

--- a/tests/mongo-readiness-guard.test.js
+++ b/tests/mongo-readiness-guard.test.js
@@ -1,0 +1,103 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const crypto = require('crypto');
+const mongoose = require('mongoose');
+const { createApp } = require('../app');
+
+function makeTelegramInitData({ telegramId, botToken, authDate = Math.floor(Date.now() / 1000) }) {
+  const user = JSON.stringify({ id: Number(telegramId), first_name: 'Test' });
+  const params = new URLSearchParams();
+  params.set('auth_date', String(authDate));
+  params.set('query_id', 'AAEAAAE');
+  params.set('user', user);
+
+  const dataCheckString = [...params.entries()]
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([key, value]) => `${key}=${value}`)
+    .join('\n');
+  const secretKey = crypto.createHmac('sha256', 'WebAppData').update(botToken).digest();
+  const hash = crypto.createHmac('sha256', secretKey).update(dataCheckString).digest('hex');
+  params.set('hash', hash);
+  return params.toString();
+}
+
+async function startServer() {
+  const app = createApp();
+  return new Promise((resolve) => {
+    const server = app.listen(0, '127.0.0.1', () => {
+      const { port } = server.address();
+      resolve({ server, baseUrl: `http://127.0.0.1:${port}` });
+    });
+  });
+}
+
+test('mongo readiness guard protects auth endpoints and keeps health/public-config available', async () => {
+  process.env.TELEGRAM_BOT_TOKEN = 'test-bot-token';
+  process.env.ENFORCE_MONGO_READINESS = 'true';
+  const originalReadyState = mongoose.connection.readyState;
+
+  try {
+    mongoose.connection.readyState = 0;
+    const { server, baseUrl } = await startServer();
+
+    const walletStart = Date.now();
+    const walletRes = await fetch(`${baseUrl}/api/account/auth/wallet`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ wallet: '0x1111111111111111111111111111111111111111', signature: '0xdeadbeef', timestamp: Date.now() })
+    });
+    const walletElapsedMs = Date.now() - walletStart;
+    assert.equal(walletRes.status, 503);
+    assert.ok(walletElapsedMs < 500, `expected fast failure, got ${walletElapsedMs}ms`);
+
+    const walletBody = await walletRes.json();
+    assert.equal(walletBody.error, 'database_unavailable');
+
+    const telegramStart = Date.now();
+    const telegramRes = await fetch(`${baseUrl}/api/account/auth/telegram`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ telegramInitData: makeTelegramInitData({ telegramId: 123, botToken: process.env.TELEGRAM_BOT_TOKEN }) })
+    });
+    const telegramElapsedMs = Date.now() - telegramStart;
+    assert.equal(telegramRes.status, 503);
+    assert.ok(telegramElapsedMs < 500, `expected fast failure, got ${telegramElapsedMs}ms`);
+
+    const healthRes = await fetch(`${baseUrl}/health`);
+    assert.equal(healthRes.status, 200);
+    const healthBody = await healthRes.json();
+    assert.equal(healthBody.status, 'DEGRADED');
+    assert.equal(typeof healthBody.uptime, 'number');
+    assert.ok(healthBody.environment);
+
+    const configRes = await fetch(`${baseUrl}/api/public-config`);
+    assert.equal(configRes.status, 200);
+
+    await server.close();
+  } finally {
+    delete process.env.ENFORCE_MONGO_READINESS;
+    mongoose.connection.readyState = originalReadyState;
+  }
+});
+
+test('wallet auth route behaves normally when mongo is ready', async () => {
+  const originalReadyState = mongoose.connection.readyState;
+
+  try {
+    process.env.ENFORCE_MONGO_READINESS = 'true';
+    mongoose.connection.readyState = 1;
+    const { server, baseUrl } = await startServer();
+
+    const res = await fetch(`${baseUrl}/api/account/auth/wallet`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ wallet: '0x1111111111111111111111111111111111111111', signature: '0xdeadbeef', timestamp: Date.now() })
+    });
+
+    assert.notEqual(res.status, 503);
+    await server.close();
+  } finally {
+    delete process.env.ENFORCE_MONGO_READINESS;
+    mongoose.connection.readyState = originalReadyState;
+  }
+});

--- a/utils/accountManager.js
+++ b/utils/accountManager.js
@@ -125,21 +125,45 @@ function buildAccountSummary({ primaryId, telegramId = null, wallet = null, isLi
 }
 
 async function ensurePlayerExists(primaryId) {
-  let player = await Player.findOne({ wallet: primaryId });
-  if (!player) {
-    player = buildNewPlayer(primaryId);
-    await player.save();
+  if (typeof Player.findOneAndUpdate !== 'function') {
+    let player = await Player.findOne({ wallet: primaryId });
+    if (!player) {
+      player = buildNewPlayer(primaryId);
+      await player.save();
+    }
+    return player;
   }
-  return player;
+  return Player.findOneAndUpdate(
+    { wallet: primaryId },
+    {
+      $setOnInsert: {
+        wallet: primaryId,
+        bestScore: 0,
+        bestDistance: 0,
+        totalGoldCoins: 0,
+        totalSilverCoins: 0,
+        gamesPlayed: 0,
+        gameHistory: []
+      }
+    },
+    { upsert: true, new: true, setDefaultsOnInsert: true }
+  );
 }
 
 async function ensureUpgradesExist(primaryId) {
-  let upgrades = await PlayerUpgrades.findOne({ wallet: primaryId });
-  if (!upgrades) {
-    upgrades = new PlayerUpgrades({ wallet: primaryId });
-    await upgrades.save();
+  if (typeof PlayerUpgrades.findOneAndUpdate !== 'function') {
+    let upgrades = await PlayerUpgrades.findOne({ wallet: primaryId });
+    if (!upgrades) {
+      upgrades = new PlayerUpgrades({ wallet: primaryId });
+      await upgrades.save();
+    }
+    return upgrades;
   }
-  return upgrades;
+  return PlayerUpgrades.findOneAndUpdate(
+    { wallet: primaryId },
+    { $setOnInsert: { wallet: primaryId } },
+    { upsert: true, new: true, setDefaultsOnInsert: true }
+  );
 }
 
 async function ensureAccountResources(primaryId) {
@@ -229,8 +253,24 @@ async function getOrCreateTelegramAccount(telegramId) {
 
   // Создаём новую
   const primaryId = `tg_${tgIdStr}`;
-  link = buildAccountLink({ primaryId, telegramId: tgIdStr });
-  await link.save();
+  if (typeof AccountLink.findOneAndUpdate === 'function') {
+    link = await AccountLink.findOneAndUpdate(
+    { telegramId: tgIdStr },
+    {
+      $setOnInsert: {
+        telegramId: tgIdStr,
+        wallet: null,
+        primaryId,
+        masterSource: null,
+        linkedAt: null
+      }
+    },
+      { upsert: true, new: true, setDefaultsOnInsert: true }
+    );
+  } else {
+    link = buildAccountLink({ primaryId, telegramId: tgIdStr });
+    await link.save();
+  }
 
   await ensureAccountResources(primaryId);
 
@@ -256,8 +296,24 @@ async function getOrCreateWalletAccount(walletAddress) {
 
   // Создаём новую связку — primaryId = адрес кошелька
   const primaryId = wallet;
-  link = buildAccountLink({ primaryId, wallet });
-  await link.save();
+  if (typeof AccountLink.findOneAndUpdate === 'function') {
+    link = await AccountLink.findOneAndUpdate(
+    { wallet },
+    {
+      $setOnInsert: {
+        telegramId: null,
+        wallet,
+        primaryId,
+        masterSource: null,
+        linkedAt: null
+      }
+    },
+      { upsert: true, new: true, setDefaultsOnInsert: true }
+    );
+  } else {
+    link = buildAccountLink({ primaryId, wallet });
+    await link.save();
+  }
 
   await ensureAccountResources(primaryId);
 


### PR DESCRIPTION
### Motivation
- Prevent DB-bound endpoints (e.g. wallet and Telegram auth) from hanging when MongoDB is not ready by returning a fast, controlled error instead of letting requests block until client timeout. 
- Make startup and DB retry behavior deterministic and avoid uncontrolled parallel reconnect attempts so background loops/bots only start after DB connectivity is established.

### Description
- Added `middleware/requireMongoReady.js` which returns HTTP `503` JSON (`error: 'database_unavailable'`) when `mongoose.connection.readyState !== 1` and provides a test-mode bypass controlled by `ENFORCE_MONGO_READINESS`.
- Updated route registry and mounting in `app.js` to apply the readiness middleware to DB-bound route groups (e.g. `/api/account`, `/api/leaderboard`, `/api/store`, `/api/share`, `/api/referral`, `/api/referrals`, `/api/onboarding`, `/api/x`, `/api/game`) while keeping `/health`, `/metrics`, static `/img`, and `/api/public-config` available.
- Enhanced `/health` JSON to include `status` (`OK` or `DEGRADED` based on Mongo readyState), `uptime`, and non-secret environment markers (`nodeEnv`, `railwayEnvironment`).
- Reworked `database.js` to use a single retry loop with structured logging and a configurable retry delay (`MONGO_RETRY_DELAY_MS`) to avoid recursive uncontrolled `setTimeout` reconnects.
- Optimized account bootstrap flows in `utils/accountManager.js` to prefer atomic upserts via `findOneAndUpdate(..., { upsert: true, new: true, setDefaultsOnInsert: true })` for `Player`, `PlayerUpgrades`, and `AccountLink`, with a compatibility fallback for test/mocked environments that lack `findOneAndUpdate`.
- Added automated tests `tests/mongo-readiness-guard.test.js` which assert fast `503` responses for auth routes when Mongo is down and verify `/health` and `/api/public-config` remain available.

### Testing
- Ran the test suite with `npm test`; the newly added readiness tests in `tests/mongo-readiness-guard.test.js` pass in this environment when `ENFORCE_MONGO_READINESS` is enabled.
- The full test run (`npm test`) still reports several pre-existing unrelated failures in this environment; the failures are not caused by the readiness guard changes and many core contract tests still pass.
- Manual assertions during test runs confirmed fast `503` responses for `/api/account/auth/wallet` and `/api/account/auth/telegram` when `mongoose.connection.readyState !== 1`, and normal behavior when `readyState === 1`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10c0d91e94832695d481a62466b885)