### PR TITLE
Unify spendable coin balance across profile and store APIs

### DIFF
--- a/routes/account.js
+++ b/routes/account.js
@@ -382,15 +382,16 @@ router.get('/me/profile', readLimiter, requireAuth, async (req, res) => {
     const totalGoldCoins = player.totalGoldCoins || 0;
     const totalSilverCoins = player.totalSilverCoins || 0;
     const rewardGold = player.gold || 0;
-    const visibleGold = totalGoldCoins + rewardGold;
 
     return res.json({
       primaryId,
       rank: rank || null,
       totalRankedPlayers: totalRankedPlayers || 0,
       bestScore: player.bestScore || 0,
-      gold: visibleGold,
+      gold: totalGoldCoins,
       silver: totalSilverCoins,
+      spendableGold: totalGoldCoins,
+      spendableSilver: totalSilverCoins,
       rewardGold,
       totalGoldCoins,
       totalSilverCoins,

--- a/routes/store.js
+++ b/routes/store.js
@@ -559,7 +559,7 @@ router.get('/upgrades/:wallet', readLimiter, requireAuth, async (req, res) => {
       wallet: linkedWallet,
       accountKey,
       foundPlayer: Boolean(player),
-      balance: { gold, silver },
+      balance: { gold, silver, spendableGold: gold, spendableSilver: silver },
       telegramUsername,
       aiByWallet,
       aiByTelegramUsername,
@@ -605,7 +605,7 @@ router.get('/upgrades/:wallet', readLimiter, requireAuth, async (req, res) => {
     res.json({
       wallet: accountKey,
       accountKey,
-      balance: { gold, silver },
+      balance: { gold, silver, spendableGold: gold, spendableSilver: silver },
       upgrades: upgradesData,
       rides: buildRidesData(upgrades),
       activeEffects: effects
@@ -840,7 +840,9 @@ router.post('/buy', writeLimiter, async (req, res) => {
           resolvedUpgradeKey,
           balance: {
             gold: player?.totalGoldCoins || 0,
-            silver: player?.totalSilverCoins || 0
+            silver: player?.totalSilverCoins || 0,
+            spendableGold: player?.totalGoldCoins || 0,
+            spendableSilver: player?.totalSilverCoins || 0
           },
           rides: buildRidesData(upgrades),
           activeEffects: calculateEffects(upgrades)
@@ -1007,7 +1009,9 @@ router.post('/buy', writeLimiter, async (req, res) => {
       resolvedUpgradeKey,
       balance: {
         gold: player.totalGoldCoins,
-        silver: player.totalSilverCoins
+        silver: player.totalSilverCoins,
+        spendableGold: player.totalGoldCoins,
+        spendableSilver: player.totalSilverCoins
       },
       rides: buildRidesData(upgrades),
       activeEffects: effects

--- a/tests/api.integration.test.js
+++ b/tests/api.integration.test.js
@@ -1044,6 +1044,8 @@ test('GET /api/v1/game/config?mode=unauth is public and CORS-enabled for product
   assert.equal(body.eligibleForLeaderboard, false);
   assert.ok(body.rides);
   assert.ok(body.balance);
+  assert.equal(body.balance.spendableGold, body.balance.gold);
+  assert.equal(body.balance.spendableSilver, body.balance.silver);
   assert.ok(body.activeEffects);
 
   await server.close();

--- a/tests/profile.test.js
+++ b/tests/profile.test.js
@@ -94,11 +94,13 @@ test('GET /api/account/me/profile - returns full profile', async () => {
 
     assert.equal(r.body.primaryId, 'tg_profile1');
     assert.equal(r.body.bestScore, 8350);
-    assert.equal(r.body.gold, 1590);
+    assert.equal(r.body.gold, 350);
     assert.equal(r.body.rewardGold, 1240);
     assert.equal(r.body.totalGoldCoins, 350);
     assert.equal(r.body.totalSilverCoins, 75);
     assert.equal(r.body.silver, 75);
+    assert.equal(r.body.spendableGold, 350);
+    assert.equal(r.body.spendableSilver, 75);
     assert.equal(r.body.referralCode, 'PROF1234');
     assert.ok(r.body.referralUrl.includes('PROF1234'), `referralUrl should contain code: ${r.body.referralUrl}`);
     assert.equal(r.body.rank, 42, 'rank = 41 + 1 = 42');


### PR DESCRIPTION
### Motivation
- Main page and Store used different balance semantics (`totalGoldCoins + rewardGold` vs `totalGoldCoins`), causing visible mismatch and UI rewrites after visiting the Store. The intent is to expose a single canonical spendable balance that both UI surfaces use.

### Description
- Changed `GET /api/account/me/profile` (`routes/account.js`) to stop mixing `rewardGold` into displayed `gold` and to expose canonical spendable fields by returning `gold`/`silver` as `totalGoldCoins`/`totalSilverCoins` and adding `spendableGold`/`spendableSilver` aliases while keeping `rewardGold`, `totalGoldCoins` and `totalSilverCoins`.
- Updated `GET /api/store/upgrades/:wallet` (`routes/store.js`) to include `spendableGold`/`spendableSilver` aliases in the `balance` payload and in store-related logging so the Store and profile share the same semantics.
- Updated store purchase responses (both normal success and idempotent duplicate path in `routes/store.js`) to include `spendableGold`/`spendableSilver` in `balance` so clients receive consistent spendable values after purchases.
- Adjusted tests (`tests/profile.test.js`, `tests/api.integration.test.js`) to assert the new spendable semantics (`gold` equals spendable and `balance.spendableGold === balance.gold`).

### Testing
- Ran syntax check with `npm run check:syntax` which passed successfully.
- Executed targeted tests with `node --test tests/profile.test.js tests/api.integration.test.js`; updated assertions for profile and store spendable fields are present, however the local test run shows multiple unrelated failing tests in the broader suite (not introduced by these changes).
- `npm test` in this environment also revealed unrelated failures in other areas; the modifications for spendable balance and the corresponding test assertions were added and validated in the modified tests included in this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10d2c3420c83269ac90e79e2d657cf)